### PR TITLE
Bump first-party zudo dependencies

### DIFF
--- a/ZUDO_DEPS_PINS.md
+++ b/ZUDO_DEPS_PINS.md
@@ -1,0 +1,15 @@
+# ZUDO_DEPS_PINS
+
+Provenance for artifacts vendored or generated from first-party (takazudo/zudolab) upstreams.
+Updated by /dev-bump-zudo-deps on every sync — keep `pinned:` accurate.
+
+## create-zudo-doc
+
+- repo: zudolab/zudo-doc
+- what: generated documentation scaffold reconciled through the repository's template-drift gate
+- files: doc/CLAUDE.md, doc/package.json, doc/.zudo-doc.json, doc/pages/, doc/scripts/, doc/src/
+- source: packages/create-zudo-doc/src/
+- track: releases
+- pinned: 7ca73f197021961603c22042748c23d9ce9d6c50 (v5.13.1)
+- updated: 2026-08-29
+- notes: doc/.template-drift-allowlist records intentional scaffold differences; preserve every listed adaptation during sync

--- a/doc/.zudo-doc.json
+++ b/doc/.zudo-doc.json
@@ -1,4 +1,4 @@
 {
-  "packageVersion": "5.13.0",
+  "packageVersion": "5.13.1",
   "ejected": {}
 }

--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -77,7 +77,7 @@ Admonitions (above), tabbed content (`<Tabs>` / `<TabItem>`, `<CodeGroup>`), and
 
 ## Enabled Features
 
-- **search** — Full-text search via Pagefind
+- **search** — Full-text search
 - **claudeResources** — Auto-generated docs for Claude Code resources
 - **sidebarResizer** — Draggable sidebar width
 - **sidebarToggle** — Show/hide desktop sidebar

