### PR TITLE
Update actions/cache to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         run: pnpm build:libs
 
       - name: Restore Playwright browser cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -220,7 +220,7 @@ jobs:
         run: node scripts/smoke.mjs --target viewer
 
       - name: Restore Playwright browser cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}

--- a/scripts/preview-gate.test.mjs
+++ b/scripts/preview-gate.test.mjs
@@ -156,7 +156,7 @@ describe("preview workflow security boundary", () => {
       "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd",
       "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320",
       "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444",
-      "actions/cache@5a3ec84eff668545956fd18022155c47e93e2684",
+      "actions/cache@caa296126883cff596d87d8935842f9db880ef25",
       "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
     ]);
     assert.equal(uses.length, 6);


### PR DESCRIPTION
Closes #186.

## Summary

- pin `actions/cache` v5.1.0 by immutable SHA in CI and preview workflows
- update the preview workflow's exact-action allowlist

## Why

The prior v4.2.3 action targets deprecated Node.js 20 and GitHub now forces it onto Node.js 24 with a warning. The official v5 action uses Node.js 24 directly and remains backward compatible on the GitHub-hosted runners used here.

## Verification

- `node --test scripts/preview-gate.test.mjs`
- `pnpm check:b4push-ci-parity`
- `pnpm exec prettier --check .github/workflows/ci.yml .github/workflows/preview.yml scripts/preview-gate.test.mjs`
