### PR TITLE
Add typed WorkerEntrypoint RPC transport with HTTP parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,32 @@ const rollback = await files.rollback("docs/guide.md", {
 if (!rollback.ok) throw new Error(rollback.error.message);
 ```
 
-For a same-account Worker, bind the stash service and give its `fetch` method to the same client.
-The hostname is only a valid URL base; the binding routes the request internally:
+For a same-account Worker, prefer the named `StashRpc` entrypoint and the same client API:
+
+```toml
+compatibility_date = "2024-04-03"
+
+[[services]]
+binding = "STASH_RPC"
+service = "zudo-history-stash"
+entrypoint = "StashRpc"
+```
+
+```ts
+import { createStashClient, type StashRpcEntrypoint } from "@takazudo/zudo-history-stash";
+
+interface Env {
+  STASH_RPC: StashRpcEntrypoint;
+  STASH_TOKEN: string;
+}
+
+const client = createStashClient({
+  transport: { kind: "rpc", binding: env.STASH_RPC, token: env.STASH_TOKEN },
+});
+```
+
+The existing fetch service binding remains available for HTTP-compatible consumers. The hostname
+is only a valid URL base; the binding routes the request internally:
 
 ```toml
 [[services]]

--- a/docs/api.md
+++ b/docs/api.md
@@ -195,10 +195,13 @@ cross-stash `404` concealment checks:
 const result = await env.STASH_RPC.getFile(env.STASH_TOKEN, "demo", "docs/guide.md");
 ```
 
-Direct typed methods return serialisable `Result` unions for business and transport failures and do
-not reject. The RPC client transport preserves `Content-Type`, `Idempotency-Key`, and
-`If-None-Match`; its responses retain `ETag` and `Idempotent-Replayed` behavior. A rejected RPC
-binding call through the client instead throws `StashHttpError` with `status === 0`.
+After a typed method reaches `StashRpc`, business failures and internal exceptions become
+serialisable `Result` unions (including an `internal` result). The outer service-binding invocation
+can still reject before dispatch or during platform serialisation, including 32 MiB enforcement, so
+callers should catch that boundary. The RPC client transport preserves `Content-Type`,
+`Idempotency-Key`, and `If-None-Match`; its responses retain `ETag` and `Idempotent-Replayed`
+behavior. A rejected binding call through the client instead throws `StashHttpError` with
+`status === 0`.
 
 Cloudflare RPC serialisation is capped at 32 MiB. This API's own limits remain lower—for example,
 v1 stores text bodies up to 1,000,000 UTF-8 bytes—so those API limits still apply. The existing

--- a/docs/api.md
+++ b/docs/api.md
@@ -148,6 +148,62 @@ export default {
 Cloudflare documents that HTTP service bindings accept a `Request` and return a `Response`; calls
 must be awaited so the downstream Worker is not terminated early.
 
+### Cloudflare Worker RPC binding
+
+For a same-account consumer Worker, a named `StashRpc` entrypoint is the recommended binding. Set
+`compatibility_date` to `2024-04-03` or later:
+
+```toml
+name = "stash-consumer"
+main = "src/index.ts"
+compatibility_date = "2024-04-03"
+
+[[services]]
+binding = "STASH_RPC"
+service = "zudo-history-stash"
+entrypoint = "StashRpc"
+```
+
+Use the RPC transport with `createStashClient` for the usual client API. Type the binding as
+`StashRpcEntrypoint`; the token is configured when the client is created and sent on every RPC
+request, rather than stored on the binding.
+
+```ts
+import { createStashClient, type StashRpcEntrypoint } from "@takazudo/zudo-history-stash";
+
+interface Env {
+  STASH_RPC: StashRpcEntrypoint;
+  STASH_TOKEN: string;
+}
+
+export default {
+  async fetch(_request: Request, env: Env): Promise<Response> {
+    const client = createStashClient({
+      transport: { kind: "rpc", binding: env.STASH_RPC, token: env.STASH_TOKEN },
+    });
+    const result = await client.files("demo").get("docs/guide.md");
+    return Response.json(result);
+  },
+};
+```
+
+The binding also exposes direct typed methods when that shape is more convenient. The token is the
+first argument to every method, and it still receives the normal authentication, scope, and
+cross-stash `404` concealment checks:
+
+```ts
+const result = await env.STASH_RPC.getFile(env.STASH_TOKEN, "demo", "docs/guide.md");
+```
+
+Direct typed methods return serialisable `Result` unions for business and transport failures and do
+not reject. The RPC client transport preserves `Content-Type`, `Idempotency-Key`, and
+`If-None-Match`; its responses retain `ETag` and `Idempotent-Replayed` behavior. A rejected RPC
+binding call through the client instead throws `StashHttpError` with `status === 0`.
+
+Cloudflare RPC serialisation is capped at 32 MiB. This API's own limits remain lower—for example,
+v1 stores text bodies up to 1,000,000 UTF-8 bytes—so those API limits still apply. The existing
+`env.STASH.fetch()` service binding remains supported for HTTP-compatible consumers.
+
 ## Routes
 
 ### `GET /v1/health`
@@ -474,7 +530,5 @@ API accepts `Authorization`, `Content-Type`, `If-None-Match`, and `Idempotency-K
 
 The v1 HTTP contract intentionally defers:
 
-- typed `WorkerEntrypoint` RPC; service-binding `.fetch()` plus the client is the supported Worker
-  interface today;
 - R2 spill-over and binary bodies; v1 stores text up to 1,000,000 UTF-8 bytes in D1;
 - multi-file atomic commits; v1 history and CAS are per path.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -21,7 +21,29 @@ if (file.ok && "value" in file) {
 }
 ```
 
-For a same-account Worker service binding, the hostname is inert and the binding supplies fetch:
+For a same-account Worker, the recommended transport is a named `StashRpc` entrypoint. Type its
+binding as `StashRpcEntrypoint` and use the discriminated `transport` option:
+
+```ts
+import { createStashClient, type StashRpcEntrypoint } from "@takazudo/zudo-history-stash";
+
+interface Env {
+  STASH_RPC: StashRpcEntrypoint;
+  STASH_TOKEN: string;
+}
+
+const client = createStashClient({
+  transport: { kind: "rpc", binding: env.STASH_RPC, token: env.STASH_TOKEN },
+});
+```
+
+The RPC transport uses its token per call. Business responses remain the same discriminated result
+unions as fetch (`{ ok: false, error, current? }`); a rejected binding call throws
+`StashHttpError` with `status === 0`. Direct `StashRpcEntrypoint` methods instead accept the token
+as their first argument and return serialisable `Result` unions without rejecting.
+
+The existing fetch transport remains compatible. For a same-account Worker service binding, the
+hostname is inert and the binding supplies fetch:
 
 ```ts
 const client = createStashClient({

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -40,7 +40,9 @@ const client = createStashClient({
 The RPC transport uses its token per call. Business responses remain the same discriminated result
 unions as fetch (`{ ok: false, error, current? }`); a rejected binding call throws
 `StashHttpError` with `status === 0`. Direct `StashRpcEntrypoint` methods instead accept the token
-as their first argument and return serialisable `Result` unions without rejecting.
+as their first argument. After dispatch, they return serialisable `Result` unions for business
+failures and internal exceptions, but callers should still catch an outer binding rejection before
+dispatch or during platform serialisation.
 
 The existing fetch transport remains compatible. For a same-account Worker service binding, the
 hostname is inert and the binding supplies fetch:

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CLIENT_ROUTES, StashHttpError, createStashClient, validatePath } from "./index.js";
-import type { StashFetch } from "./index.js";
+import { createRpcSend } from "./transport.js";
+import type { StashFetch, StashRpcBinding } from "./index.js";
 import {
   ROUTES as coreRoutes,
   validatePath as coreValidatePath,
@@ -47,8 +48,6 @@ describe("route and validator pins", () => {
 });
 
 describe("transport options", () => {
-  const binding = { request: vi.fn(async () => new Response(null, { status: 204 })) };
-
   it("keeps explicit fetch transport options on the existing fetch path", async () => {
     mock.mockResolvedValueOnce(jsonResponse({ ok: true }));
     const c = createStashClient({
@@ -63,6 +62,7 @@ describe("transport options", () => {
   });
 
   it("rejects an rpc transport without a non-empty token", () => {
+    const binding = { request: vi.fn(async () => new Response(null, { status: 204 })) };
     expect(() =>
       createStashClient({
         transport: { kind: "rpc", binding },
@@ -84,6 +84,7 @@ describe("transport options", () => {
   });
 
   it("rejects fetch-only fields on the rpc branch", () => {
+    const binding = { request: vi.fn(async () => new Response(null, { status: 204 })) };
     expect(() =>
       createStashClient({
         baseUrl: "https://stash.example",
@@ -98,10 +99,60 @@ describe("transport options", () => {
     ).toThrow("rpc transport does not accept baseUrl or fetch");
   });
 
-  it("accepts valid rpc options up to the deliberate implementation placeholder", () => {
-    expect(() =>
-      createStashClient({ transport: { kind: "rpc", binding, token: "rpc-token" } }),
-    ).toThrow("rpc transport is implemented in a later change");
+  it("uses rpc without touching global fetch and sends the transport token separately", async () => {
+    const binding = {
+      request: vi.fn<StashRpcBinding["request"]>(async () => jsonResponse({ ok: true })),
+    };
+    const c = createStashClient({ transport: { kind: "rpc", binding, token: "rpc-token" } });
+
+    await expect(c.health()).resolves.toEqual({ ok: true, value: { ok: true } });
+    expect(mock).not.toHaveBeenCalled();
+    expect(binding.request).toHaveBeenCalledWith({
+      method: "GET",
+      path: "/v1/health",
+      token: "rpc-token",
+    });
+  });
+
+  it("ignores caller-supplied Authorization headers in favor of the rpc token", async () => {
+    const binding = {
+      request: vi.fn<StashRpcBinding["request"]>(async () => new Response(null, { status: 204 })),
+    };
+    const send = createRpcSend(binding, "rpc-token");
+
+    await send(
+      "GET",
+      "/v1/me",
+      undefined,
+      { Authorization: "Bearer caller-token", authorization: "Bearer second", "X-Test": "kept" },
+      undefined,
+    );
+
+    expect(binding.request).toHaveBeenCalledWith({
+      method: "GET",
+      path: "/v1/me",
+      headers: { "X-Test": "kept" },
+      token: "rpc-token",
+    });
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("preserves local validation boundaries before rpc dispatch", async () => {
+    const binding = {
+      request: vi.fn<StashRpcBinding["request"]>(async () => jsonResponse({ ok: true })),
+    };
+    const c = createStashClient({ transport: { kind: "rpc", binding, token: "rpc-token" } });
+
+    await expect(c.files("demo").get("bad path")).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalid-path" },
+    });
+    await expect(c.changes({ since: 1, before: 2 })).resolves.toMatchObject({
+      ok: false,
+      error: { code: "validation" },
+    });
+    expect(binding.request).not.toHaveBeenCalled();
+    expect(mock).not.toHaveBeenCalled();
   });
 });
 
@@ -359,6 +410,35 @@ describe("response mapping and safety", () => {
     });
   });
 
+  it("wraps request serialization failures before either transport dispatches", async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const input = { body: "x", expectedVersion: null, meta: circular } as never;
+    const binding = {
+      request: vi.fn<StashRpcBinding["request"]>(async () => jsonResponse({ ok: true })),
+    };
+    const rpcClient = createStashClient({
+      transport: { kind: "rpc", binding, token: "rpc-token" },
+    });
+
+    await expect(
+      client().files("demo").put("a.txt", input, { idempotencyKey: "fetch-circular" }),
+    ).rejects.toMatchObject({
+      name: "StashHttpError",
+      status: 0,
+      cause: expect.any(TypeError),
+    });
+    await expect(
+      rpcClient.files("demo").put("a.txt", input, { idempotencyKey: "rpc-circular" }),
+    ).rejects.toMatchObject({
+      name: "StashHttpError",
+      status: 0,
+      cause: expect.any(TypeError),
+    });
+    expect(mock).not.toHaveBeenCalled();
+    expect(binding.request).not.toHaveBeenCalled();
+  });
+
   it("validates paths before fetch and never percent-encodes route paths", async () => {
     const c = client();
     const result = await c.files("demo").get("bad path");
@@ -418,5 +498,31 @@ describe("putLatest", () => {
       error: { code: "stale", message: "stale-3" },
     });
     expect(mock).toHaveBeenCalledTimes(6);
+  });
+
+  it("shares head reads and stale retries with the rpc transport", async () => {
+    const responses = [
+      jsonResponse({ path: "a.txt", version: 1, hash: "h1", deleted: false }),
+      jsonResponse({ error: { code: "stale", message: "moved" }, current: { version: 2 } }, 409),
+      jsonResponse({ path: "a.txt", version: 2, hash: "h2", deleted: false }),
+      jsonResponse({ version: 3, hash: "h3", size: 1, changeId: 3 }),
+    ];
+    const binding = {
+      request: vi.fn<StashRpcBinding["request"]>(async () => {
+        const response = responses.shift();
+        if (response === undefined) throw new Error("unexpected rpc request");
+        return response;
+      }),
+    };
+    const c = createStashClient({ transport: { kind: "rpc", binding, token: "rpc-token" } });
+
+    await expect(c.putLatest("demo", "a.txt", "new")).resolves.toEqual({
+      ok: true,
+      value: { version: 3, hash: "h3", size: 1, changeId: 3 },
+    });
+    expect(binding.request).toHaveBeenCalledTimes(4);
+    expect(binding.request.mock.calls[1]?.[0].body).toContain('"expectedVersion":1');
+    expect(binding.request.mock.calls[3]?.[0].body).toContain('"expectedVersion":2');
+    expect(mock).not.toHaveBeenCalled();
   });
 });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -46,6 +46,65 @@ describe("route and validator pins", () => {
   });
 });
 
+describe("transport options", () => {
+  const binding = { request: vi.fn(async () => new Response(null, { status: 204 })) };
+
+  it("keeps explicit fetch transport options on the existing fetch path", async () => {
+    mock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const c = createStashClient({
+      baseUrl: "https://stash.example",
+      token: "admin-token",
+      fetch: mock,
+      transport: { kind: "fetch" },
+    });
+
+    await expect(c.health()).resolves.toEqual({ ok: true, value: { ok: true } });
+    expect(mock).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an rpc transport without a non-empty token", () => {
+    expect(() =>
+      createStashClient({
+        transport: { kind: "rpc", binding },
+      } as unknown as Parameters<typeof createStashClient>[0]),
+    ).toThrow("rpc transport requires a non-empty token");
+    expect(() =>
+      createStashClient({
+        transport: { kind: "rpc", binding, token: "   " },
+      }),
+    ).toThrow("rpc transport requires a non-empty token");
+  });
+
+  it("rejects an rpc transport without a request-capable binding", () => {
+    expect(() =>
+      createStashClient({
+        transport: { kind: "rpc", binding: {}, token: "rpc-token" },
+      } as unknown as Parameters<typeof createStashClient>[0]),
+    ).toThrow("rpc transport requires a binding with a request function");
+  });
+
+  it("rejects fetch-only fields on the rpc branch", () => {
+    expect(() =>
+      createStashClient({
+        baseUrl: "https://stash.example",
+        transport: { kind: "rpc", binding, token: "rpc-token" },
+      } as unknown as Parameters<typeof createStashClient>[0]),
+    ).toThrow("rpc transport does not accept baseUrl or fetch");
+    expect(() =>
+      createStashClient({
+        fetch: mock,
+        transport: { kind: "rpc", binding, token: "rpc-token" },
+      } as unknown as Parameters<typeof createStashClient>[0]),
+    ).toThrow("rpc transport does not accept baseUrl or fetch");
+  });
+
+  it("accepts valid rpc options up to the deliberate implementation placeholder", () => {
+    expect(() =>
+      createStashClient({ transport: { kind: "rpc", binding, token: "rpc-token" } }),
+    ).toThrow("rpc transport is implemented in a later change");
+  });
+});
+
 describe("golden requests", () => {
   it("covers every public route with exact URL, method, headers, and body", async () => {
     const c = client();

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -40,18 +40,36 @@ import type {
   RouteId,
   StashRecord,
 } from "@takazudo/zudo-history-stash-core";
+import type { StashRpcBinding } from "./rpc-types.js";
 
 export { ROUTES, validatePath, validateStashName } from "@takazudo/zudo-history-stash-core";
 
 /** A fetch implementation supplied by the host (browser, Node, or a Worker binding). */
 export type StashFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
-/** Configuration for {@link createStashClient}. */
-export interface StashClientOptions {
+/** Configuration for the existing fetch transport. */
+export interface StashFetchClientOptions {
   baseUrl: string;
   token?: string;
   fetch?: StashFetch;
   idempotencyKey?: () => string | Promise<string>;
+  transport?: { kind: "fetch" };
+}
+
+/** Configuration for an in-process Worker RPC binding. */
+export interface StashRpcClientOptions {
+  transport: { kind: "rpc"; binding: StashRpcBinding; token: string };
+  baseUrl?: never;
+  token?: never;
+  fetch?: never;
+  idempotencyKey?: never;
+}
+
+/** Configuration for {@link createStashClient}. */
+export type StashClientOptions = StashFetchClientOptions | StashRpcClientOptions;
+
+function isRpcClientOptions(options: StashClientOptions): options is StashRpcClientOptions {
+  return options.transport?.kind === "rpc";
 }
 
 /** An optional key for a mutation that should be safely replayable. */
@@ -398,6 +416,25 @@ export interface StashClient {
  * `fetch: (input, init) => env.STASH.fetch(input, init)`.
  */
 export function createStashClient(options: StashClientOptions): StashClient {
+  if (isRpcClientOptions(options)) {
+    if ("baseUrl" in options || "fetch" in options) {
+      throw new TypeError("rpc transport does not accept baseUrl or fetch");
+    }
+    if (
+      !isRecord(options.transport.binding) ||
+      typeof options.transport.binding.request !== "function"
+    ) {
+      throw new TypeError("rpc transport requires a binding with a request function");
+    }
+    if (
+      typeof options.transport.token !== "string" ||
+      options.transport.token.trim().length === 0
+    ) {
+      throw new TypeError("rpc transport requires a non-empty token");
+    }
+    throw new TypeError("rpc transport is implemented in a later change");
+  }
+
   const fetcher = options.fetch ?? globalThis.fetch.bind(globalThis);
   const token = options.token;
   const keyFactory = options.idempotencyKey ?? (() => globalThis.crypto.randomUUID());

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -38,14 +38,20 @@ import type {
   RollbackBody,
   RollbackResult,
   RouteId,
+  RouteMethod,
   StashRecord,
 } from "@takazudo/zudo-history-stash-core";
 import type { StashRpcBinding } from "./rpc-types.js";
+import {
+  createFetchSend,
+  createRpcSend,
+  type Send,
+  type StashFetch,
+  type TransportQuery,
+} from "./transport.js";
 
 export { ROUTES, validatePath, validateStashName } from "@takazudo/zudo-history-stash-core";
-
-/** A fetch implementation supplied by the host (browser, Node, or a Worker binding). */
-export type StashFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+export type { StashFetch } from "./transport.js";
 
 /** Configuration for the existing fetch transport. */
 export interface StashFetchClientOptions {
@@ -119,7 +125,7 @@ export type PutLatestOptions = Omit<PutFileBody, "body" | "expectedVersion"> & {
   retries?: number;
 };
 
-/** An HTTP or network failure that is not a business outcome. */
+/** A request or transport failure that is not a business outcome. */
 export class StashHttpError extends Error {
   override readonly name = "StashHttpError";
   readonly status: number;
@@ -148,6 +154,11 @@ type ErrorBody = {
 
 type RouteTemplate = Record<RouteId, string>;
 
+type RequestTarget = {
+  path: string;
+  query?: TransportQuery;
+};
+
 const routeTemplates = Object.fromEntries(
   ROUTES.map((route) => [route.id, route.template]),
 ) as RouteTemplate;
@@ -166,20 +177,15 @@ function route(id: RouteId, stash?: string, operationPath?: string, tokenId?: st
   return template;
 }
 
-function appendQuery(
+function target(
   path: string,
-  entries: readonly (readonly [string, string | number | boolean | undefined])[],
-): string {
-  const query = new URLSearchParams();
+  entries: readonly (readonly [string, string | number | boolean | undefined])[] = [],
+): RequestTarget {
+  const query: TransportQuery = {};
   for (const [key, value] of entries) {
-    if (value !== undefined) query.set(key, String(value));
+    if (value !== undefined) query[key] = String(value);
   }
-  const serialized = query.toString();
-  return serialized.length > 0 ? `${path}?${serialized}` : path;
-}
-
-function joinBaseUrl(baseUrl: string, path: string): string {
-  return `${baseUrl.replace(/\/+$/, "")}${path}`;
+  return Object.keys(query).length === 0 ? { path } : { path, query };
 }
 
 function validationResult<T>(
@@ -277,22 +283,24 @@ function requestHeaders(
 }
 
 async function readRaw(
-  fetcher: StashFetch,
-  baseUrl: string,
-  token: string | undefined,
-  method: string,
-  path: string,
+  send: Send,
+  authorizationToken: string | undefined,
+  method: RouteMethod,
+  requestTarget: RequestTarget,
   body?: unknown,
   idempotencyKey?: string,
   ifNoneMatch?: string,
 ): Promise<RawResponse> {
   let response: Response;
   try {
-    response = await fetcher(joinBaseUrl(baseUrl, path), {
+    const serializedBody = body === undefined ? undefined : JSON.stringify(body);
+    response = await send(
       method,
-      headers: requestHeaders(token, body, idempotencyKey, ifNoneMatch),
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    });
+      requestTarget.path,
+      requestTarget.query,
+      requestHeaders(authorizationToken, body, idempotencyKey, ifNoneMatch),
+      serializedBody,
+    );
   } catch (error) {
     throw new StashHttpError(0, undefined, undefined, error);
   }
@@ -307,7 +315,7 @@ async function readRaw(
     status: response.status,
     body: parsedBody,
     response,
-    replayed: replayedHeader(response),
+    replayed: (response.status === 200 || response.status === 201) && replayedHeader(response),
   };
 
   if (response.status >= 500) {
@@ -321,21 +329,19 @@ async function readRaw(
 }
 
 async function request<T>(
-  fetcher: StashFetch,
-  baseUrl: string,
-  token: string | undefined,
-  method: string,
-  path: string,
+  send: Send,
+  authorizationToken: string | undefined,
+  method: RouteMethod,
+  requestTarget: RequestTarget,
   body?: unknown,
   idempotencyKey?: string,
   ifNoneMatch?: string,
 ): Promise<ClientResult<T> | NotModifiedResult> {
   const raw = await readRaw(
-    fetcher,
-    baseUrl,
-    token,
+    send,
+    authorizationToken,
     method,
-    path,
+    requestTarget,
     body,
     idempotencyKey,
     ifNoneMatch,
@@ -412,10 +418,14 @@ export interface StashClient {
 }
 
 /**
- * Creates an isomorphic HTTP client. `fetch` can be replaced with a Cloudflare service binding:
- * `fetch: (input, init) => env.STASH.fetch(input, init)`.
+ * Creates an isomorphic stash client over fetch or an in-process RPC binding. Fetch can be
+ * replaced with a Cloudflare service binding: `fetch: (input, init) => env.STASH.fetch(input, init)`.
  */
 export function createStashClient(options: StashClientOptions): StashClient {
+  let send: Send;
+  let authorizationToken: string | undefined;
+  let keyFactory: () => string | Promise<string>;
+
   if (isRpcClientOptions(options)) {
     if ("baseUrl" in options || "fetch" in options) {
       throw new TypeError("rpc transport does not accept baseUrl or fetch");
@@ -432,30 +442,33 @@ export function createStashClient(options: StashClientOptions): StashClient {
     ) {
       throw new TypeError("rpc transport requires a non-empty token");
     }
-    throw new TypeError("rpc transport is implemented in a later change");
+    send = createRpcSend(options.transport.binding, options.transport.token);
+    authorizationToken = undefined;
+    keyFactory = () => globalThis.crypto.randomUUID();
+  } else {
+    const fetcher = options.fetch ?? globalThis.fetch.bind(globalThis);
+    send = createFetchSend(fetcher, options.baseUrl);
+    authorizationToken = options.token;
+    keyFactory = options.idempotencyKey ?? (() => globalThis.crypto.randomUUID());
   }
 
-  const fetcher = options.fetch ?? globalThis.fetch.bind(globalThis);
-  const token = options.token;
-  const keyFactory = options.idempotencyKey ?? (() => globalThis.crypto.randomUUID());
-
   const rawCall = (
-    method: string,
-    path: string,
+    method: RouteMethod,
+    requestTarget: RequestTarget,
     body?: unknown,
     idempotencyKey?: string,
     ifNoneMatch?: string,
   ): Promise<RawResponse> =>
-    readRaw(fetcher, options.baseUrl, token, method, path, body, idempotencyKey, ifNoneMatch);
+    readRaw(send, authorizationToken, method, requestTarget, body, idempotencyKey, ifNoneMatch);
 
   const call = <T>(
-    method: string,
-    path: string,
+    method: RouteMethod,
+    requestTarget: RequestTarget,
     body?: unknown,
     idempotencyKey?: string,
     ifNoneMatch?: string,
   ): Promise<ClientResult<T> | NotModifiedResult> =>
-    request(fetcher, options.baseUrl, token, method, path, body, idempotencyKey, ifNoneMatch);
+    request(send, authorizationToken, method, requestTarget, body, idempotencyKey, ifNoneMatch);
 
   const stashError = <T>(stash: string): ClientResult<T> | undefined => validateStash<T>(stash);
 
@@ -469,10 +482,10 @@ export function createStashClient(options: StashClientOptions): StashClient {
     async get(path, getOptions = {}) {
       const invalid = filePath<FileRecordWithEtag>(stash, path);
       if (invalid !== undefined) return invalid;
-      const requestPath = appendQuery(route("getFile", stash, path), [
+      const requestTarget = target(route("getFile", stash, path), [
         ["version", getOptions.version],
       ]);
-      const raw = await rawCall("GET", requestPath, undefined, undefined, getOptions.ifNoneMatch);
+      const raw = await rawCall("GET", requestTarget, undefined, undefined, getOptions.ifNoneMatch);
       if (raw.status === 304) return { ok: true, notModified: true };
       if (raw.status < 200 || raw.status >= 300) return mapFailure<FileRecordWithEtag>(raw);
       const record = raw.body as FileRecord;
@@ -496,7 +509,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const idempotencyKey = await mintKey(keyFactory, mutationOptions.idempotencyKey);
       return (await call<PutResult>(
         "PUT",
-        route("putFile", stash, path),
+        target(route("putFile", stash, path)),
         input,
         idempotencyKey,
       )) as ClientResult<PutResult>;
@@ -507,7 +520,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const idempotencyKey = await mintKey(keyFactory, mutationOptions.idempotencyKey);
       return (await call<DeleteResult>(
         "POST",
-        route("deleteFile", stash, path),
+        target(route("deleteFile", stash, path)),
         input,
         idempotencyKey,
       )) as ClientResult<DeleteResult>;
@@ -518,7 +531,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const idempotencyKey = await mintKey(keyFactory, mutationOptions.idempotencyKey);
       return (await call<RollbackResult>(
         "POST",
-        route("rollbackFile", stash, path),
+        target(route("rollbackFile", stash, path)),
         input,
         idempotencyKey,
       )) as ClientResult<RollbackResult>;
@@ -528,7 +541,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalid !== undefined) return invalid;
       return (await call<FileListResponse>(
         "GET",
-        appendQuery(route("listFiles", stash), [
+        target(route("listFiles", stash), [
           ["includeDeleted", listOptions.includeDeleted],
           ["limit", listOptions.limit],
           ["after", listOptions.after],
@@ -540,7 +553,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalid !== undefined) return invalid;
       return (await call<GetHistoryResult>(
         "GET",
-        appendQuery(route("getHistory", stash, path), [
+        target(route("getHistory", stash, path), [
           ["limit", historyOptions.limit],
           ["before", historyOptions.before],
         ]),
@@ -551,7 +564,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalid !== undefined) return invalid;
       return (await call<GetDiffResult>(
         "GET",
-        appendQuery(route("getDiff", stash, path), [
+        target(route("getDiff", stash, path), [
           ["from", diffOptions.from],
           ["to", diffOptions.to],
           ["context", diffOptions.context],
@@ -564,7 +577,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalid !== undefined) return invalid;
       return (await call<CandidateDiffResult>(
         "POST",
-        route("diffCandidate", stash, path),
+        target(route("diffCandidate", stash, path)),
         input,
       )) as ClientResult<CandidateDiffResult>;
     },
@@ -576,7 +589,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       }
       return (await call<ListChangesResult>(
         "GET",
-        appendQuery(route("getStashChanges", stash), [
+        target(route("getStashChanges", stash), [
           ["since", changesOptions.since],
           ["before", changesOptions.before],
           ["limit", changesOptions.limit],
@@ -589,7 +602,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
     async list(listOptions: ListStashesOptions = {}) {
       return (await call<ListStashesResult>(
         "GET",
-        appendQuery(route("listStashes"), [
+        target(route("listStashes"), [
           ["limit", listOptions.limit],
           ["after", listOptions.after],
         ]),
@@ -600,7 +613,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (stashResult !== undefined) return stashResult;
       return (await call<CreateStashResult>(
         "POST",
-        route("createStash"),
+        target(route("createStash")),
         input,
       )) as ClientResult<CreateStashResult>;
     },
@@ -609,7 +622,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalid !== undefined) return invalid;
       return (await call<StashRecord>(
         "GET",
-        route("getStash", stash),
+        target(route("getStash", stash)),
       )) as ClientResult<StashRecord>;
     },
     tokens(stash: string): StashTokensClient {
@@ -619,7 +632,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
           if (invalid !== undefined) return invalid;
           return (await call<CreateTokenResult>(
             "POST",
-            route("createToken", stash),
+            target(route("createToken", stash)),
             input,
           )) as ClientResult<CreateTokenResult>;
         },
@@ -628,7 +641,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
           if (invalid !== undefined) return invalid;
           return (await call<ListTokensResult>(
             "GET",
-            route("listTokens", stash),
+            target(route("listTokens", stash)),
           )) as ClientResult<ListTokensResult>;
         },
         async revoke(id) {
@@ -636,7 +649,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
           if (invalid !== undefined) return invalid;
           return (await call<undefined>(
             "DELETE",
-            route("revokeToken", stash, undefined, id),
+            target(route("revokeToken", stash, undefined, id)),
           )) as ClientResult<undefined>;
         },
       };
@@ -648,7 +661,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalidPath !== undefined) return invalidPath;
       return (await call<ImportResult>(
         "POST",
-        route("importHistory", stash),
+        target(route("importHistory", stash)),
         input,
       )) as ClientResult<ImportResult>;
     },
@@ -660,7 +673,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
     }
     return (await call<ChangesPage>(
       "GET",
-      appendQuery(route("listChanges"), [
+      target(route("listChanges"), [
         ["since", changesOptions.since],
         ["before", changesOptions.before],
         ["limit", changesOptions.limit],
@@ -670,10 +683,13 @@ export function createStashClient(options: StashClientOptions): StashClient {
 
   const client: StashClient = {
     async health() {
-      return (await call<HealthResponse>("GET", route("health"))) as ClientResult<HealthResponse>;
+      return (await call<HealthResponse>(
+        "GET",
+        target(route("health")),
+      )) as ClientResult<HealthResponse>;
     },
     async me() {
-      return (await call<MeResponse>("GET", route("me"))) as ClientResult<MeResponse>;
+      return (await call<MeResponse>("GET", target(route("me")))) as ClientResult<MeResponse>;
     },
     stashes,
     changes,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,6 +1,5 @@
 import {
   ROUTES,
-  formatEtag,
   statusForCode,
   validatePath,
   validateStashName,
@@ -17,7 +16,6 @@ import type {
   DeleteFileBody,
   DeleteResult,
   DiffCandidateBody,
-  ErrorCode,
   FileListResponse,
   FileRecord,
   FileGetQuery,
@@ -42,6 +40,7 @@ import type {
   StashRecord,
 } from "@takazudo/zudo-history-stash-core";
 import type { StashRpcBinding } from "./rpc-types.js";
+import { parseClientResponse, StashHttpError } from "./parse.js";
 import {
   createFetchSend,
   createRpcSend,
@@ -125,33 +124,6 @@ export type PutLatestOptions = Omit<PutFileBody, "body" | "expectedVersion"> & {
   retries?: number;
 };
 
-/** A request or transport failure that is not a business outcome. */
-export class StashHttpError extends Error {
-  override readonly name = "StashHttpError";
-  readonly status: number;
-  readonly code?: ErrorCode;
-  readonly body?: unknown;
-
-  constructor(status: number, code?: ErrorCode, body?: unknown, cause?: unknown) {
-    super(`History Stash request failed${status ? ` (${status})` : ""}`, { cause });
-    this.status = status;
-    this.code = code;
-    this.body = body;
-  }
-}
-
-type RawResponse = {
-  status: number;
-  body: unknown;
-  response: Response;
-  replayed: boolean;
-};
-
-type ErrorBody = {
-  error?: { code?: unknown; message?: unknown };
-  current?: unknown;
-};
-
 type RouteTemplate = Record<RouteId, string>;
 
 type RequestTarget = {
@@ -212,62 +184,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
 
-async function parseBody(response: Response): Promise<unknown> {
-  if (response.status === 204 || response.status === 304) return undefined;
-  if (typeof response.text !== "function") {
-    if (typeof response.json === "function") return response.json();
-    return undefined;
-  }
-  const text = await response.text();
-  if (text.length === 0) return undefined;
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return text;
-  }
-}
-
-function getErrorBody(body: unknown): ErrorBody {
-  return isRecord(body) ? (body as ErrorBody) : {};
-}
-
-function getErrorCode(body: unknown, fallback: string): string {
-  const error = getErrorBody(body).error;
-  return error && typeof error.code === "string" ? error.code : fallback;
-}
-
-function getErrorMessage(body: unknown, fallback: string): string {
-  const error = getErrorBody(body).error;
-  return error && typeof error.message === "string" ? error.message : fallback;
-}
-
-function getCurrent(body: unknown): Current | undefined {
-  const current = getErrorBody(body).current;
-  return current === undefined ? undefined : (current as Current);
-}
-
-function replayedHeader(response: Response): boolean {
-  return response.headers.get("Idempotent-Replayed")?.toLowerCase() === "true";
-}
-
-function withReplay<T>(value: T, replayed: boolean): ClientSuccess<T> {
-  return replayed ? { ok: true, value, replayed: true } : { ok: true, value };
-}
-
-function mapFailure<T>(raw: RawResponse): ClientResult<T> {
-  const fallback = raw.status >= 400 && raw.status < 500 ? "validation" : "internal";
-  const current = getCurrent(raw.body);
-  return {
-    ok: false,
-    error: {
-      code: getErrorCode(raw.body, fallback) as ApiError["code"],
-      message: getErrorMessage(raw.body, `History Stash request failed (${raw.status})`),
-      status: raw.status,
-    },
-    ...(current === undefined ? {} : { current }),
-  };
-}
-
 function requestHeaders(
   token: string | undefined,
   body: unknown,
@@ -282,15 +198,16 @@ function requestHeaders(
   return headers;
 }
 
-async function readRaw(
+async function request<T>(
   send: Send,
   authorizationToken: string | undefined,
+  routeId: RouteId,
   method: RouteMethod,
   requestTarget: RequestTarget,
   body?: unknown,
   idempotencyKey?: string,
   ifNoneMatch?: string,
-): Promise<RawResponse> {
+): Promise<ClientResult<T> | NotModifiedResult> {
   let response: Response;
   try {
     const serializedBody = body === undefined ? undefined : JSON.stringify(body);
@@ -305,50 +222,7 @@ async function readRaw(
     throw new StashHttpError(0, undefined, undefined, error);
   }
 
-  let parsedBody: unknown;
-  try {
-    parsedBody = await parseBody(response);
-  } catch (error) {
-    throw new StashHttpError(0, undefined, undefined, error);
-  }
-  const raw: RawResponse = {
-    status: response.status,
-    body: parsedBody,
-    response,
-    replayed: (response.status === 200 || response.status === 201) && replayedHeader(response),
-  };
-
-  if (response.status >= 500) {
-    throw new StashHttpError(
-      response.status,
-      getErrorCode(parsedBody, "internal") as ErrorCode,
-      parsedBody,
-    );
-  }
-  return raw;
-}
-
-async function request<T>(
-  send: Send,
-  authorizationToken: string | undefined,
-  method: RouteMethod,
-  requestTarget: RequestTarget,
-  body?: unknown,
-  idempotencyKey?: string,
-  ifNoneMatch?: string,
-): Promise<ClientResult<T> | NotModifiedResult> {
-  const raw = await readRaw(
-    send,
-    authorizationToken,
-    method,
-    requestTarget,
-    body,
-    idempotencyKey,
-    ifNoneMatch,
-  );
-  if (raw.status === 304) return { ok: true, notModified: true };
-  if (raw.status >= 200 && raw.status < 300) return withReplay(raw.body as T, raw.replayed);
-  return mapFailure<T>(raw);
+  return parseClientResponse<T>(response, routeId);
 }
 
 async function mintKey(
@@ -452,23 +326,24 @@ export function createStashClient(options: StashClientOptions): StashClient {
     keyFactory = options.idempotencyKey ?? (() => globalThis.crypto.randomUUID());
   }
 
-  const rawCall = (
-    method: RouteMethod,
-    requestTarget: RequestTarget,
-    body?: unknown,
-    idempotencyKey?: string,
-    ifNoneMatch?: string,
-  ): Promise<RawResponse> =>
-    readRaw(send, authorizationToken, method, requestTarget, body, idempotencyKey, ifNoneMatch);
-
   const call = <T>(
+    routeId: RouteId,
     method: RouteMethod,
     requestTarget: RequestTarget,
     body?: unknown,
     idempotencyKey?: string,
     ifNoneMatch?: string,
   ): Promise<ClientResult<T> | NotModifiedResult> =>
-    request(send, authorizationToken, method, requestTarget, body, idempotencyKey, ifNoneMatch);
+    request(
+      send,
+      authorizationToken,
+      routeId,
+      method,
+      requestTarget,
+      body,
+      idempotencyKey,
+      ifNoneMatch,
+    );
 
   const stashError = <T>(stash: string): ClientResult<T> | undefined => validateStash<T>(stash);
 
@@ -482,32 +357,21 @@ export function createStashClient(options: StashClientOptions): StashClient {
     async get(path, getOptions = {}) {
       const invalid = filePath<FileRecordWithEtag>(stash, path);
       if (invalid !== undefined) return invalid;
-      const requestTarget = target(route("getFile", stash, path), [
-        ["version", getOptions.version],
-      ]);
-      const raw = await rawCall("GET", requestTarget, undefined, undefined, getOptions.ifNoneMatch);
-      if (raw.status === 304) return { ok: true, notModified: true };
-      if (raw.status < 200 || raw.status >= 300) return mapFailure<FileRecordWithEtag>(raw);
-      const record = raw.body as FileRecord;
-      const headerEtag = raw.response.headers.get("ETag");
-      return {
-        ok: true,
-        value: {
-          ...record,
-          etag:
-            headerEtag ??
-            (record.deleted
-              ? formatEtag({ version: record.version, hash: null, deleted: true })
-              : formatEtag({ version: record.version, hash: record.hash ?? "", deleted: false })),
-        },
-        ...(raw.replayed ? { replayed: true as const } : {}),
-      };
+      return (await call<FileRecordWithEtag>(
+        "getFile",
+        "GET",
+        target(route("getFile", stash, path), [["version", getOptions.version]]),
+        undefined,
+        undefined,
+        getOptions.ifNoneMatch,
+      )) as FileGetResult;
     },
     async put(path, input, mutationOptions = {}) {
       const invalid = filePath<PutResult>(stash, path);
       if (invalid !== undefined) return invalid;
       const idempotencyKey = await mintKey(keyFactory, mutationOptions.idempotencyKey);
       return (await call<PutResult>(
+        "putFile",
         "PUT",
         target(route("putFile", stash, path)),
         input,
@@ -519,6 +383,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalid !== undefined) return invalid;
       const idempotencyKey = await mintKey(keyFactory, mutationOptions.idempotencyKey);
       return (await call<DeleteResult>(
+        "deleteFile",
         "POST",
         target(route("deleteFile", stash, path)),
         input,
@@ -530,6 +395,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       if (invalid !== undefined) return invalid;
       const idempotencyKey = await mintKey(keyFactory, mutationOptions.idempotencyKey);
       return (await call<RollbackResult>(
+        "rollbackFile",
         "POST",
         target(route("rollbackFile", stash, path)),
         input,
@@ -540,6 +406,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const invalid = stashError<FileListResponse>(stash);
       if (invalid !== undefined) return invalid;
       return (await call<FileListResponse>(
+        "listFiles",
         "GET",
         target(route("listFiles", stash), [
           ["includeDeleted", listOptions.includeDeleted],
@@ -552,6 +419,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const invalid = filePath<GetHistoryResult>(stash, path);
       if (invalid !== undefined) return invalid;
       return (await call<GetHistoryResult>(
+        "getHistory",
         "GET",
         target(route("getHistory", stash, path), [
           ["limit", historyOptions.limit],
@@ -563,6 +431,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const invalid = filePath<GetDiffResult>(stash, path);
       if (invalid !== undefined) return invalid;
       return (await call<GetDiffResult>(
+        "getDiff",
         "GET",
         target(route("getDiff", stash, path), [
           ["from", diffOptions.from],
@@ -576,6 +445,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const invalid = filePath<CandidateDiffResult>(stash, path);
       if (invalid !== undefined) return invalid;
       return (await call<CandidateDiffResult>(
+        "diffCandidate",
         "POST",
         target(route("diffCandidate", stash, path)),
         input,
@@ -588,6 +458,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
         return validationResult("validation", "since and before are mutually exclusive");
       }
       return (await call<ListChangesResult>(
+        "getStashChanges",
         "GET",
         target(route("getStashChanges", stash), [
           ["since", changesOptions.since],
@@ -601,6 +472,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
   const stashes = {
     async list(listOptions: ListStashesOptions = {}) {
       return (await call<ListStashesResult>(
+        "listStashes",
         "GET",
         target(route("listStashes"), [
           ["limit", listOptions.limit],
@@ -612,6 +484,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const stashResult = validateStash<CreateStashResult>(input.name);
       if (stashResult !== undefined) return stashResult;
       return (await call<CreateStashResult>(
+        "createStash",
         "POST",
         target(route("createStash")),
         input,
@@ -621,6 +494,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const invalid = stashError<StashRecord>(stash);
       if (invalid !== undefined) return invalid;
       return (await call<StashRecord>(
+        "getStash",
         "GET",
         target(route("getStash", stash)),
       )) as ClientResult<StashRecord>;
@@ -631,6 +505,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
           const invalid = stashError<CreateTokenResult>(stash);
           if (invalid !== undefined) return invalid;
           return (await call<CreateTokenResult>(
+            "createToken",
             "POST",
             target(route("createToken", stash)),
             input,
@@ -640,6 +515,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
           const invalid = stashError<ListTokensResult>(stash);
           if (invalid !== undefined) return invalid;
           return (await call<ListTokensResult>(
+            "listTokens",
             "GET",
             target(route("listTokens", stash)),
           )) as ClientResult<ListTokensResult>;
@@ -648,6 +524,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
           const invalid = stashError<undefined>(stash);
           if (invalid !== undefined) return invalid;
           return (await call<undefined>(
+            "revokeToken",
             "DELETE",
             target(route("revokeToken", stash, undefined, id)),
           )) as ClientResult<undefined>;
@@ -660,6 +537,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       const invalidPath = validateFilePath<ImportResult>(input.path);
       if (invalidPath !== undefined) return invalidPath;
       return (await call<ImportResult>(
+        "importHistory",
         "POST",
         target(route("importHistory", stash)),
         input,
@@ -672,6 +550,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
       return validationResult<ChangesPage>("validation", "since and before are mutually exclusive");
     }
     return (await call<ChangesPage>(
+      "listChanges",
       "GET",
       target(route("listChanges"), [
         ["since", changesOptions.since],
@@ -684,12 +563,13 @@ export function createStashClient(options: StashClientOptions): StashClient {
   const client: StashClient = {
     async health() {
       return (await call<HealthResponse>(
+        "health",
         "GET",
         target(route("health")),
       )) as ClientResult<HealthResponse>;
     },
     async me() {
-      return (await call<MeResponse>("GET", target(route("me")))) as ClientResult<MeResponse>;
+      return (await call<MeResponse>("me", "GET", target(route("me")))) as ClientResult<MeResponse>;
     },
     stashes,
     changes,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,7 @@
 export const VERSION = "0.0.0";
 
 export * from "./client.js";
+export * from "./parse.js";
 export * from "./rpc-types.js";
 export {
   ROUTES,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,7 @@
 export const VERSION = "0.0.0";
 
 export * from "./client.js";
+export * from "./rpc-types.js";
 export {
   ROUTES,
   formatEtag,

--- a/packages/client/src/parse.ts
+++ b/packages/client/src/parse.ts
@@ -1,0 +1,131 @@
+import { formatEtag } from "@takazudo/zudo-history-stash-core";
+import type {
+  ApiError,
+  Current,
+  ErrorCode,
+  FileRecord,
+  RouteId,
+} from "@takazudo/zudo-history-stash-core";
+import type {
+  ClientResult,
+  ClientSuccess,
+  FileRecordWithEtag,
+  NotModifiedResult,
+} from "./client.js";
+
+type ErrorBody = {
+  error?: { code?: unknown; message?: unknown };
+  current?: unknown;
+};
+
+/** A request or transport failure that is not a business outcome. */
+export class StashHttpError extends Error {
+  override readonly name = "StashHttpError";
+  readonly status: number;
+  readonly code?: ErrorCode;
+  readonly body?: unknown;
+
+  constructor(status: number, code?: ErrorCode, body?: unknown, cause?: unknown) {
+    super(`History Stash request failed${status ? ` (${status})` : ""}`, { cause });
+    this.status = status;
+    this.code = code;
+    this.body = body;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+  if (response.status === 204 || response.status === 304) return undefined;
+  if (typeof response.text !== "function") {
+    if (typeof response.json === "function") return response.json();
+    return undefined;
+  }
+  const text = await response.text();
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function getErrorBody(body: unknown): ErrorBody {
+  return isRecord(body) ? (body as ErrorBody) : {};
+}
+
+function getErrorCode(body: unknown, fallback: string): string {
+  const error = getErrorBody(body).error;
+  return error && typeof error.code === "string" ? error.code : fallback;
+}
+
+function getErrorMessage(body: unknown, fallback: string): string {
+  const error = getErrorBody(body).error;
+  return error && typeof error.message === "string" ? error.message : fallback;
+}
+
+function getCurrent(body: unknown): Current | undefined {
+  const current = getErrorBody(body).current;
+  return current === undefined ? undefined : (current as Current);
+}
+
+function withReplay<T>(value: T, replayed: boolean): ClientSuccess<T> {
+  return replayed ? { ok: true, value, replayed: true } : { ok: true, value };
+}
+
+function mapFailure<T>(status: number, body: unknown): ClientResult<T> {
+  const fallback = status >= 400 && status < 500 ? "validation" : "internal";
+  const current = getCurrent(body);
+  return {
+    ok: false,
+    error: {
+      code: getErrorCode(body, fallback) as ApiError["code"],
+      message: getErrorMessage(body, `History Stash request failed (${status})`),
+      status,
+    },
+    ...(current === undefined ? {} : { current }),
+  };
+}
+
+/** Parses a route response into the same business-result union used by every client transport. */
+export async function parseClientResponse<T>(
+  response: Response,
+  routeId: RouteId,
+): Promise<ClientResult<T> | NotModifiedResult> {
+  let body: unknown;
+  try {
+    body = await parseBody(response);
+  } catch (error) {
+    throw new StashHttpError(0, undefined, undefined, error);
+  }
+
+  if (response.status >= 500) {
+    throw new StashHttpError(response.status, getErrorCode(body, "internal") as ErrorCode, body);
+  }
+  if (response.status === 304) return { ok: true, notModified: true };
+  if (response.status < 200 || response.status >= 300) {
+    return mapFailure<T>(response.status, body);
+  }
+
+  const replayed =
+    (response.status === 200 || response.status === 201) &&
+    response.headers.get("Idempotent-Replayed")?.toLowerCase() === "true";
+  if (routeId !== "getFile") return withReplay(body as T, replayed);
+
+  const record = body as FileRecord;
+  const value: FileRecordWithEtag = {
+    ...record,
+    etag:
+      response.headers.get("ETag") ??
+      (record.deleted
+        ? formatEtag({ version: record.version, hash: null, deleted: true })
+        : formatEtag({
+            version: record.version,
+            hash: record.hash ?? "",
+            deleted: false,
+          })),
+  };
+  return withReplay(value as T, replayed);
+}

--- a/packages/client/src/rpc-types.test.ts
+++ b/packages/client/src/rpc-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { RouteId } from "@takazudo/zudo-history-stash-core";
+import type { StashRpcMethods } from "./rpc-types.js";
+
+const rpcMethodsByRoute = {
+  health: "health",
+  me: "me",
+  listStashes: "listStashes",
+  createStash: "createStash",
+  getStash: "getStash",
+  createToken: "createToken",
+  listTokens: "listTokens",
+  revokeToken: "revokeToken",
+  importHistory: "importHistory",
+  listChanges: "listChanges",
+  listFiles: "listFiles",
+  getFile: "getFile",
+  putFile: "putFile",
+  deleteFile: "deleteFile",
+  rollbackFile: "rollbackFile",
+  getHistory: "getHistory",
+  getDiff: "getDiff",
+  diffCandidate: "diffCandidate",
+  getStashChanges: "getStashChanges",
+} as const satisfies Record<RouteId, keyof StashRpcMethods>;
+
+const routesByRpcMethod = rpcMethodsByRoute satisfies Record<keyof StashRpcMethods, RouteId>;
+
+describe("StashRpcMethods route pin", () => {
+  it("covers every RouteId and exposes no extra method keys", () => {
+    expect(routesByRpcMethod).toBe(rpcMethodsByRoute);
+  });
+});

--- a/packages/client/src/rpc-types.ts
+++ b/packages/client/src/rpc-types.ts
@@ -1,0 +1,126 @@
+import type {
+  CandidateDiffResult,
+  ChangesPage,
+  CreateStashBody,
+  CreateStashResult,
+  CreateTokenBody,
+  CreateTokenResult,
+  DeleteFileBody,
+  DeleteResult,
+  DiffCandidateBody,
+  FileListResponse,
+  GetDiffResult,
+  GetHistoryResult,
+  HealthResponse,
+  ImportBody,
+  ImportResult,
+  ListChangesResult,
+  ListStashesResult,
+  ListTokensResult,
+  MeResponse,
+  PutFileBody,
+  PutResult,
+  RollbackBody,
+  RollbackResult,
+  RpcRequest,
+  StashRecord,
+} from "@takazudo/zudo-history-stash-core";
+import type {
+  ChangesOptions,
+  ClientResult,
+  DiffOptions,
+  FileGetOptions,
+  FileGetResult,
+  HistoryOptions,
+  ListFilesOptions,
+  ListStashesOptions,
+  MutationOptions,
+} from "./client.js";
+
+/** The minimal named RPC binding exposed by the stash Worker. */
+export interface StashRpcBinding {
+  request(init: RpcRequest): Promise<Response>;
+}
+
+/** One explicit RPC method per core route, using the same inputs and results as {@link StashClient}. */
+export interface StashRpcMethods {
+  health(token: string): Promise<ClientResult<HealthResponse>>;
+  me(token: string): Promise<ClientResult<MeResponse>>;
+  listStashes(
+    token: string,
+    options?: ListStashesOptions,
+  ): Promise<ClientResult<ListStashesResult>>;
+  createStash(token: string, input: CreateStashBody): Promise<ClientResult<CreateStashResult>>;
+  getStash(token: string, stash: string): Promise<ClientResult<StashRecord>>;
+  createToken(
+    token: string,
+    stash: string,
+    input: CreateTokenBody,
+  ): Promise<ClientResult<CreateTokenResult>>;
+  listTokens(token: string, stash: string): Promise<ClientResult<ListTokensResult>>;
+  revokeToken(token: string, stash: string, id: string): Promise<ClientResult<undefined>>;
+  importHistory(
+    token: string,
+    stash: string,
+    input: ImportBody,
+  ): Promise<ClientResult<ImportResult>>;
+  listChanges(token: string, options?: ChangesOptions): Promise<ClientResult<ChangesPage>>;
+  listFiles(
+    token: string,
+    stash: string,
+    options?: ListFilesOptions,
+  ): Promise<ClientResult<FileListResponse>>;
+  getFile(
+    token: string,
+    stash: string,
+    path: string,
+    options?: FileGetOptions,
+  ): Promise<FileGetResult>;
+  putFile(
+    token: string,
+    stash: string,
+    path: string,
+    input: PutFileBody,
+    options?: MutationOptions,
+  ): Promise<ClientResult<PutResult>>;
+  deleteFile(
+    token: string,
+    stash: string,
+    path: string,
+    input: DeleteFileBody,
+    options?: MutationOptions,
+  ): Promise<ClientResult<DeleteResult>>;
+  rollbackFile(
+    token: string,
+    stash: string,
+    path: string,
+    input: RollbackBody,
+    options?: MutationOptions,
+  ): Promise<ClientResult<RollbackResult>>;
+  getHistory(
+    token: string,
+    stash: string,
+    path: string,
+    options?: HistoryOptions,
+  ): Promise<ClientResult<GetHistoryResult>>;
+  getDiff(
+    token: string,
+    stash: string,
+    path: string,
+    options: DiffOptions,
+  ): Promise<ClientResult<GetDiffResult>>;
+  diffCandidate(
+    token: string,
+    stash: string,
+    path: string,
+    input: DiffCandidateBody,
+  ): Promise<ClientResult<CandidateDiffResult>>;
+  getStashChanges(
+    token: string,
+    stash: string,
+    options?: ChangesOptions,
+  ): Promise<ClientResult<ListChangesResult>>;
+}
+
+/** The complete type of the named RPC entrypoint bound by a consumer Worker. */
+export type StashRpcEntrypoint = StashRpcBinding & StashRpcMethods;

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -1,0 +1,58 @@
+import type { RouteMethod } from "@takazudo/zudo-history-stash-core";
+import type { StashRpcBinding } from "./rpc-types.js";
+
+/** A fetch implementation supplied by the host (browser, Node, or a Worker binding). */
+export type StashFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/** String query parameters passed through either client transport. */
+export type TransportQuery = Record<string, string>;
+
+/** The single request seam shared by the fetch and RPC client transports. */
+export type Send = (
+  method: RouteMethod,
+  path: string,
+  query: TransportQuery | undefined,
+  headers: Record<string, string>,
+  body: string | undefined,
+) => Promise<Response>;
+
+function joinBaseUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+function appendQuery(url: string, query: TransportQuery | undefined): string {
+  if (query === undefined) return url;
+  const serialized = new URLSearchParams(query).toString();
+  return serialized.length === 0 ? url : `${url}?${serialized}`;
+}
+
+/** Creates the existing HTTP/fetch request path without changing its request bytes. */
+export function createFetchSend(fetcher: StashFetch, baseUrl: string): Send {
+  return (method, path, query, headers, body) =>
+    fetcher(appendQuery(joinBaseUrl(baseUrl, path), query), {
+      method,
+      headers,
+      ...(body === undefined ? {} : { body }),
+    });
+}
+
+function withoutAuthorization(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => name.toLowerCase() !== "authorization"),
+  );
+}
+
+/** Creates an in-process RPC request path. The dedicated token always wins over headers. */
+export function createRpcSend(binding: StashRpcBinding, token: string): Send {
+  return (method, path, query, headers, body) => {
+    const rpcHeaders = withoutAuthorization(headers);
+    return binding.request({
+      method,
+      path,
+      ...(query === undefined ? {} : { query }),
+      ...(Object.keys(rpcHeaders).length === 0 ? {} : { headers: rpcHeaders }),
+      ...(body === undefined ? {} : { body }),
+      token,
+    });
+  };
+}

--- a/packages/client/test/testing/golden.test.ts
+++ b/packages/client/test/testing/golden.test.ts
@@ -1,7 +1,381 @@
-import { describe, expect, it } from "vitest";
-import { createStashClient } from "../../src/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StashHttpError, createStashClient } from "../../src/index.js";
+import type { StashClient, StashFetch, StashRpcBinding } from "../../src/index.js";
+import type { RpcRequest } from "@takazudo/zudo-history-stash-core";
 import { createFakeStash } from "../../src/testing/index.js";
 import { GOLDEN_NOW, GOLDEN_RESPONSES } from "./fixtures/golden-responses.js";
+
+const globalFetch = vi.fn<StashFetch>();
+
+beforeEach(() => {
+  globalFetch.mockImplementation(async () => {
+    throw new Error("rpc transport touched global fetch");
+  });
+  vi.stubGlobal("fetch", globalFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  globalFetch.mockReset();
+});
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(body === undefined ? null : JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+type TransportOutcome =
+  | { settled: "fulfilled"; value: unknown }
+  | {
+      settled: "rejected";
+      error: {
+        name: string;
+        status: number;
+        code: unknown;
+        body: unknown;
+        cause: unknown;
+      };
+    };
+
+async function captureTransportOutcome(promise: Promise<unknown>): Promise<TransportOutcome> {
+  try {
+    return { settled: "fulfilled", value: await promise };
+  } catch (error) {
+    expect(error).toBeInstanceOf(StashHttpError);
+    const httpError = error as StashHttpError;
+    const cause = httpError.cause;
+    return {
+      settled: "rejected",
+      error: {
+        name: httpError.name,
+        status: httpError.status,
+        code: httpError.code,
+        body: httpError.body,
+        cause: cause instanceof Error ? cause.message : cause,
+      },
+    };
+  }
+}
+
+type TransportMatrixCase = {
+  name: string;
+  dispatch: () => Promise<Response>;
+  invoke: (client: StashClient) => Promise<unknown>;
+  expected: TransportOutcome;
+  expectedFetchUrl?: string;
+  expectedRpcQuery?: Record<string, string>;
+};
+
+const goldenFileBody = {
+  path: GOLDEN_RESPONSES.file.path,
+  version: GOLDEN_RESPONSES.file.version,
+  hash: GOLDEN_RESPONSES.file.hash,
+  size: GOLDEN_RESPONSES.file.size,
+  kind: GOLDEN_RESPONSES.file.kind,
+  author: GOLDEN_RESPONSES.file.author,
+  message: GOLDEN_RESPONSES.file.message,
+  meta: GOLDEN_RESPONSES.file.meta,
+  createdAt: GOLDEN_RESPONSES.file.createdAt,
+  deleted: GOLDEN_RESPONSES.file.deleted,
+  body: GOLDEN_RESPONSES.file.body,
+};
+
+const rollbackResult = {
+  version: 3,
+  hash: GOLDEN_RESPONSES.file.hash,
+  rollbackOf: 1,
+  identicalToHead: false,
+  changeId: 3,
+  createdAt: GOLDEN_RESPONSES.file.createdAt,
+};
+
+const transportMatrix: TransportMatrixCase[] = [
+  {
+    name: "get 200 with ETag",
+    dispatch: async () => jsonResponse(goldenFileBody, 200, { ETag: GOLDEN_RESPONSES.file.etag }),
+    invoke: (client) => client.files("golden").get("docs/readme.md"),
+    expected: {
+      settled: "fulfilled",
+      value: { ok: true, value: GOLDEN_RESPONSES.file },
+    },
+  },
+  {
+    name: "get 304 with an empty body",
+    dispatch: async () =>
+      new Response(null, {
+        status: 304,
+        headers: { ETag: GOLDEN_RESPONSES.file.etag, "Idempotent-Replayed": "true" },
+      }),
+    invoke: (client) =>
+      client.files("golden").get("docs/readme.md", {
+        ifNoneMatch: GOLDEN_RESPONSES.file.etag,
+      }),
+    expected: { settled: "fulfilled", value: { ok: true, notModified: true } },
+  },
+  {
+    name: "put 201",
+    dispatch: async () => jsonResponse(GOLDEN_RESPONSES.put, 201),
+    invoke: (client) =>
+      client
+        .files("golden")
+        .put("docs/readme.md", { body: "hello", expectedVersion: null }, { idempotencyKey: "put" }),
+    expected: {
+      settled: "fulfilled",
+      value: { ok: true, value: GOLDEN_RESPONSES.put },
+    },
+  },
+  {
+    name: "put 200 unchanged",
+    dispatch: async () => jsonResponse({ unchanged: true, version: 1 }, 200),
+    invoke: (client) =>
+      client
+        .files("golden")
+        .put(
+          "docs/readme.md",
+          { body: "hello", expectedVersion: 1, skipIfUnchanged: true },
+          { idempotencyKey: "unchanged" },
+        ),
+    expected: {
+      settled: "fulfilled",
+      value: { ok: true, value: { unchanged: true, version: 1 } },
+    },
+  },
+  {
+    name: "put 201 replay",
+    dispatch: async () =>
+      jsonResponse(GOLDEN_RESPONSES.put, 201, { "Idempotent-Replayed": "true" }),
+    invoke: (client) =>
+      client
+        .files("golden")
+        .put(
+          "docs/readme.md",
+          { body: "hello", expectedVersion: null },
+          { idempotencyKey: "replay" },
+        ),
+    expected: {
+      settled: "fulfilled",
+      value: { ok: true, value: GOLDEN_RESPONSES.put, replayed: true },
+    },
+  },
+  {
+    name: "422 reused idempotency key does not expose replay metadata",
+    dispatch: async () =>
+      jsonResponse(
+        {
+          error: {
+            code: "idempotency-key-reused",
+            message: "Idempotency key was used for another request",
+          },
+        },
+        422,
+        { "Idempotent-Replayed": "true" },
+      ),
+    invoke: (client) =>
+      client
+        .files("golden")
+        .put(
+          "docs/readme.md",
+          { body: "changed", expectedVersion: 1 },
+          { idempotencyKey: "reused" },
+        ),
+    expected: {
+      settled: "fulfilled",
+      value: {
+        ok: false,
+        error: {
+          code: "idempotency-key-reused",
+          message: "Idempotency key was used for another request",
+          status: 422,
+        },
+      },
+    },
+  },
+  {
+    name: "delete 200",
+    dispatch: async () => jsonResponse(GOLDEN_RESPONSES.deleted, 200),
+    invoke: (client) =>
+      client
+        .files("golden")
+        .delete("docs/readme.md", { expectedVersion: 1 }, { idempotencyKey: "delete" }),
+    expected: {
+      settled: "fulfilled",
+      value: { ok: true, value: GOLDEN_RESPONSES.deleted },
+    },
+  },
+  {
+    name: "rollback 201",
+    dispatch: async () => jsonResponse(rollbackResult, 201),
+    invoke: (client) =>
+      client
+        .files("golden")
+        .rollback(
+          "docs/readme.md",
+          { toVersion: 1, expectedVersion: 2 },
+          { idempotencyKey: "rollback" },
+        ),
+    expected: { settled: "fulfilled", value: { ok: true, value: rollbackResult } },
+  },
+  {
+    name: "revoke 204 returns undefined without replay metadata",
+    dispatch: async () =>
+      new Response(null, { status: 204, headers: { "Idempotent-Replayed": "true" } }),
+    invoke: (client) => client.stashes.tokens("golden").revoke("tok_123"),
+    expected: { settled: "fulfilled", value: { ok: true, value: undefined } },
+  },
+  {
+    name: "stale 409 includes current",
+    dispatch: async () =>
+      jsonResponse(
+        {
+          error: {
+            code: GOLDEN_RESPONSES.stale.error.code,
+            message: GOLDEN_RESPONSES.stale.error.message,
+          },
+          current: GOLDEN_RESPONSES.stale.current,
+        },
+        409,
+      ),
+    invoke: (client) =>
+      client
+        .files("golden")
+        .put(
+          "docs/readme.md",
+          { body: "changed", expectedVersion: 99 },
+          { idempotencyKey: "stale" },
+        ),
+    expected: { settled: "fulfilled", value: GOLDEN_RESPONSES.stale },
+  },
+  {
+    name: "401 is an ordinary client result",
+    dispatch: async () =>
+      jsonResponse(
+        { error: { code: "unauthorized", message: "A valid bearer token is required." } },
+        401,
+      ),
+    invoke: (client) => client.me(),
+    expected: {
+      settled: "fulfilled",
+      value: {
+        ok: false,
+        error: {
+          code: "unauthorized",
+          message: "A valid bearer token is required.",
+          status: 401,
+        },
+      },
+    },
+  },
+  {
+    name: "malformed request body validation 400",
+    dispatch: async () =>
+      jsonResponse(
+        { error: { code: "validation", message: "Request body failed validation." } },
+        400,
+      ),
+    invoke: (client) =>
+      client.files("golden").put("docs/readme.md", { body: 1, expectedVersion: "bad" } as never, {
+        idempotencyKey: "malformed-body",
+      }),
+    expected: {
+      settled: "fulfilled",
+      value: {
+        ok: false,
+        error: {
+          code: "validation",
+          message: "Request body failed validation.",
+          status: 400,
+        },
+      },
+    },
+  },
+  {
+    name: "malformed query validation 400",
+    dispatch: async () =>
+      jsonResponse({ error: { code: "validation", message: "Invalid limit." } }, 400),
+    invoke: (client) => client.files("golden").list({ limit: 0 }),
+    expected: {
+      settled: "fulfilled",
+      value: {
+        ok: false,
+        error: { code: "validation", message: "Invalid limit.", status: 400 },
+      },
+    },
+  },
+  {
+    name: "list files preserves limit and after query order",
+    dispatch: async () =>
+      jsonResponse({
+        files: [
+          {
+            path: "docs/readme.md",
+            headVersion: 1,
+            hash: GOLDEN_RESPONSES.file.hash,
+            size: 5,
+            deleted: false,
+            updatedAt: GOLDEN_RESPONSES.file.createdAt,
+          },
+        ],
+        nextAfter: "docs/readme.md",
+      }),
+    invoke: (client) => client.files("golden").list({ limit: 2, after: "docs/readme.md" }),
+    expected: {
+      settled: "fulfilled",
+      value: {
+        ok: true,
+        value: {
+          files: [
+            {
+              path: "docs/readme.md",
+              headVersion: 1,
+              hash: GOLDEN_RESPONSES.file.hash,
+              size: 5,
+              deleted: false,
+              updatedAt: GOLDEN_RESPONSES.file.createdAt,
+            },
+          ],
+          nextAfter: "docs/readme.md",
+        },
+      },
+    },
+    expectedFetchUrl:
+      "https://stash.example/v1/stashes/golden/files?limit=2&after=docs%2Freadme.md",
+    expectedRpcQuery: { limit: "2", after: "docs/readme.md" },
+  },
+  {
+    name: "500 throws StashHttpError",
+    dispatch: async () => jsonResponse({ error: { code: "internal", message: "down" } }, 500),
+    invoke: (client) => client.me(),
+    expected: {
+      settled: "rejected",
+      error: {
+        name: "StashHttpError",
+        status: 500,
+        code: "internal",
+        body: { error: { code: "internal", message: "down" } },
+        cause: undefined,
+      },
+    },
+  },
+  {
+    name: "rejected transport becomes status zero with cause",
+    dispatch: async () => {
+      throw new TypeError("binding unavailable");
+    },
+    invoke: (client) => client.me(),
+    expected: {
+      settled: "rejected",
+      error: {
+        name: "StashHttpError",
+        status: 0,
+        code: undefined,
+        body: undefined,
+        cause: "binding unavailable",
+      },
+    },
+  },
+];
 
 describe("client golden response parity", () => {
   it("returns deterministic stash and token administration contracts", async () => {
@@ -127,5 +501,60 @@ describe("client golden response parity", () => {
       ok: true,
       value: GOLDEN_RESPONSES.tombstone,
     });
+  });
+});
+
+describe("fetch and rpc transport golden response parity", () => {
+  it.each(transportMatrix)("maps $name identically", async (scenario) => {
+    const fetcher = vi.fn<StashFetch>(async () => scenario.dispatch());
+    const rpcRequests: RpcRequest[] = [];
+    const binding = {
+      request: vi.fn<StashRpcBinding["request"]>(async (request) => {
+        rpcRequests.push(request);
+        return scenario.dispatch();
+      }),
+    };
+    const fetchClient = createStashClient({
+      baseUrl: "https://stash.example",
+      token: "matrix-token",
+      fetch: fetcher,
+      idempotencyKey: () => "matrix-key",
+    });
+    const rpcClient = createStashClient({
+      transport: { kind: "rpc", binding, token: "matrix-token" },
+    });
+
+    const fetchOutcome = await captureTransportOutcome(scenario.invoke(fetchClient));
+    const rpcOutcome = await captureTransportOutcome(scenario.invoke(rpcClient));
+
+    expect(fetchOutcome).toEqual(scenario.expected);
+    expect(rpcOutcome).toEqual(fetchOutcome);
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(binding.request).toHaveBeenCalledOnce();
+    expect(globalFetch).not.toHaveBeenCalled();
+
+    const [fetchInput, fetchInit] = fetcher.mock.calls[0] as [string, RequestInit];
+    const fetchUrl = new URL(fetchInput);
+    const rpcRequest = rpcRequests[0];
+    expect(rpcRequest).toBeDefined();
+    expect(rpcRequest?.method).toBe(fetchInit.method);
+    expect(rpcRequest?.path).toBe(fetchUrl.pathname);
+    expect(
+      rpcRequest?.query === undefined ? "" : new URLSearchParams(rpcRequest.query).toString(),
+    ).toBe(fetchUrl.search.slice(1));
+    expect(rpcRequest?.body).toBe(fetchInit.body);
+    expect(rpcRequest?.token).toBe("matrix-token");
+
+    const fetchHeaders = Object.fromEntries(new Headers(fetchInit.headers).entries());
+    delete fetchHeaders.authorization;
+    const rpcHeaders = Object.fromEntries(new Headers(rpcRequest?.headers).entries());
+    expect(rpcHeaders).toEqual(fetchHeaders);
+
+    if (scenario.expectedFetchUrl !== undefined) {
+      expect(fetchInput).toBe(scenario.expectedFetchUrl);
+    }
+    if (scenario.expectedRpcQuery !== undefined) {
+      expect(rpcRequest?.query).toEqual(scenario.expectedRpcQuery);
+    }
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./etag.js";
 export * from "./hash.js";
 export * from "./limits.js";
 export * from "./paths.js";
+export * from "./rpc.js";
 export * from "./routes.js";
 export * from "./schemas.js";
 export * from "./types.js";

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -1,0 +1,13 @@
+import type { RouteMethod } from "./routes.js";
+
+/** A structured-clone-friendly request sent through the stash RPC entrypoint. */
+export interface RpcRequest {
+  method: RouteMethod;
+  /** A `/v1/...` path with route parameters substituted and left unencoded. */
+  path: string;
+  query?: Record<string, string>;
+  /** Request metadata. `Authorization` is ignored because {@link token} always wins. */
+  headers?: Record<string, string>;
+  body?: string;
+  token: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,22 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@22.20.1)(jsdom@28.1.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
+  workers/example-rpc-consumer:
+    dependencies:
+      '@takazudo/zudo-history-stash':
+        specifier: workspace:*
+        version: link:../../packages/client
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^5.20260825.1
+        version: 5.20260825.1
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      wrangler:
+        specifier: ^4.125.0
+        version: 4.125.0(@cloudflare/workers-types@5.20260825.1)
+
   workers/stash:
     dependencies:
       '@hono/zod-validator':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.9.0
         version: 0.9.0(hono@4.13.4)(zod@4.4.3)
+      '@takazudo/zudo-history-stash':
+        specifier: workspace:*
+        version: link:../../packages/client
       '@takazudo/zudo-history-stash-core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -156,9 +159,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^5.20260825.1
         version: 5.20260825.1
-      '@takazudo/zudo-history-stash':
-        specifier: workspace:*
-        version: link:../../packages/client
       typescript:
         specifier: ^5.9.0
         version: 5.9.3

--- a/workers/example-rpc-consumer/README.md
+++ b/workers/example-rpc-consumer/README.md
@@ -1,0 +1,20 @@
+# RPC consumer example
+
+This private Worker demonstrates a consumer of the History Stash named `StashRpc` entrypoint.
+`GET /demo` reads `example-rpc-demo/demo.txt`, writes a demo revision, reads its history, and
+rolls back through the typed RPC transport. It is intended as a deployment and integration
+example, not a public API.
+
+`STASH_TOKEN` is deliberately an empty placeholder in `wrangler.toml` so the binding shape is
+visible. In a real deployment, replace it with a Worker secret:
+
+```sh
+pnpm exec wrangler secret put STASH_TOKEN
+```
+
+After setting the secret, remove `STASH_TOKEN = ""` from `[vars]`; keeping a plaintext value in
+the configuration would expose the credential. Give the token write access to the
+`example-rpc-demo` stash, or adjust the constants in `src/index.ts` for a different stash.
+
+The `STASH` fetch binding remains available for existing HTTP consumers. This example calls
+`STASH_RPC` instead, so the client keeps its normal result unions without HTTP serialisation.

--- a/workers/example-rpc-consumer/package.json
+++ b/workers/example-rpc-consumer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "zudo-history-stash-example-rpc-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "wrangler deploy --dry-run",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@takazudo/zudo-history-stash": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260825.1",
+    "typescript": "^5.9.0",
+    "wrangler": "^4.125.0"
+  }
+}

--- a/workers/example-rpc-consumer/src/index.ts
+++ b/workers/example-rpc-consumer/src/index.ts
@@ -1,0 +1,80 @@
+import {
+  createStashClient,
+  type FileGetResult,
+  type StashRpcEntrypoint,
+} from "@takazudo/zudo-history-stash";
+
+export interface Env {
+  STASH: Fetcher;
+  STASH_RPC: StashRpcEntrypoint;
+  STASH_TOKEN: string;
+}
+
+export const DEMO_STASH = "example-rpc-demo";
+export const DEMO_PATH = "demo.txt";
+const DEMO_BODY = "Written by the example RPC consumer.\n";
+
+function versionForPut(get: FileGetResult): number | null | undefined {
+  if (get.ok) return "value" in get ? get.value.version : undefined;
+  if (get.error.code === "not-found") return null;
+  return get.current?.version;
+}
+
+function rollbackTarget(get: FileGetResult, putVersion: number): number {
+  if (get.ok && "value" in get) return get.value.version;
+  return putVersion;
+}
+
+/**
+ * Demonstrates one typed RPC client sequence. It is exported so hosts can test the consumer
+ * without deploying this example Worker.
+ */
+export async function handleRequest(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname !== "/demo") return new Response("Not found", { status: 404 });
+  if (request.method !== "GET") {
+    return new Response("Method not allowed", { status: 405, headers: { Allow: "GET" } });
+  }
+
+  const client = createStashClient({
+    transport: { kind: "rpc", binding: env.STASH_RPC, token: env.STASH_TOKEN },
+  });
+  const files = client.files(DEMO_STASH);
+  const get = await files.get(DEMO_PATH);
+  const expectedVersion = versionForPut(get);
+  const put =
+    expectedVersion === undefined
+      ? {
+          ok: false as const,
+          error: { code: "internal", status: 500, message: "Demo read failed" },
+        }
+      : await files.put(
+          DEMO_PATH,
+          { body: DEMO_BODY, expectedVersion, skipIfUnchanged: true },
+          { idempotencyKey: `example-rpc-demo-put-${expectedVersion ?? "new"}` },
+        );
+  const history = await files.history(DEMO_PATH);
+  const rollback =
+    put.ok && history.ok
+      ? await files.rollback(
+          DEMO_PATH,
+          {
+            expectedVersion: put.value.version,
+            toVersion: rollbackTarget(get, put.value.version),
+          },
+          {
+            idempotencyKey: `example-rpc-demo-rollback-${put.value.version}-${rollbackTarget(
+              get,
+              put.value.version,
+            )}`,
+          },
+        )
+      : {
+          ok: false as const,
+          error: { code: "internal", status: 500, message: "Demo write or history failed" },
+        };
+
+  return Response.json({ get, put, history, rollback });
+}
+
+export default { fetch: handleRequest } satisfies ExportedHandler<Env>;

--- a/workers/example-rpc-consumer/tsconfig.json
+++ b/workers/example-rpc-consumer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.worker.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/workers/example-rpc-consumer/wrangler.toml
+++ b/workers/example-rpc-consumer/wrangler.toml
@@ -1,0 +1,17 @@
+name = "zudo-history-stash-example-rpc-consumer"
+main = "src/index.ts"
+compatibility_date = "2026-08-25"
+workers_dev = true
+preview_urls = true
+
+[[services]]
+binding = "STASH"
+service = "zudo-history-stash"
+
+[[services]]
+binding = "STASH_RPC"
+service = "zudo-history-stash"
+entrypoint = "StashRpc"
+
+[vars]
+STASH_TOKEN = ""

--- a/workers/stash/package.json
+++ b/workers/stash/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hono/zod-validator": "^0.9.0",
+    "@takazudo/zudo-history-stash": "workspace:*",
     "@takazudo/zudo-history-stash-core": "workspace:*",
     "hono": "^4.13.4",
     "zod": "^4.4.3"
@@ -19,7 +20,6 @@
   "devDependencies": {
     "@cloudflare/vitest-plugin": "^1.0.0",
     "@cloudflare/workers-types": "^5.20260825.1",
-    "@takazudo/zudo-history-stash": "workspace:*",
     "typescript": "^5.9.0",
     "vitest": "^4.1.11",
     "wrangler": "^4.125.0"

--- a/workers/stash/src/d1/admin-store.ts
+++ b/workers/stash/src/d1/admin-store.ts
@@ -175,8 +175,8 @@ export interface AdminStore {
 }
 
 const defaultDependencies: AdminStoreDependencies = {
-  now: Date.now,
-  mintToken,
+  now: () => Date.now(),
+  mintToken: () => mintToken(),
 };
 
 function validation(message: string): never {

--- a/workers/stash/src/d1/store.ts
+++ b/workers/stash/src/d1/store.ts
@@ -8,7 +8,7 @@ export interface StoreDependencies {
 }
 
 const defaultDependencies: StoreDependencies = {
-  now: Date.now,
+  now: () => Date.now(),
   createId: () => crypto.randomUUID(),
 };
 

--- a/workers/stash/src/index.ts
+++ b/workers/stash/src/index.ts
@@ -1,6 +1,8 @@
 import app from "./app.js";
 import type { Env } from "./env.js";
 
+export { StashRpc } from "./rpc.js";
+
 export default {
   fetch: (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> =>
     Promise.resolve(app.fetch(request, env, ctx)),

--- a/workers/stash/src/rpc.ts
+++ b/workers/stash/src/rpc.ts
@@ -1,4 +1,44 @@
-import type { RpcRequest } from "@takazudo/zudo-history-stash-core";
+import {
+  createStashClient,
+  type ChangesOptions,
+  type ClientResult,
+  type DiffOptions,
+  type FileGetOptions,
+  type FileGetResult,
+  type HistoryOptions,
+  type ListFilesOptions,
+  type ListStashesOptions,
+  type MutationOptions,
+  type StashRpcMethods,
+} from "@takazudo/zudo-history-stash";
+import type {
+  CandidateDiffResult,
+  ChangesPage,
+  CreateStashBody,
+  CreateStashResult,
+  CreateTokenBody,
+  CreateTokenResult,
+  DeleteFileBody,
+  DeleteResult,
+  DiffCandidateBody,
+  FileListResponse,
+  GetDiffResult,
+  GetHistoryResult,
+  HealthResponse,
+  ImportBody,
+  ImportResult,
+  ListChangesResult,
+  ListStashesResult,
+  ListTokensResult,
+  MeResponse,
+  PutFileBody,
+  PutResult,
+  RollbackBody,
+  RollbackResult,
+  RouteId,
+  RpcRequest,
+  StashRecord,
+} from "@takazudo/zudo-history-stash-core";
 import { WorkerEntrypoint } from "cloudflare:workers";
 import app from "./app.js";
 import type { Env } from "./env.js";
@@ -12,7 +52,7 @@ function requestUrl(init: RpcRequest): string {
   return `https://stash.internal${init.path}${query === "" ? "" : `?${query}`}`;
 }
 
-export class StashRpc extends WorkerEntrypoint<Env> {
+export class StashRpc extends WorkerEntrypoint<Env> implements StashRpcMethods {
   async request(init: RpcRequest): Promise<Response> {
     const headers = new Headers(init.headers);
     headers.delete("authorization");
@@ -24,4 +64,195 @@ export class StashRpc extends WorkerEntrypoint<Env> {
     });
     return app.fetch(request, this.env, this.ctx);
   }
+
+  async health(token: string): Promise<ClientResult<HealthResponse>> {
+    return noThrow(() => rpcClient(this, token).health());
+  }
+
+  async me(token: string): Promise<ClientResult<MeResponse>> {
+    return noThrow(() => rpcClient(this, token).me());
+  }
+
+  async listStashes(
+    token: string,
+    options?: ListStashesOptions,
+  ): Promise<ClientResult<ListStashesResult>> {
+    return noThrow(() => rpcClient(this, token).stashes.list(options));
+  }
+
+  async createStash(
+    token: string,
+    input: CreateStashBody,
+  ): Promise<ClientResult<CreateStashResult>> {
+    return noThrow(() => rpcClient(this, token).stashes.create(input));
+  }
+
+  async getStash(token: string, stash: string): Promise<ClientResult<StashRecord>> {
+    return noThrow(() => rpcClient(this, token).stashes.get(stash));
+  }
+
+  async createToken(
+    token: string,
+    stash: string,
+    input: CreateTokenBody,
+  ): Promise<ClientResult<CreateTokenResult>> {
+    return noThrow(() => rpcClient(this, token).stashes.tokens(stash).create(input));
+  }
+
+  async listTokens(token: string, stash: string): Promise<ClientResult<ListTokensResult>> {
+    return noThrow(() => rpcClient(this, token).stashes.tokens(stash).list());
+  }
+
+  async revokeToken(token: string, stash: string, id: string): Promise<ClientResult<undefined>> {
+    return noThrow(() => rpcClient(this, token).stashes.tokens(stash).revoke(id));
+  }
+
+  async importHistory(
+    token: string,
+    stash: string,
+    input: ImportBody,
+  ): Promise<ClientResult<ImportResult>> {
+    return noThrow(() => rpcClient(this, token).stashes.import(stash, input));
+  }
+
+  async listChanges(token: string, options?: ChangesOptions): Promise<ClientResult<ChangesPage>> {
+    return noThrow(() => rpcClient(this, token).changes(options));
+  }
+
+  async listFiles(
+    token: string,
+    stash: string,
+    options?: ListFilesOptions,
+  ): Promise<ClientResult<FileListResponse>> {
+    return noThrow(() => rpcClient(this, token).files(stash).list(options));
+  }
+
+  async getFile(
+    token: string,
+    stash: string,
+    path: string,
+    options?: FileGetOptions,
+  ): Promise<FileGetResult> {
+    return noThrowFile(() => rpcClient(this, token).files(stash).get(path, options));
+  }
+
+  async putFile(
+    token: string,
+    stash: string,
+    path: string,
+    input: PutFileBody,
+    options?: MutationOptions,
+  ): Promise<ClientResult<PutResult>> {
+    return noThrow(() => rpcClient(this, token).files(stash).put(path, input, options));
+  }
+
+  async deleteFile(
+    token: string,
+    stash: string,
+    path: string,
+    input: DeleteFileBody,
+    options?: MutationOptions,
+  ): Promise<ClientResult<DeleteResult>> {
+    return noThrow(() => rpcClient(this, token).files(stash).delete(path, input, options));
+  }
+
+  async rollbackFile(
+    token: string,
+    stash: string,
+    path: string,
+    input: RollbackBody,
+    options?: MutationOptions,
+  ): Promise<ClientResult<RollbackResult>> {
+    return noThrow(() => rpcClient(this, token).files(stash).rollback(path, input, options));
+  }
+
+  async getHistory(
+    token: string,
+    stash: string,
+    path: string,
+    options?: HistoryOptions,
+  ): Promise<ClientResult<GetHistoryResult>> {
+    return noThrow(() => rpcClient(this, token).files(stash).history(path, options));
+  }
+
+  async getDiff(
+    token: string,
+    stash: string,
+    path: string,
+    options: DiffOptions,
+  ): Promise<ClientResult<GetDiffResult>> {
+    return noThrow(() => rpcClient(this, token).files(stash).diff(path, options));
+  }
+
+  async diffCandidate(
+    token: string,
+    stash: string,
+    path: string,
+    input: DiffCandidateBody,
+  ): Promise<ClientResult<CandidateDiffResult>> {
+    return noThrow(() => rpcClient(this, token).files(stash).diffCandidate(path, input));
+  }
+
+  async getStashChanges(
+    token: string,
+    stash: string,
+    options?: ChangesOptions,
+  ): Promise<ClientResult<ListChangesResult>> {
+    return noThrow(() => rpcClient(this, token).files(stash).changes(options));
+  }
 }
+
+function rpcClient(binding: StashRpc, token: string) {
+  return createStashClient({ transport: { kind: "rpc", binding, token } });
+}
+
+function internalFailure(error: unknown): ClientResult<never> {
+  return {
+    ok: false,
+    error: {
+      code: "internal",
+      status: 500,
+      message: error instanceof Error ? error.message : "An internal error occurred.",
+    },
+  };
+}
+
+async function noThrow<T>(run: () => Promise<ClientResult<T>>): Promise<ClientResult<T>> {
+  try {
+    return await run();
+  } catch (error) {
+    return internalFailure(error);
+  }
+}
+
+async function noThrowFile(run: () => Promise<FileGetResult>): Promise<FileGetResult> {
+  try {
+    return await run();
+  } catch (error) {
+    return internalFailure(error);
+  }
+}
+
+const rpcMethodsByRoute = {
+  health: "health",
+  me: "me",
+  listStashes: "listStashes",
+  createStash: "createStash",
+  getStash: "getStash",
+  createToken: "createToken",
+  listTokens: "listTokens",
+  revokeToken: "revokeToken",
+  importHistory: "importHistory",
+  listChanges: "listChanges",
+  listFiles: "listFiles",
+  getFile: "getFile",
+  putFile: "putFile",
+  deleteFile: "deleteFile",
+  rollbackFile: "rollbackFile",
+  getHistory: "getHistory",
+  getDiff: "getDiff",
+  diffCandidate: "diffCandidate",
+  getStashChanges: "getStashChanges",
+} as const satisfies Record<RouteId, keyof StashRpc>;
+
+void rpcMethodsByRoute;

--- a/workers/stash/src/rpc.ts
+++ b/workers/stash/src/rpc.ts
@@ -1,0 +1,27 @@
+import type { RpcRequest } from "@takazudo/zudo-history-stash-core";
+import { WorkerEntrypoint } from "cloudflare:workers";
+import app from "./app.js";
+import type { Env } from "./env.js";
+
+function acceptsBody(method: string): boolean {
+  return method !== "GET" && method !== "HEAD";
+}
+
+function requestUrl(init: RpcRequest): string {
+  const query = new URLSearchParams(init.query).toString();
+  return `https://stash.internal${init.path}${query === "" ? "" : `?${query}`}`;
+}
+
+export class StashRpc extends WorkerEntrypoint<Env> {
+  async request(init: RpcRequest): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.delete("authorization");
+    headers.set("Authorization", `Bearer ${init.token}`);
+    const request = new Request(requestUrl(init), {
+      method: init.method,
+      headers,
+      body: acceptsBody(init.method) ? init.body : undefined,
+    });
+    return app.fetch(request, this.env, this.ctx);
+  }
+}

--- a/workers/stash/test/env.d.ts
+++ b/workers/stash/test/env.d.ts
@@ -1,4 +1,9 @@
 import type { D1Migration } from "cloudflare:test";
+import type { RpcRequest } from "@takazudo/zudo-history-stash-core";
+
+interface TestStashRpcBinding {
+  request(init: RpcRequest): Promise<Response>;
+}
 
 declare global {
   namespace Cloudflare {
@@ -7,6 +12,7 @@ declare global {
       STASH_ADMIN_TOKEN: string;
       ALLOWED_ORIGINS: string;
       TEST_MIGRATIONS: D1Migration[];
+      STASH_RPC: TestStashRpcBinding;
     }
   }
 }

--- a/workers/stash/test/example-consumer.test.ts
+++ b/workers/stash/test/example-consumer.test.ts
@@ -1,0 +1,80 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEMO_STASH,
+  handleRequest,
+  type Env as ExampleEnv,
+} from "../../example-rpc-consumer/src/index.js";
+import type { StashRpcEntrypoint } from "@takazudo/zudo-history-stash";
+import { mintToken, resetDatabase, seedStash } from "./helpers/app.js";
+
+function exampleEnv(token: string): ExampleEnv {
+  return {
+    STASH: {
+      fetch: async () => {
+        throw new Error("The example test must use the named RPC binding");
+      },
+      connect: () => {
+        throw new Error("The example test must use the named RPC binding");
+      },
+    },
+    // The test binding is declared with only request() because Miniflare's service-binding
+    // helper does not expose the entrypoint's typed methods in its generated test Env.
+    STASH_RPC: env.STASH_RPC as unknown as StashRpcEntrypoint,
+    STASH_TOKEN: token,
+  };
+}
+
+describe("example RPC consumer", () => {
+  beforeEach(resetDatabase);
+
+  it("runs its get, put, history, and rollback round trip through the named RPC binding", async () => {
+    await seedStash(DEMO_STASH);
+    const token = await mintToken(DEMO_STASH, "write");
+
+    const response = await handleRequest(
+      new Request("https://example-consumer.test/demo"),
+      exampleEnv(token.token),
+    );
+
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as {
+      get: { ok: boolean; error?: { code: string } };
+      put: { ok: boolean; value?: { version: number } };
+      history: { ok: boolean; value?: { versions: unknown[] } };
+      rollback: { ok: boolean; value?: { rollbackOf: number } };
+    };
+    expect(result.get).toMatchObject({ ok: false, error: { code: "not-found" } });
+    expect(result.put).toMatchObject({ ok: true, value: { version: 1 } });
+    expect(result.history).toMatchObject({ ok: true, value: { versions: [{ version: 1 }] } });
+    expect(result.rollback).toMatchObject({ ok: true, value: { rollbackOf: 1 } });
+
+    const second = await handleRequest(
+      new Request("https://example-consumer.test/demo"),
+      exampleEnv(token.token),
+    );
+    const secondResult = (await second.json()) as {
+      get: { ok: boolean; value?: { version: number } };
+      put: { ok: boolean };
+      history: { ok: boolean };
+      rollback: { ok: boolean };
+    };
+    expect(secondResult.get).toMatchObject({ ok: true, value: { version: 2 } });
+    expect(secondResult.put.ok).toBe(true);
+    expect(secondResult.history.ok).toBe(true);
+    expect(secondResult.rollback.ok).toBe(true);
+  });
+
+  it("has deterministic route and method responses", async () => {
+    const bindings = exampleEnv("unused");
+    await expect(
+      handleRequest(new Request("https://example-consumer.test/missing"), bindings),
+    ).resolves.toMatchObject({ status: 404 });
+    const response = await handleRequest(
+      new Request("https://example-consumer.test/demo", { method: "POST" }),
+      bindings,
+    );
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET");
+  });
+});

--- a/workers/stash/test/helpers/app.ts
+++ b/workers/stash/test/helpers/app.ts
@@ -30,6 +30,7 @@ export async function resetDatabase(): Promise<void> {
   for (const table of ["idempotency", "versions", "files", "blobs", "tokens", "stashes"]) {
     await db.prepare(`DELETE FROM ${table}`).run();
   }
+  await db.prepare("DELETE FROM sqlite_sequence WHERE name = 'versions'").run();
 }
 
 export async function mintToken(stash: string, scope: "read" | "write") {

--- a/workers/stash/test/helpers/rpc.ts
+++ b/workers/stash/test/helpers/rpc.ts
@@ -1,0 +1,54 @@
+import { sha256Hex } from "../../src/auth.js";
+import { createTestEnv } from "./env.js";
+
+export const RPC_STASH = "rpc-fixture";
+export const RPC_FOREIGN_STASH = "rpc-foreign";
+export const RPC_WRITE_TOKEN = `zhs_${"W".repeat(43)}`;
+export const RPC_READ_TOKEN = `zhs_${"R".repeat(43)}`;
+export const RPC_FOREIGN_TOKEN = `zhs_${"F".repeat(43)}`;
+export const RPC_WRITE_TOKEN_ID = `tok_${"a".repeat(32)}`;
+export const RPC_READ_TOKEN_ID = `tok_${"b".repeat(32)}`;
+export const RPC_FOREIGN_TOKEN_ID = `tok_${"c".repeat(32)}`;
+export const RPC_FIXED_NOW = 1_700_100_000_000;
+
+const STASHES = [
+  ["alpha", "first page fixture", RPC_FIXED_NOW - 40],
+  [RPC_FOREIGN_STASH, "foreign credential fixture", RPC_FIXED_NOW - 30],
+  [RPC_STASH, "RPC parity fixture", RPC_FIXED_NOW - 20],
+  ["zeta", "last page fixture", RPC_FIXED_NOW - 10],
+] as const;
+
+const TOKENS = [
+  [RPC_WRITE_TOKEN_ID, RPC_STASH, RPC_WRITE_TOKEN, "write", "fixed writer", RPC_FIXED_NOW - 3],
+  [RPC_READ_TOKEN_ID, RPC_STASH, RPC_READ_TOKEN, "read", "fixed reader", RPC_FIXED_NOW - 2],
+  [
+    RPC_FOREIGN_TOKEN_ID,
+    RPC_FOREIGN_STASH,
+    RPC_FOREIGN_TOKEN,
+    "read",
+    "fixed foreign reader",
+    RPC_FIXED_NOW - 1,
+  ],
+] as const;
+
+export async function seedRpcFixture(): Promise<void> {
+  const db = createTestEnv().env.DB;
+  for (const [name, description, createdAt] of STASHES) {
+    await db
+      .prepare(
+        "INSERT INTO stashes (name, description, meta_json, created_at) VALUES (?, ?, '{}', ?)",
+      )
+      .bind(name, description, createdAt)
+      .run();
+  }
+  for (const [id, stash, token, scope, label, createdAt] of TOKENS) {
+    await db
+      .prepare(
+        `INSERT INTO tokens
+           (id, stash_name, token_hash, label, scope, created_at, revoked_at, last_used_at)
+         VALUES (?, ?, ?, ?, ?, ?, NULL, NULL)`,
+      )
+      .bind(id, stash, await sha256Hex(token), label, scope, createdAt)
+      .run();
+  }
+}

--- a/workers/stash/test/route-pin.test.ts
+++ b/workers/stash/test/route-pin.test.ts
@@ -1,8 +1,9 @@
 import { ROUTES } from "@takazudo/zudo-history-stash-core";
 import { describe, expect, it } from "vitest";
-import { CLIENT_ROUTES } from "@takazudo/zudo-history-stash";
+import { CLIENT_ROUTES, parseClientResponse, StashHttpError } from "@takazudo/zudo-history-stash";
 import apiReference from "../../../docs/api.md?raw";
 import app from "../src/app.js";
+import { StashRpc } from "../src/rpc.js";
 
 type RouteTuple = readonly [string, string];
 
@@ -46,5 +47,28 @@ describe("route contract pin", () => {
     expect(registeredRouteSet()).toEqual(expected);
     expect(coreRouteSet(CLIENT_ROUTES)).toEqual(expected);
     expect(documentedRouteSet()).toEqual(expected);
+  });
+
+  it("exposes every route as an explicit StashRpc prototype method", () => {
+    const prototypeNames = new Set(Object.getOwnPropertyNames(StashRpc.prototype));
+    for (const { id } of ROUTES) {
+      expect(prototypeNames.has(id), `missing StashRpc.prototype.${id}`).toBe(true);
+      expect(typeof Object.getOwnPropertyDescriptor(StashRpc.prototype, id)?.value).toBe(
+        "function",
+      );
+    }
+  });
+
+  it("exports one parser and transport-error identity from the client package root", async () => {
+    const parsing = parseClientResponse(
+      new Response('{"error":{"code":"internal","message":"down"}}', {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+      "health",
+    );
+
+    await expect(parsing).rejects.toBeInstanceOf(StashHttpError);
+    await expect(parsing).rejects.toMatchObject({ status: 503, code: "internal" });
   });
 });

--- a/workers/stash/test/rpc.test.ts
+++ b/workers/stash/test/rpc.test.ts
@@ -1,4 +1,5 @@
 import type { RpcRequest } from "@takazudo/zudo-history-stash-core";
+import { createStashClient } from "@takazudo/zudo-history-stash";
 import { env } from "cloudflare:workers";
 import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -477,5 +478,97 @@ describe("named-entrypoint RPC boundary", () => {
     expect(response.headers.get("x-stash-version")).toBe("1");
     expect(response.headers.get("content-type")).toBe("application/json");
     expect(await response.text()).toContain('"body":"boundary body\\n"');
+  });
+});
+
+async function typedParity<T>(
+  seed: (() => Promise<unknown>) | undefined,
+  direct: (rpc: StashRpc) => Promise<T>,
+  throughClient: (rpc: StashRpc) => Promise<T>,
+): Promise<[direct: T, throughClient: T]> {
+  const results: T[] = [];
+  for (const invoke of [direct, throughClient]) {
+    await resetDatabase();
+    await seedRpcFixture();
+    await seed?.();
+    results.push(await invoke(new StashRpc(createExecutionContext(), createTestEnv().env)));
+  }
+  const [directResult, clientResult] = results;
+  if (directResult === undefined || clientResult === undefined) {
+    throw new Error("Typed RPC parity invocation did not return a result");
+  }
+  return [directResult, clientResult];
+}
+
+describe("typed StashRpc methods", () => {
+  it("matches the rpc-transport client for putFile", async () => {
+    const input = { body: "typed put\n", expectedVersion: null };
+    const options = { idempotencyKey: "typed-put" };
+    const [direct, client] = await typedParity(
+      undefined,
+      (rpc) => rpc.putFile(RPC_WRITE_TOKEN, RPC_STASH, "docs/typed.txt", input, options),
+      (rpc) =>
+        createStashClient({
+          transport: { kind: "rpc", binding: rpc, token: RPC_WRITE_TOKEN },
+        })
+          .files(RPC_STASH)
+          .put("docs/typed.txt", input, options),
+    );
+    expect(direct).toEqual(client);
+  });
+
+  it("matches the rpc-transport client for getFile", async () => {
+    const [direct, client] = await typedParity(
+      () => seedFile("typed get\n"),
+      (rpc) => rpc.getFile(RPC_READ_TOKEN, RPC_STASH, "docs/rpc.txt"),
+      (rpc) =>
+        createStashClient({
+          transport: { kind: "rpc", binding: rpc, token: RPC_READ_TOKEN },
+        })
+          .files(RPC_STASH)
+          .get("docs/rpc.txt"),
+    );
+    expect(direct).toEqual(client);
+  });
+
+  it("matches the rpc-transport client for revokeToken", async () => {
+    const [direct, client] = await typedParity(
+      undefined,
+      (rpc) => rpc.revokeToken("test-admin", RPC_STASH, RPC_WRITE_TOKEN_ID),
+      (rpc) =>
+        createStashClient({ transport: { kind: "rpc", binding: rpc, token: "test-admin" } })
+          .stashes.tokens(RPC_STASH)
+          .revoke(RPC_WRITE_TOKEN_ID),
+    );
+    expect(direct).toEqual(client);
+  });
+
+  it("matches the rpc-transport client for listFiles", async () => {
+    const options = { includeDeleted: true, limit: 1 };
+    const [direct, client] = await typedParity(
+      () => seedFile("typed list\n"),
+      (rpc) => rpc.listFiles(RPC_READ_TOKEN, RPC_STASH, options),
+      (rpc) =>
+        createStashClient({
+          transport: { kind: "rpc", binding: rpc, token: RPC_READ_TOKEN },
+        })
+          .files(RPC_STASH)
+          .list(options),
+    );
+    expect(direct).toEqual(client);
+  });
+
+  it("returns an internal Result when request rejects", async () => {
+    const rpc = new StashRpc(createExecutionContext(), createTestEnv().env);
+    vi.spyOn(rpc, "request").mockRejectedValueOnce(new Error("typed request failed"));
+
+    await expect(rpc.listFiles(RPC_READ_TOKEN, RPC_STASH)).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "internal",
+        status: 500,
+        message: "History Stash request failed",
+      },
+    });
   });
 });

--- a/workers/stash/test/rpc.test.ts
+++ b/workers/stash/test/rpc.test.ts
@@ -1,0 +1,481 @@
+import type { RpcRequest } from "@takazudo/zudo-history-stash-core";
+import { env } from "cloudflare:workers";
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/app.js";
+import { createStashStore } from "../src/d1/store.js";
+import type { Env } from "../src/env.js";
+import { StashRpc } from "../src/rpc.js";
+import { resetDatabase } from "./helpers/app.js";
+import { createTestEnv } from "./helpers/env.js";
+import {
+  RPC_FIXED_NOW,
+  RPC_FOREIGN_TOKEN,
+  RPC_READ_TOKEN,
+  RPC_STASH,
+  RPC_WRITE_TOKEN,
+  RPC_WRITE_TOKEN_ID,
+  seedRpcFixture,
+} from "./helpers/rpc.js";
+
+const PARITY_HEADERS = ["etag", "x-stash-version", "idempotent-replayed", "content-type"] as const;
+
+interface ResponseSnapshot {
+  status: number;
+  body: string;
+  headers: Record<(typeof PARITY_HEADERS)[number], string | null>;
+}
+
+interface ScenarioState {
+  etag?: string;
+}
+
+interface ParityScenario {
+  name: string;
+  expectedStatus: number;
+  expectedBody?: string;
+  expectedBodyIncludes?: string;
+  expectedHeaders?: Partial<ResponseSnapshot["headers"]>;
+  seed?: () => Promise<ScenarioState | void>;
+  init: RpcRequest | ((state: ScenarioState) => RpcRequest);
+  bindings?: () => Env;
+}
+
+function acceptsBody(method: string): boolean {
+  return method !== "GET" && method !== "HEAD";
+}
+
+function requestUrl(init: RpcRequest): string {
+  const query = new URLSearchParams(init.query).toString();
+  return `https://stash.internal${init.path}${query === "" ? "" : `?${query}`}`;
+}
+
+async function snapshot(response: Response): Promise<ResponseSnapshot> {
+  const headers = Object.fromEntries(
+    PARITY_HEADERS.map((name) => [name, response.headers.get(name)]),
+  ) as ResponseSnapshot["headers"];
+  return { status: response.status, body: await response.text(), headers };
+}
+
+async function dispatchHttp(init: RpcRequest, bindings: Env): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.delete("authorization");
+  headers.set("Authorization", `Bearer ${init.token}`);
+  const ctx = createExecutionContext();
+  const response = await app.request(
+    requestUrl(init),
+    {
+      method: init.method,
+      headers,
+      body: acceptsBody(init.method) ? init.body : undefined,
+    },
+    bindings,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+async function dispatchRpc(init: RpcRequest, bindings: Env): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await new StashRpc(ctx, bindings).request(init);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+async function putFixture(
+  body: string,
+  expectedVersion: number | null,
+  idempotencyKey?: string,
+): Promise<{ hash: string; version: number }> {
+  const result = await createStashStore(createTestEnv().env).writes.put(
+    RPC_STASH,
+    "docs/rpc.txt",
+    { body, expectedVersion },
+    idempotencyKey === undefined ? undefined : { idempotencyKey },
+  );
+  if (!result.ok || "unchanged" in result.value) throw new Error("RPC fixture write failed");
+  return { hash: result.value.hash, version: result.value.version };
+}
+
+async function seedFile(body = "first version\n"): Promise<ScenarioState> {
+  const result = await putFixture(body, null);
+  return { etag: `"v${result.version}-${result.hash}"` };
+}
+
+async function seedTwoVersions(): Promise<void> {
+  await putFixture("first version\n", null);
+  await putFixture("second version\n", 1);
+}
+
+function jsonRequest(
+  method: "POST" | "PUT",
+  path: string,
+  body: unknown,
+  token = "test-admin",
+  headers: Record<string, string> = {},
+): RpcRequest {
+  return {
+    method,
+    path,
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+    token,
+  };
+}
+
+function failingDatabase(database: D1Database): D1Database {
+  return new Proxy(database, {
+    get(target, property) {
+      if (property === "withSession") {
+        return () => {
+          throw new Error("forced RPC parity database failure");
+        };
+      }
+      const value: unknown = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+const scenarios: ParityScenario[] = [
+  {
+    name: "health",
+    expectedStatus: 200,
+    expectedBodyIncludes: '"ok":true',
+    init: { method: "GET", path: "/v1/health", token: "unused" },
+  },
+  {
+    name: "me admin",
+    expectedStatus: 200,
+    expectedBodyIncludes: '"principal":"admin"',
+    init: { method: "GET", path: "/v1/me", token: "test-admin" },
+  },
+  {
+    name: "me stash token",
+    expectedStatus: 200,
+    expectedBodyIncludes: `"stash":"${RPC_STASH}"`,
+    init: { method: "GET", path: "/v1/me", token: RPC_WRITE_TOKEN },
+  },
+  {
+    name: "list stashes with limit and after",
+    expectedStatus: 200,
+    expectedBodyIncludes: `"name":"${RPC_STASH}"`,
+    init: {
+      method: "GET",
+      path: "/v1/stashes",
+      query: { limit: "1", after: "alpha" },
+      token: "test-admin",
+    },
+  },
+  {
+    name: "create stash",
+    expectedStatus: 201,
+    expectedBodyIncludes: '"name":"rpc-created"',
+    init: jsonRequest("POST", "/v1/stashes", {
+      name: "rpc-created",
+      description: "created through parity",
+      meta: { source: "rpc" },
+    }),
+  },
+  {
+    name: "create token",
+    expectedStatus: 201,
+    expectedBodyIncludes: '"label":"parity token"',
+    init: jsonRequest("POST", `/v1/stashes/${RPC_STASH}/tokens`, {
+      label: "parity token",
+      scope: "read",
+    }),
+  },
+  {
+    name: "list files",
+    expectedStatus: 200,
+    expectedBodyIncludes: '"path":"docs/rpc.txt"',
+    seed: seedFile,
+    init: { method: "GET", path: `/v1/stashes/${RPC_STASH}/files`, token: RPC_READ_TOKEN },
+  },
+  {
+    name: "get file",
+    expectedStatus: 200,
+    expectedBodyIncludes: '"body":"first version\\n"',
+    expectedHeaders: { "x-stash-version": "1" },
+    seed: seedFile,
+    init: {
+      method: "GET",
+      path: `/v1/stashes/${RPC_STASH}/files/docs/rpc.txt`,
+      token: RPC_READ_TOKEN,
+    },
+  },
+  {
+    name: "get file with If-None-Match",
+    expectedStatus: 304,
+    expectedBody: "",
+    expectedHeaders: { "x-stash-version": "1" },
+    seed: seedFile,
+    init: (state) => ({
+      method: "GET",
+      path: `/v1/stashes/${RPC_STASH}/files/docs/rpc.txt`,
+      headers: { "If-None-Match": state.etag ?? "missing fixture etag" },
+      token: RPC_READ_TOKEN,
+    }),
+  },
+  {
+    name: "put create-only",
+    expectedStatus: 201,
+    expectedBodyIncludes: '"version":1',
+    init: jsonRequest(
+      "PUT",
+      `/v1/stashes/${RPC_STASH}/files/docs/rpc.txt`,
+      { body: "created over transport\n", expectedVersion: null },
+      RPC_WRITE_TOKEN,
+    ),
+  },
+  {
+    name: "put stale conflict with current",
+    expectedStatus: 409,
+    expectedBodyIncludes: '"current":{"version":1',
+    seed: seedFile,
+    init: jsonRequest(
+      "PUT",
+      `/v1/stashes/${RPC_STASH}/files/docs/rpc.txt`,
+      { body: "stale write\n", expectedVersion: 2 },
+      RPC_WRITE_TOKEN,
+    ),
+  },
+  {
+    name: "put idempotency replay",
+    expectedStatus: 201,
+    expectedBodyIncludes: '"version":1',
+    expectedHeaders: { "idempotent-replayed": "true" },
+    seed: async () => {
+      await putFixture("replayed body\n", null, "rpc-replay");
+    },
+    init: jsonRequest(
+      "PUT",
+      `/v1/stashes/${RPC_STASH}/files/docs/rpc.txt`,
+      { body: "replayed body\n", expectedVersion: null },
+      RPC_WRITE_TOKEN,
+      { "Idempotency-Key": "rpc-replay" },
+    ),
+  },
+  {
+    name: "delete file",
+    expectedStatus: 200,
+    expectedBodyIncludes: '"version":2',
+    seed: seedFile,
+    init: jsonRequest(
+      "POST",
+      `/v1/stashes/${RPC_STASH}/delete/docs/rpc.txt`,
+      { expectedVersion: 1 },
+      RPC_WRITE_TOKEN,
+    ),
+  },
+  {
+    name: "revoke token with empty 204 body",
+    expectedStatus: 204,
+    expectedBody: "",
+    init: {
+      method: "DELETE",
+      path: `/v1/stashes/${RPC_STASH}/tokens/${RPC_WRITE_TOKEN_ID}`,
+      token: "test-admin",
+    },
+  },
+  {
+    name: "rollback file",
+    expectedStatus: 201,
+    expectedBodyIncludes: '"rollbackOf":1',
+    seed: seedTwoVersions,
+    init: jsonRequest(
+      "POST",
+      `/v1/stashes/${RPC_STASH}/rollback/docs/rpc.txt`,
+      { expectedVersion: 2, toVersion: 1 },
+      RPC_WRITE_TOKEN,
+    ),
+  },
+  {
+    name: "diff GET",
+    expectedStatus: 200,
+    expectedBodyIncludes: '"state":"ready"',
+    seed: seedTwoVersions,
+    init: {
+      method: "GET",
+      path: `/v1/stashes/${RPC_STASH}/diff/docs/rpc.txt`,
+      query: { from: "1", to: "2", context: "1" },
+      token: RPC_READ_TOKEN,
+    },
+  },
+  {
+    name: "candidate diff POST",
+    expectedStatus: 200,
+    expectedBodyIncludes: '"state":"ready"',
+    seed: seedTwoVersions,
+    init: jsonRequest(
+      "POST",
+      `/v1/stashes/${RPC_STASH}/diff/docs/rpc.txt`,
+      { from: 1, body: "candidate version\n", context: 1 },
+      RPC_READ_TOKEN,
+    ),
+  },
+  {
+    name: "foreign stash concealment",
+    expectedStatus: 404,
+    expectedBodyIncludes: '"code":"not-found"',
+    init: {
+      method: "GET",
+      path: `/v1/stashes/${RPC_STASH}/files`,
+      token: RPC_FOREIGN_TOKEN,
+    },
+  },
+  {
+    name: "read token on write route",
+    expectedStatus: 403,
+    expectedBodyIncludes: '"code":"scope"',
+    init: jsonRequest(
+      "PUT",
+      `/v1/stashes/${RPC_STASH}/files/docs/denied.txt`,
+      { body: "denied\n", expectedVersion: null },
+      RPC_READ_TOKEN,
+    ),
+  },
+  {
+    name: "malformed body",
+    expectedStatus: 400,
+    expectedBodyIncludes: '"code":"validation"',
+    init: {
+      method: "PUT",
+      path: `/v1/stashes/${RPC_STASH}/files/docs/malformed.txt`,
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+      token: RPC_WRITE_TOKEN,
+    },
+  },
+  {
+    name: "unexpected handler error",
+    expectedStatus: 500,
+    expectedBody: '{"error":{"code":"internal","message":"An internal error occurred."}}',
+    init: { method: "GET", path: "/v1/stashes", token: "test-admin" },
+    bindings: () => {
+      const bindings = createTestEnv().env;
+      return { ...bindings, DB: failingDatabase(bindings.DB) };
+    },
+  },
+];
+
+function fixedRandomValues<T extends ArrayBufferView | null>(value: T): T {
+  if (value === null) return value;
+  new Uint8Array(value.buffer, value.byteOffset, value.byteLength).fill(0x11);
+  return value;
+}
+
+beforeEach(() => {
+  vi.spyOn(Date, "now").mockReturnValue(RPC_FIXED_NOW);
+  vi.spyOn(crypto, "getRandomValues").mockImplementation(fixedRandomValues);
+  vi.spyOn(crypto, "randomUUID").mockReturnValue("11111111-1111-4111-8111-111111111111");
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("StashRpc request construction", () => {
+  it("dispatches the exact Request, Env, and context to the singleton app and returns its Response", async () => {
+    const expected = new Response("same response", {
+      status: 202,
+      headers: { "X-Identity": "preserved" },
+    });
+    const fetchSpy = vi.spyOn(app, "fetch").mockResolvedValueOnce(expected);
+    const bindings = createTestEnv().env;
+    const ctx = createExecutionContext();
+    const suppliedHeaders = {
+      AUTHORIZATION: "Bearer ignored",
+      "Content-Type": "application/json",
+      "X-Probe": "kept",
+    };
+    const response = await new StashRpc(ctx, bindings).request({
+      method: "POST",
+      path: "/v1/stashes/rpc-fixture/diff/docs/nested.txt",
+      query: { from: "head", label: "a b" },
+      headers: suppliedHeaders,
+      body: "exact body",
+      token: "winner",
+    });
+
+    expect(response).toBe(expected);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [request, actualBindings, actualContext] = fetchSpy.mock.calls[0]!;
+    expect(request.url).toBe(
+      "https://stash.internal/v1/stashes/rpc-fixture/diff/docs/nested.txt?from=head&label=a+b",
+    );
+    expect(request.headers.get("authorization")).toBe("Bearer winner");
+    expect(request.headers.get("content-type")).toBe("application/json");
+    expect(request.headers.get("x-probe")).toBe("kept");
+    expect(await request.text()).toBe("exact body");
+    expect(actualBindings).toBe(bindings);
+    expect(actualContext).toBe(ctx);
+    expect(suppliedHeaders.AUTHORIZATION).toBe("Bearer ignored");
+  });
+
+  it.each(["GET", "HEAD"])("omits a supplied body for %s", async (method) => {
+    const fetchSpy = vi.spyOn(app, "fetch").mockResolvedValueOnce(new Response("ok"));
+    await new StashRpc(createExecutionContext(), createTestEnv().env).request({
+      method: method as RpcRequest["method"],
+      path: "/v1/health",
+      body: "must not be forwarded",
+      token: "unused",
+    });
+    const [request] = fetchSpy.mock.calls[0]!;
+    expect(request.body).toBeNull();
+    expect(await request.text()).toBe("");
+  });
+});
+
+describe("HTTP and RPC parity", () => {
+  it.each(scenarios)("matches $name byte-for-byte", async (scenario) => {
+    const results: Partial<Record<"http" | "rpc", ResponseSnapshot>> = {};
+    for (const transport of ["http", "rpc"] as const) {
+      await resetDatabase();
+      await seedRpcFixture();
+      const state = (await scenario.seed?.()) ?? {};
+      const init = typeof scenario.init === "function" ? scenario.init(state) : scenario.init;
+      const bindings = scenario.bindings?.() ?? createTestEnv().env;
+      const response =
+        transport === "http"
+          ? await dispatchHttp(init, bindings)
+          : await dispatchRpc(init, bindings);
+      results[transport] = await snapshot(response);
+    }
+
+    expect(results.rpc).toEqual(results.http);
+    expect(results.rpc?.status).toBe(scenario.expectedStatus);
+    if (scenario.expectedBody !== undefined) expect(results.rpc?.body).toBe(scenario.expectedBody);
+    if (scenario.expectedBodyIncludes !== undefined) {
+      expect(results.rpc?.body).toContain(scenario.expectedBodyIncludes);
+    }
+    if (scenario.expectedHeaders !== undefined) {
+      expect(results.rpc?.headers).toMatchObject(scenario.expectedHeaders);
+    }
+  });
+});
+
+describe("named-entrypoint RPC boundary", () => {
+  it("round-trips a real Response with headers and lets token override Authorization", async () => {
+    await resetDatabase();
+    await seedRpcFixture();
+    const { etag } = await seedFile("boundary body\n");
+
+    const response = await env.STASH_RPC.request({
+      method: "GET",
+      path: `/v1/stashes/${RPC_STASH}/files/docs/rpc.txt`,
+      headers: {
+        Authorization: "Bearer definitely-wrong",
+        "If-None-Match": '"not-the-current-etag"',
+      },
+      token: RPC_WRITE_TOKEN,
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("etag")).toBe(etag);
+    expect(response.headers.get("x-stash-version")).toBe("1");
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(await response.text()).toContain('"body":"boundary body\\n"');
+  });
+});

--- a/workers/stash/vitest.config.ts
+++ b/workers/stash/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
           STASH_ADMIN_TOKEN: "test-admin",
           ALLOWED_ORIGINS: "http://localhost:5173",
         },
+        serviceBindings: {
+          STASH_RPC: { name: "zudo-history-stash", entrypoint: "StashRpc" },
+        },
       },
     }),
   ],


### PR DESCRIPTION
Closes #103.

Part of #60. Parent PR: #61.

## Summary

Add a typed Cloudflare `WorkerEntrypoint` RPC surface that dispatches through the existing Hono application, preserves the HTTP contract, and is consumable through the existing typed client. The existing `env.STASH.fetch()` service-binding path remains supported.

## What changed

- Added the plain-data `RpcRequest` core contract, client `StashRpcBinding` / `StashRpcMethods` / `StashRpcEntrypoint` types, and a discriminated fetch-or-RPC client configuration.
- Refactored the client around one request seam so fetch and RPC share validation, result mapping, ETag/304 handling, replay metadata, idempotency, pagination, and `putLatest` retry behavior.
- Exported the named `StashRpc` entrypoint. Its `request()` builds an internal `Request`, gives the explicit per-call token precedence, dispatches through the singleton Hono app, and returns the original `Response`.
- Added HTTP/RPC byte-and-header parity coverage plus a real named-entrypoint loopback boundary test.
- Added nineteen explicit `StashRpc` prototype methods, one per route, backed by the shared client parser with compile-time and runtime route pins.
- Added a private, typechecked, Wrangler-dry-run example consumer Worker and a direct-module integration test that exercises its get → put → history → rollback flow through the real loopback RPC binding.
- Documented the named binding, compatibility date, token and header behavior, 32 MiB platform boundary, direct-method results, caller-side outer-boundary rejection caveat, and fetch fallback.

## Behavior notes

- Every request carries the caller's token through the same authentication, scope, concealment, CAS, and idempotency middleware as HTTP.
- Client RPC binding rejection is exposed as `StashHttpError` with status `0`; expected API failures remain `ClientResult` values.
- Once a direct typed method reaches `StashRpc`, business failures and internal exceptions become serialisable `Result` values. The outer Cloudflare binding call can still reject before dispatch or during platform serialisation, so direct callers must catch that boundary.
- No HTTP route was added and `docs/openapi.json` is byte-unchanged.

## Verification

- Exact final head: `fba7d89249b18feda9f20cbc2654fc166370f015`
- `pnpm b4push`: all 9/9 steps passed on the exact merged head
- Core: 127 tests passed
- Client: 52 tests passed
- Stash Worker: 160 tests passed
- Recursive workspace build, typecheck, lint, design-token lint, tests, and Worker dry-runs passed
- Each child topic received foreground self-review plus independent exact-commit review
- Aggregate exact-head review: PASS with no actionable findings
- OpenAPI generation check passed; generated bytes are unchanged

## Child issues

- #104 — RPC contracts and discriminated client options
- #105 — client RPC transport and fetch/RPC result matrix
- #106 — `StashRpc.request()` entrypoint, parity matrix, and real boundary smoke
- #107 — nineteen typed prototype methods and shared parser
- #108 — example RPC consumer and integration test
- #109 — consumer documentation and full gate