--- a/doc/package.json
+++ b/doc/package.json
@@ -45,27 +45,25 @@
     "setup:doc-skill:both": "bash scripts/setup-doc-skill.sh --target both zudo-history-stash-wisdom"
   },
   "dependencies": {
-    "@takazudo/zfb": "2.12.0",
-    "@takazudo/zfb-runtime": "2.12.0",
-    "@takazudo/zfb-md-wasm": "2.12.0",
-    "@takazudo/zudo-doc": "5.13.0",
+    "@takazudo/zfb": "2.13.1",
+    "@takazudo/zfb-runtime": "2.13.1",
+    "@takazudo/zfb-md-wasm": "2.13.1",
+    "@takazudo/zudo-doc": "5.13.1",
     "zod": "^4.3.6",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
     "katex": "^0.16.38",
     "diff": "^8.0.3",
     "@takazudo/zdtp": "0.4.12",
-    "minisearch": "^7.2.0",
-    "@takazudo/zudo-doc-history-server": "5.13.0"
+    "@takazudo/zudo-doc-history-server": "5.13.1"
   },
   "devDependencies": {
     "@resvg/resvg-js": "2.6.2",
-    "@takazudo/zfb-adapter-cloudflare": "2.12.0",
-    "create-zudo-doc": "5.13.0",
+    "@takazudo/zfb-adapter-cloudflare": "2.13.1",
+    "create-zudo-doc": "5.13.1",
     "html-validate": "10.9.0",
     "typescript": "^5.9.0",
     "@types/node": "^22.0.0",
-    "pagefind": "^1.4.0",
     "npm-run-all2": "^7.0.2",
     "wrangler": "4.125.0"
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
-    "@takazudo/mdx-formatter": "^1.2.1",
+    "@takazudo/mdx-formatter": "^1.3.0-next.4",
     "@takazudo/zudo-design-token-lint": "^2.1.0",
     "@takazudo/zudo-history-stash-core": "workspace:*",
     "@takazudo/zudo-history-stash": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^9.0.0
         version: 9.39.5
       '@takazudo/mdx-formatter':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.3.0-next.4
+        version: 1.3.0-next.4
       '@takazudo/zudo-design-token-lint':
         specifier: ^2.1.0
         version: 2.1.0
@@ -63,29 +63,26 @@ importers:
         specifier: 0.4.12
         version: 0.4.12(preact@10.29.8)
       '@takazudo/zfb':
-        specifier: 2.12.0
-        version: 2.12.0(react@19.2.8)
+        specifier: 2.13.1
+        version: 2.13.1(react@19.2.8)
       '@takazudo/zfb-md-wasm':
-        specifier: 2.12.0
-        version: 2.12.0
+        specifier: 2.13.1
+        version: 2.13.1
       '@takazudo/zfb-runtime':
-        specifier: 2.12.0
-        version: 2.12.0(@takazudo/zfb@2.12.0(react@19.2.8))(react@19.2.8)
+        specifier: 2.13.1
+        version: 2.13.1(@takazudo/zfb@2.13.1(react@19.2.8))(react@19.2.8)
       '@takazudo/zudo-doc':
-        specifier: 5.13.0
-        version: 5.13.0(@takazudo/zdtp@0.4.12(preact@10.29.8))(@takazudo/zfb-md-wasm@2.12.0)(@takazudo/zfb-runtime@2.12.0(@takazudo/zfb@2.12.0(react@19.2.8))(react@19.2.8))(@takazudo/zfb@2.12.0(react@19.2.8))(@takazudo/zudo-doc-history-server@5.13.0)(@types/node@22.20.1)(diff@8.0.4)(katex@0.16.47)(preact@10.29.8)(zod@4.4.3)
+        specifier: 5.13.1
+        version: 5.13.1(@takazudo/zdtp@0.4.12(preact@10.29.8))(@takazudo/zfb-md-wasm@2.13.1)(@takazudo/zfb-runtime@2.13.1(@takazudo/zfb@2.13.1(react@19.2.8))(react@19.2.8))(@takazudo/zfb@2.13.1(react@19.2.8))(@takazudo/zudo-doc-history-server@5.13.1)(@types/node@22.20.1)(diff@8.0.4)(katex@0.16.47)(preact@10.29.8)(zod@4.4.3)
       '@takazudo/zudo-doc-history-server':
-        specifier: 5.13.0
-        version: 5.13.0
+        specifier: 5.13.1
+        version: 5.13.1
       diff:
         specifier: ^8.0.3
         version: 8.0.4
       katex:
         specifier: ^0.16.38
         version: 0.16.47
-      minisearch:
-        specifier: ^7.2.0
-        version: 7.2.0
       preact:
         specifier: ^10.29.1
         version: 10.29.8(preact-render-to-string@6.7.0)
@@ -100,23 +97,20 @@ importers:
         specifier: 2.6.2
         version: 2.6.2
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 2.12.0
-        version: 2.12.0
+        specifier: 2.13.1
+        version: 2.13.1
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.1
       create-zudo-doc:
-        specifier: 5.13.0
-        version: 5.13.0
+        specifier: 5.13.1
+        version: 5.13.1
       html-validate:
         specifier: 10.9.0
         version: 10.9.0(vitest@4.1.11(@types/node@22.20.1)(jsdom@28.1.0)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))
       npm-run-all2:
         specifier: ^7.0.2
         version: 7.0.2
-      pagefind:
-        specifier: ^1.4.0
-        version: 1.5.2
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
@@ -1395,41 +1389,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@pagefind/darwin-arm64@1.5.2':
-    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pagefind/darwin-x64@1.5.2':
-    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@pagefind/freebsd-x64@1.5.2':
-    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@pagefind/linux-arm64@1.5.2':
-    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pagefind/linux-x64@1.5.2':
-    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pagefind/windows-arm64@1.5.2':
-    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pagefind/windows-x64@1.5.2':
-    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
-    cpu: [x64]
-    os: [win32]
-
   '@playwright/test@1.62.1':
     resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
     engines: {node: '>=20'}
@@ -1798,28 +1757,28 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/mdx-formatter-darwin-arm64@1.2.1':
-    resolution: {integrity: sha512-6p2bIGfSQAaDldQwnTsFJKUsiEkMbd7ccZWTITxYym5RPuG46hL/Si2VVuIw3vfwciRbqkxN8k7zkrFSLmgMPA==}
+  '@takazudo/mdx-formatter-darwin-arm64@1.3.0-next.4':
+    resolution: {integrity: sha512-huHNILi2DLvBD5LlIF/nbhzUtcmTSi5ItC46T61DKTojPNdVUMKcGO/IfgorKwC3mhjPKqUYVSpY6E58B+bF6A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/mdx-formatter-darwin-x64@1.2.1':
-    resolution: {integrity: sha512-1Q6xqzdda8RtAM/LZSRof2L0ggShGjGWGO0zAEb+Kvq3HA3RwNMt7fXr/hEFtn8UarOkvxYAH5puRsJco8JL9g==}
+  '@takazudo/mdx-formatter-darwin-x64@1.3.0-next.4':
+    resolution: {integrity: sha512-7eep22peISXJMI3zbEAksQQn6z8eQestll/4k5RdjEX863K3Hpz5nw0TiRbhn37HY9c/nhXsyYwh0/wTp19L8w==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/mdx-formatter-linux-x64-gnu@1.2.1':
-    resolution: {integrity: sha512-qkNufO/xT8o3/BantkemXGkCBcDqzfjfiHLOCcVvQabzhbIVaf7m6ReMRlsXAv/AaZLS3/uPaTBziL75lPysVg==}
+  '@takazudo/mdx-formatter-linux-x64-gnu@1.3.0-next.4':
+    resolution: {integrity: sha512-Xr0PB53VGsv47XkmV00sVn1Byg1HBwI7kbRRokeft0v5SgmSIxeh6MM45rFW6WNsEKydmOZ6yCtjghTdbiuyaQ==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/mdx-formatter-win32-x64-msvc@1.2.1':
-    resolution: {integrity: sha512-lmd81nM6+9BmEIUDDrrsR2rvCK01APex8Y5uVZ2xdc4xZagQBRVD2Z2HPCaW3yvoy/jIYmBdRjri84AWZgmadA==}
+  '@takazudo/mdx-formatter-win32-x64-msvc@1.3.0-next.4':
+    resolution: {integrity: sha512-VhRuVeH/PGYRr+RXgvaKeW4y4eTIcZaFE6s7YD85NREXQv0sJLydAuU/VW3ayGZRf3eANdj06zi+jVMl+VJ9Vw==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/mdx-formatter@1.2.1':
-    resolution: {integrity: sha512-voMOJFXGvtOMO+lEzkEbqkz9ZEGNYv2UBtmzvIJ+y328XlUK5xcNgWgHQjEpkTu7G4hdz/X8aBoqy4ZvDiYwHA==}
+  '@takazudo/mdx-formatter@1.3.0-next.4':
+    resolution: {integrity: sha512-0Oc+dKmrBXSKnYh3pPgcgg8C5hqS+CFQeyBtP1rSwFmcD5pEiUrtYqMVfkJxpBPRN6Kl6yNxJqQn+liOvmyzbg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -1830,52 +1789,52 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@2.12.0':
-    resolution: {integrity: sha512-15rxrPnhgQY+ItvOrMYhjBNZCvbzlD7M/OmpJ9EWuD+aW8jKlF9l4fNlKQavA4B6WlgrDMApe2MOIkH54Jyxrg==}
+  '@takazudo/zfb-adapter-cloudflare@2.13.1':
+    resolution: {integrity: sha512-b1TjEVRX4FLEzESd0V7ysaKNsK0mpURaQWXY7kS+u5t0gow/dGEn4lG1pTnHc8e7Vl2/mBqrBzGdTI7wUmGs4A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@2.12.0':
-    resolution: {integrity: sha512-Hq1v/9L8J2Kr/uDXubkQBy+xoXDt6e7d3WtjlZMSjYLStAp9N6tVjJ4E0uErjKeMeRb9NnPndwtVIXOSNEhI+g==}
+  '@takazudo/zfb-darwin-arm64@2.13.1':
+    resolution: {integrity: sha512-gXIN1Qhoyamwg6/Guqp1/AWrs36YSLnq5MwkEva8arNvehj6pHBoElDiq0kPLyLsjj2ieIRy4ygyr9drpoPT5w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@2.12.0':
-    resolution: {integrity: sha512-bz35DyopCRIWcZ8sYYhX99+PCQaWI7hyQynZs3l6gwXukqZxm4yX8GJ8bzB5gVfbLmnEHFaHpA9cvzqHVckR0A==}
+  '@takazudo/zfb-darwin-x64@2.13.1':
+    resolution: {integrity: sha512-CwqWOr17hLjSCj9Rx+rJaYC3pVzi9Hw/cqZHVn+FzNx5s+mXJlA1qWHArabjYIFrtETaqMHVsDQQsDp47qT+ZQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@2.12.0':
-    resolution: {integrity: sha512-HKPNAnDjuA+52fpD5vS3TF+eSXGjZGxTAUN23K2IV00qHMx4v5NKepj37qyu2MdKnKNfQeoR9kpBS7M/BRMVug==}
+  '@takazudo/zfb-linux-arm64-gnu@2.13.1':
+    resolution: {integrity: sha512-a6YAEf8zZq3dYv3rn9rGVNAZFkyd2Qi4JPdS8LnAiWTIKylwaLaeH81jLmOQ3FUR4P9IZn/RkqXuZ/vUDkQvKw==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@2.12.0':
-    resolution: {integrity: sha512-jmLbDaka9aXeR0HN1zcrJ77rVColbeEaLA9OQAfv+09RgsodMAXv0oju1CtjzWKSmEoMCaSMqdX6dRfYVeuWCQ==}
+  '@takazudo/zfb-linux-x64-gnu@2.13.1':
+    resolution: {integrity: sha512-jGnnJW8LUH+JAJaOmINYphxCfifQvEu6z/5wfM0+ywJUiXbTA9zn/JRm77hr592h66q7Brn9R0bhoe9O5chtXg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-md-wasm@2.12.0':
-    resolution: {integrity: sha512-4GmocK8m9sQCn+JRfznYvphcqsqoyUNQAOgjH7JjubymYjrxMKk+uHWHKeqUfnbjxcbwZlus7pdq2WP4yzKbYA==}
+  '@takazudo/zfb-md-wasm@2.13.1':
+    resolution: {integrity: sha512-tUspRhOtruY3wOd2aB3lymea6ElapACgdrFiHgRSrBj4Ugou/yOsgAfmVOkdVe7ADqbdsh/KlHVc3AmAFN2ZEA==}
     engines: {node: '>=20.0.0', pnpm: '>=10.0.0'}
 
-  '@takazudo/zfb-runtime@2.12.0':
-    resolution: {integrity: sha512-mxH/QGZFKOrvNxI7zgqZv61Z+tvDHksKhG4kLThv9y2xIOd73jRetLH9jdBRuR1Lh0uaM9WEifMm0vcNJfonPw==}
+  '@takazudo/zfb-runtime@2.13.1':
+    resolution: {integrity: sha512-+EIWz9LKE8qeXYtTOPwFsvVZE2JArBVhtv8XeYs5FOOTGhi7o3VosjIvn1l4No8WUgu800/CmiwwGmiJwskG5Q==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 2.12.0
+      '@takazudo/zfb': 2.13.1
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@2.12.0':
-    resolution: {integrity: sha512-rRXtGlh1WpNFRa90g/JXz3LbXyglNpB2tvNs60R8R15TZeOeEdpXwPYN+elC1hRvyllx0xTmainiTbQT8cZ0TQ==}
+  '@takazudo/zfb-win32-x64-msvc@2.13.1':
+    resolution: {integrity: sha512-seZcTqcUhLf/w00kSGkncx0M2UzybkAPBy3+wIn+WO2+1Iq+XbyCq62e2rNUIv6/i5ddzjANPKDIlwTOencokg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@2.12.0':
-    resolution: {integrity: sha512-KgzM+fqMQUWxOYn0hLKSBqpEoWvxTyhDewQOkGSTlwdBMbtfBSwcx1sS6KvAitAV77mIksycCE0zQdxMFU6N8g==}
+  '@takazudo/zfb@2.13.1':
+    resolution: {integrity: sha512-GI3KbRY/H89YIBPtOHjazjX+svCco5Nsq6udf+oaPDXLdhOiPYG6XiLiLgKFOspMmHZf4L3w0qJydtrcKxcsLw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -1889,19 +1848,19 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@takazudo/zudo-doc-history-server@5.13.0':
-    resolution: {integrity: sha512-73BKvpmrZIJmT8Om/UBNOm/R8TI1uILmYvjYVB9kmc/c//yTdxky+W5zBvlB2cxMh1pxmb3Qa60ICO2VEFLJLQ==}
+  '@takazudo/zudo-doc-history-server@5.13.1':
+    resolution: {integrity: sha512-sYBfoa8oK9+LxE+0CMgZTg1r9TKjfVR2dwxLWaQ5pe0VJft4QJzhEqX9/89eFX8XWUs5yImAhR/qTvonjWWIfg==}
     hasBin: true
 
-  '@takazudo/zudo-doc@5.13.0':
-    resolution: {integrity: sha512-3340tXJmO2uR2qsnyNROCiGwMaWL8ix3Xn+8YuW0NaU5FIzqneFmyGIwHIpwX8FAR9uPNXAmlc3eTwL46Z3vBA==}
+  '@takazudo/zudo-doc@5.13.1':
+    resolution: {integrity: sha512-KqBNjhd0j9PP1anLD4TC6hp4StHdiJNjKnhNLyHCCfeKPOohk+2kd5SKIzMAxLIS/VbIqaFw7OvMDZBv2Q8o6g==}
     hasBin: true
     peerDependencies:
       '@takazudo/zdtp': ^0.4.12
-      '@takazudo/zfb': ^2.12.0
-      '@takazudo/zfb-md-wasm': ^2.12.0
-      '@takazudo/zfb-runtime': ^2.12.0
-      '@takazudo/zudo-doc-history-server': ^5.12.1
+      '@takazudo/zfb': ^2.13.1
+      '@takazudo/zfb-md-wasm': ^2.13.1
+      '@takazudo/zfb-runtime': ^2.13.1
+      '@takazudo/zudo-doc-history-server': ^5.13.0
       diff: ^8.0.0
       katex: ^0.16.0
       preact: ^10.29.1
@@ -2339,8 +2298,8 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
-  create-zudo-doc@5.13.0:
-    resolution: {integrity: sha512-JuiPyclIJ4WZ6evfrN5vZlXQNBtsWjTr/psjWlby3K97oVjuTPBLIqV5MZgNI9RydEWgdLFFYEV6nX7MujKnUQ==}
+  create-zudo-doc@5.13.1:
+    resolution: {integrity: sha512-CQuoOul3CylVIDHJeuA7RiR8K0ZXufxUHDalrjJ8h9tq43R07lkjj5d4OpM5W7ScnC6kv3kyDzKAls8X7Rip1A==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3320,9 +3279,6 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minisearch@7.2.0:
-    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
-
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -3408,10 +3364,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  pagefind@1.5.2:
-    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
-    hasBin: true
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4929,27 +4881,6 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
-  '@pagefind/darwin-arm64@1.5.2':
-    optional: true
-
-  '@pagefind/darwin-x64@1.5.2':
-    optional: true
-
-  '@pagefind/freebsd-x64@1.5.2':
-    optional: true
-
-  '@pagefind/linux-arm64@1.5.2':
-    optional: true
-
-  '@pagefind/linux-x64@1.5.2':
-    optional: true
-
-  '@pagefind/windows-arm64@1.5.2':
-    optional: true
-
-  '@pagefind/windows-x64@1.5.2':
-    optional: true
-
   '@playwright/test@1.62.1':
     dependencies:
       playwright: 1.62.1
@@ -5202,29 +5133,30 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
-  '@takazudo/mdx-formatter-darwin-arm64@1.2.1':
+  '@takazudo/mdx-formatter-darwin-arm64@1.3.0-next.4':
     optional: true
 
-  '@takazudo/mdx-formatter-darwin-x64@1.2.1':
+  '@takazudo/mdx-formatter-darwin-x64@1.3.0-next.4':
     optional: true
 
-  '@takazudo/mdx-formatter-linux-x64-gnu@1.2.1':
+  '@takazudo/mdx-formatter-linux-x64-gnu@1.3.0-next.4':
     optional: true
 
-  '@takazudo/mdx-formatter-win32-x64-msvc@1.2.1':
+  '@takazudo/mdx-formatter-win32-x64-msvc@1.3.0-next.4':
     optional: true
 
-  '@takazudo/mdx-formatter@1.2.1':
+  '@takazudo/mdx-formatter@1.3.0-next.4':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
       glob: 13.0.6
+      ignore: 7.0.6
       js-yaml: 4.3.1
     optionalDependencies:
-      '@takazudo/mdx-formatter-darwin-arm64': 1.2.1
-      '@takazudo/mdx-formatter-darwin-x64': 1.2.1
-      '@takazudo/mdx-formatter-linux-x64-gnu': 1.2.1
-      '@takazudo/mdx-formatter-win32-x64-msvc': 1.2.1
+      '@takazudo/mdx-formatter-darwin-arm64': 1.3.0-next.4
+      '@takazudo/mdx-formatter-darwin-x64': 1.3.0-next.4
+      '@takazudo/mdx-formatter-linux-x64-gnu': 1.3.0-next.4
+      '@takazudo/mdx-formatter-win32-x64-msvc': 1.3.0-next.4
 
   '@takazudo/zdtp@0.4.12(preact@10.29.8)':
     dependencies:
@@ -5233,21 +5165,21 @@ snapshots:
       preact: 10.29.8(preact-render-to-string@6.7.0)
       tailwind-merge: 3.6.0
 
-  '@takazudo/zfb-adapter-cloudflare@2.12.0': {}
+  '@takazudo/zfb-adapter-cloudflare@2.13.1': {}
 
-  '@takazudo/zfb-darwin-arm64@2.12.0':
+  '@takazudo/zfb-darwin-arm64@2.13.1':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@2.12.0':
+  '@takazudo/zfb-darwin-x64@2.13.1':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@2.12.0':
+  '@takazudo/zfb-linux-arm64-gnu@2.13.1':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@2.12.0':
+  '@takazudo/zfb-linux-x64-gnu@2.13.1':
     optional: true
 
-  '@takazudo/zfb-md-wasm@2.12.0':
+  '@takazudo/zfb-md-wasm@2.13.1':
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-directive: 3.1.0
@@ -5255,23 +5187,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@takazudo/zfb-runtime@2.12.0(@takazudo/zfb@2.12.0(react@19.2.8))(react@19.2.8)':
+  '@takazudo/zfb-runtime@2.13.1(@takazudo/zfb@2.13.1(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@takazudo/zfb': 2.12.0(react@19.2.8)
+      '@takazudo/zfb': 2.13.1(react@19.2.8)
       hono: 4.13.4
     optionalDependencies:
       react: 19.2.8
 
-  '@takazudo/zfb-win32-x64-msvc@2.12.0':
+  '@takazudo/zfb-win32-x64-msvc@2.13.1':
     optional: true
 
-  '@takazudo/zfb@2.12.0(react@19.2.8)':
+  '@takazudo/zfb@2.13.1(react@19.2.8)':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 2.12.0
-      '@takazudo/zfb-darwin-x64': 2.12.0
-      '@takazudo/zfb-linux-arm64-gnu': 2.12.0
-      '@takazudo/zfb-linux-x64-gnu': 2.12.0
-      '@takazudo/zfb-win32-x64-msvc': 2.12.0
+      '@takazudo/zfb-darwin-arm64': 2.13.1
+      '@takazudo/zfb-darwin-x64': 2.13.1
+      '@takazudo/zfb-linux-arm64-gnu': 2.13.1
+      '@takazudo/zfb-linux-x64-gnu': 2.13.1
+      '@takazudo/zfb-win32-x64-msvc': 2.13.1
       react: 19.2.8
 
   '@takazudo/zudo-design-token-lint@2.1.0':
@@ -5279,13 +5211,13 @@ snapshots:
       chalk: 5.6.2
       glob: 13.0.6
 
-  '@takazudo/zudo-doc-history-server@5.13.0': {}
+  '@takazudo/zudo-doc-history-server@5.13.1': {}
 
-  '@takazudo/zudo-doc@5.13.0(@takazudo/zdtp@0.4.12(preact@10.29.8))(@takazudo/zfb-md-wasm@2.12.0)(@takazudo/zfb-runtime@2.12.0(@takazudo/zfb@2.12.0(react@19.2.8))(react@19.2.8))(@takazudo/zfb@2.12.0(react@19.2.8))(@takazudo/zudo-doc-history-server@5.13.0)(@types/node@22.20.1)(diff@8.0.4)(katex@0.16.47)(preact@10.29.8)(zod@4.4.3)':
+  '@takazudo/zudo-doc@5.13.1(@takazudo/zdtp@0.4.12(preact@10.29.8))(@takazudo/zfb-md-wasm@2.13.1)(@takazudo/zfb-runtime@2.13.1(@takazudo/zfb@2.13.1(react@19.2.8))(react@19.2.8))(@takazudo/zfb@2.13.1(react@19.2.8))(@takazudo/zudo-doc-history-server@5.13.1)(@types/node@22.20.1)(diff@8.0.4)(katex@0.16.47)(preact@10.29.8)(zod@4.4.3)':
     dependencies:
       '@inquirer/prompts': 8.7.0(@types/node@22.20.1)
-      '@takazudo/zfb': 2.12.0(react@19.2.8)
-      '@takazudo/zfb-runtime': 2.12.0(@takazudo/zfb@2.12.0(react@19.2.8))(react@19.2.8)
+      '@takazudo/zfb': 2.13.1(react@19.2.8)
+      '@takazudo/zfb-runtime': 2.13.1(@takazudo/zfb@2.13.1(react@19.2.8))(react@19.2.8)
       esbuild: 0.28.2
       fs-extra: 11.4.0
       gray-matter: 4.0.3
@@ -5298,8 +5230,8 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@takazudo/zdtp': 0.4.12(preact@10.29.8)
-      '@takazudo/zfb-md-wasm': 2.12.0
-      '@takazudo/zudo-doc-history-server': 5.13.0
+      '@takazudo/zfb-md-wasm': 2.13.1
+      '@takazudo/zudo-doc-history-server': 5.13.1
       diff: 8.0.4
       katex: 0.16.47
     transitivePeerDependencies:
@@ -5771,7 +5703,7 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  create-zudo-doc@5.13.0:
+  create-zudo-doc@5.13.1:
     dependencies:
       '@clack/prompts': 0.9.1
       fs-extra: 11.4.0
@@ -7043,8 +6975,6 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  minisearch@7.2.0: {}
-
   mlly@1.8.2:
     dependencies:
       acorn: 8.18.0
@@ -7149,16 +7079,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  pagefind@1.5.2:
-    optionalDependencies:
-      '@pagefind/darwin-arm64': 1.5.2
-      '@pagefind/darwin-x64': 1.5.2
-      '@pagefind/freebsd-x64': 1.5.2
-      '@pagefind/linux-arm64': 1.5.2
-      '@pagefind/linux-x64': 1.5.2
-      '@pagefind/windows-arm64': 1.5.2
-      '@pagefind/windows-x64': 1.5.2
 
   parent-module@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- update `@takazudo/mdx-formatter` to the npm `latest` target, `1.3.0-next.4`, while preserving its caret specifier
- update the lockstep ZFB package family from `2.12.0` to `2.13.1`
- update the zudo-doc package family and `create-zudo-doc` from `5.13.0` to `5.13.1`
- synchronize scaffold provenance, remove the generator's unused `minisearch` and `pagefind` dependencies, and add the vendored-artifact pin

## Upstream impact

- mdx-formatter now honors `.gitignore` during glob discovery and includes list-formatting and convergence safety fixes; the repository's complete Markdown corpus remains byte-stable under its check
- ZFB adds a development livereload/BFCache lifecycle fix; its runtime, WASM, and Cloudflare adapter packages are compatible lockstep releases without a consumer migration
- zudo-doc raises its ZFB peer floors; create-zudo-doc removes search packages that the built-in search widget does not use

## Risk

- npm currently points mdx-formatter's `latest` tag at a prerelease; local formatter checks processed all 108 Markdown/MDX files successfully

## Verification

- `pnpm b4push` — all 10 CI-parity steps passed
- `pnpm b4push:doc` — all 13 documentation steps passed, including template drift, pin parity, fresh build, HTML validation, and strict link validation
