### PR TITLE
[Binary Objects][Sub] Add byte-aware reads and raw downloads

### DIFF
--- a/packages/core/src/binary.ts
+++ b/packages/core/src/binary.ts
@@ -1,6 +1,8 @@
 export type Representation = "text" | "binary";
 export type ContentAccess = "inline" | "raw" | "deleted";
 export type StorageTier = "d1" | "r2";
+/** Selects the immutable content table referenced by a version row. */
+export type ContentStorage = "legacy" | "bytes";
 export type UploadMode = "single" | "multipart";
 
 export interface ContentMetadata {
@@ -49,7 +51,15 @@ export interface ByteObject {
 
 /** Read seam shared by legacy TEXT, D1 BLOB, and private R2 implementations. */
 export interface ByteStorageReader {
-  get(input: { stash: string; hash: string; range?: ByteRange }): Promise<ByteObject | null>;
+  get(input: {
+    stash: string;
+    hash: string;
+    storage: ContentStorage;
+    size: number;
+    etag: string;
+    contentType: string;
+    range?: ByteRange;
+  }): Promise<ByteObject | null>;
 }
 
 export interface StagedByteObject {

--- a/workers/stash/src/app.ts
+++ b/workers/stash/src/app.ts
@@ -12,10 +12,22 @@ const ALLOW_HEADERS = [
   "Authorization",
   "Content-Type",
   "If-None-Match",
+  "If-Range",
+  "Range",
   "Idempotency-Key",
   "X-Stash-Client-Id",
 ];
-const EXPOSE_HEADERS = ["ETag", "X-Stash-Version", "Idempotent-Replayed", "Retry-After"];
+const EXPOSE_HEADERS = [
+  "ETag",
+  "X-Stash-Version",
+  "Idempotent-Replayed",
+  "Retry-After",
+  "Accept-Ranges",
+  "Content-Length",
+  "Content-Range",
+  "Content-Disposition",
+  "X-Content-Type-Options",
+];
 
 function allowedOrigins(value: string): Set<string> {
   return new Set(

--- a/workers/stash/src/d1/admin-store.ts
+++ b/workers/stash/src/d1/admin-store.ts
@@ -22,6 +22,7 @@ import {
   type TokenRecord,
 } from "@takazudo/zudo-history-stash-core";
 import { mintToken, sha256Hex } from "../auth.js";
+import { parseBinarySettings } from "../binary-config.js";
 import type { Env } from "../env.js";
 import type { StashRow, TokenRow } from "./schema.js";
 
@@ -165,10 +166,14 @@ const CHANGES_ASC = `
     v.path,
     v.version,
     v.kind,
+    v.blob_hash AS hash,
     v.author,
     v.message,
     v.size_bytes AS size,
-    v.created_at
+    v.created_at,
+    v.content_type,
+    v.representation,
+    v.application_etag
   FROM versions AS v
   INNER JOIN stashes AS s ON s.name = v.stash_name AND s.deleted_at IS NULL
   WHERE v.id > ?
@@ -183,10 +188,14 @@ const CHANGES_BEFORE = `
     v.path,
     v.version,
     v.kind,
+    v.blob_hash AS hash,
     v.author,
     v.message,
     v.size_bytes AS size,
-    v.created_at
+    v.created_at,
+    v.content_type,
+    v.representation,
+    v.application_etag
   FROM versions AS v
   INNER JOIN stashes AS s ON s.name = v.stash_name AND s.deleted_at IS NULL
   WHERE v.id < ?
@@ -201,10 +210,14 @@ const CHANGES_NEWEST = `
     v.path,
     v.version,
     v.kind,
+    v.blob_hash AS hash,
     v.author,
     v.message,
     v.size_bytes AS size,
-    v.created_at
+    v.created_at,
+    v.content_type,
+    v.representation,
+    v.application_etag
   FROM versions AS v
   INNER JOIN stashes AS s ON s.name = v.stash_name AND s.deleted_at IS NULL
   ORDER BY v.id DESC
@@ -249,10 +262,14 @@ interface ChangeRow {
   path: string;
   version: number;
   kind: "put" | "delete" | "rollback";
+  hash: string | null;
   author: string;
   message: string;
   size: number;
   created_at: number;
+  content_type: string;
+  representation: "text" | "binary";
+  application_etag: string | null;
 }
 
 export interface AdminStoreDependencies {
@@ -423,7 +440,12 @@ function mapToken(row: TokenListRow): TokenRecord | null {
   };
 }
 
-function mapChange(row: ChangeRow): ChangeItem {
+function mapChange(row: ChangeRow, jsonInlineMaxBytes: number): ChangeItem {
+  const deleted = row.kind === "delete";
+  const etag = deleted ? null : (row.application_etag ?? row.hash);
+  if ((!deleted && (row.hash === null || etag !== row.hash)) || (deleted && row.hash !== null)) {
+    throw new StashError("internal", "Stored change metadata is invalid.");
+  }
   return {
     changeId: row.change_id,
     stash: row.stash,
@@ -434,6 +456,15 @@ function mapChange(row: ChangeRow): ChangeItem {
     message: row.message,
     size: row.size,
     createdAt: toIso(row.created_at),
+    representation: row.representation,
+    contentAccess: deleted
+      ? "deleted"
+      : row.representation === "text" && row.size <= jsonInlineMaxBytes
+        ? "inline"
+        : "raw",
+    contentType: row.content_type,
+    byteSize: row.size,
+    etag,
   };
 }
 
@@ -442,6 +473,7 @@ export function createAdminStore(
   dependencies: Partial<AdminStoreDependencies> = {},
 ): AdminStore {
   const deps = { ...defaultDependencies, ...dependencies };
+  const { jsonInlineMaxBytes } = parseBinarySettings(env);
 
   return {
     async listStashes(query) {
@@ -729,7 +761,7 @@ export function createAdminStore(
       const result = await statement.all<ChangeRow>();
       const hasMore = result.results.length > limit;
       const rows = result.results.slice(0, limit);
-      const changes = rows.map(mapChange);
+      const changes = rows.map((row) => mapChange(row, jsonInlineMaxBytes));
       if (since !== undefined) {
         return {
           changes,

--- a/workers/stash/src/d1/byte-reader.ts
+++ b/workers/stash/src/d1/byte-reader.ts
@@ -1,0 +1,146 @@
+import {
+  StashError,
+  type ByteObject,
+  type ByteRange,
+  type ByteStorageReader,
+} from "@takazudo/zudo-history-stash-core";
+import type { Env } from "../env.js";
+import { parseBlobKey } from "./blobs.js";
+
+interface LegacyByteRow {
+  body: string | null;
+  r2_key: string | null;
+  size_bytes: number;
+}
+
+interface ByteRow {
+  body_bytes: ArrayBuffer | null;
+  r2_key: string | null;
+  size_bytes: number;
+}
+
+function internalReadError(): never {
+  throw new StashError("internal", "Stored file content is unavailable or invalid.");
+}
+
+function assertRange(range: ByteRange | undefined, size: number): void {
+  if (
+    range !== undefined &&
+    (!Number.isSafeInteger(range.start) ||
+      !Number.isSafeInteger(range.end) ||
+      range.start < 0 ||
+      range.end < range.start ||
+      range.end >= size)
+  ) {
+    internalReadError();
+  }
+}
+
+function byteStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      if (bytes.byteLength > 0) controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+function selectedBytes(bytes: Uint8Array, range: ByteRange | undefined): Uint8Array {
+  return range === undefined ? bytes : bytes.subarray(range.start, range.end + 1);
+}
+
+async function readR2(
+  env: Env,
+  key: string,
+  expectedSize: number,
+  range: ByteRange | undefined,
+): Promise<ReadableStream<Uint8Array>> {
+  try {
+    const object = await env.BLOBS.get(
+      key,
+      range === undefined
+        ? undefined
+        : { range: { offset: range.start, length: range.end - range.start + 1 } },
+    );
+    if (object === null || object.size !== expectedSize) internalReadError();
+    return object.body;
+  } catch (error) {
+    if (error instanceof StashError) throw error;
+    internalReadError();
+  }
+}
+
+/** Resolves exact bytes from the version-selected legacy or byte table. */
+export function createByteStorageReader(env: Env): ByteStorageReader {
+  return {
+    async get(input): Promise<ByteObject | null> {
+      if (!Number.isSafeInteger(input.size) || input.size < 0) internalReadError();
+      assertRange(input.range, input.size);
+      const db = env.DB.withSession("first-primary");
+
+      if (input.storage === "legacy") {
+        const row = await db
+          .prepare(
+            `SELECT body, r2_key, size_bytes FROM blobs
+             WHERE stash_name = ? AND hash = ? LIMIT 1`,
+          )
+          .bind(input.stash, input.hash)
+          .first<LegacyByteRow>();
+        if (row === null) return null;
+        if (row.size_bytes !== input.size || (row.body === null) === (row.r2_key === null)) {
+          internalReadError();
+        }
+
+        let stream: ReadableStream<Uint8Array>;
+        if (row.body !== null) {
+          const bytes = new TextEncoder().encode(row.body);
+          if (bytes.byteLength !== input.size) internalReadError();
+          stream = byteStream(selectedBytes(bytes, input.range));
+        } else {
+          const key = row.r2_key;
+          if (key === null) internalReadError();
+          const parsed = parseBlobKey(key);
+          if (parsed === null || parsed.stash !== input.stash || parsed.hash !== input.hash) {
+            internalReadError();
+          }
+          stream = await readR2(env, key, input.size, input.range);
+        }
+        return {
+          stream,
+          size: input.size,
+          etag: input.etag,
+          contentType: input.contentType,
+          ...(input.range === undefined ? {} : { range: input.range }),
+        };
+      }
+
+      const row = await db
+        .prepare(
+          `SELECT body_bytes, r2_key, size_bytes FROM byte_blobs
+           WHERE stash_name = ? AND hash = ? LIMIT 1`,
+        )
+        .bind(input.stash, input.hash)
+        .first<ByteRow>();
+      if (row === null) return null;
+      if (row.size_bytes !== input.size || (row.body_bytes === null) === (row.r2_key === null)) {
+        internalReadError();
+      }
+
+      const stream =
+        row.body_bytes !== null
+          ? (() => {
+              const bytes = new Uint8Array(row.body_bytes);
+              if (bytes.byteLength !== input.size) internalReadError();
+              return byteStream(selectedBytes(bytes, input.range));
+            })()
+          : await readR2(env, row.r2_key ?? internalReadError(), input.size, input.range);
+      return {
+        stream,
+        size: input.size,
+        etag: input.etag,
+        contentType: input.contentType,
+        ...(input.range === undefined ? {} : { range: input.range }),
+      };
+    },
+  };
+}

--- a/workers/stash/src/d1/reads.ts
+++ b/workers/stash/src/d1/reads.ts
@@ -2,11 +2,18 @@ import {
   LIST_LIMIT_DEFAULT,
   LIST_LIMIT_MAX,
   StashError,
+  sha256Hex,
+  type ByteObject,
+  type ByteRange,
+  type ContentAccess,
+  type ContentStorage,
   type JsonValue,
+  type Representation,
   type VersionKind,
 } from "@takazudo/zudo-history-stash-core";
+import { parseBinarySettings } from "../binary-config.js";
 import type { Env } from "../env.js";
-import { assertBlobRowShape, readBlob, type BlobCodecRow } from "./blobs.js";
+import { createByteStorageReader } from "./byte-reader.js";
 import type { StoreDependencies } from "./store.js";
 import {
   SELECT_CHANGES_ASC,
@@ -37,14 +44,21 @@ export interface ReadFileRecord {
   createdAt: string;
   deleted: boolean;
   body: string | null;
+  representation: Representation;
+  contentAccess: ContentAccess;
   contentType: string;
+  byteSize: number;
+  etag: string | null;
 }
 
-export type ReadFileMetadata = Omit<ReadFileRecord, "body">;
+export type ReadFileMetadata = Omit<ReadFileRecord, "body"> & {
+  contentStorage: ContentStorage;
+  contentRemote: boolean;
+};
 
 export interface ReadFileSource {
+  stash: string;
   metadata: ReadFileMetadata;
-  blob: BlobCodecRow | null;
 }
 
 export interface ReadVersionRecord {
@@ -57,6 +71,11 @@ export interface ReadVersionRecord {
   message: string;
   meta: Record<string, JsonValue>;
   createdAt: string;
+  representation: Representation;
+  contentAccess: ContentAccess;
+  contentType: string;
+  byteSize: number;
+  etag: string | null;
 }
 
 export interface ReadFileSummary {
@@ -66,6 +85,11 @@ export interface ReadFileSummary {
   size: number;
   deleted: boolean;
   updatedAt: string;
+  representation: Representation;
+  contentAccess: ContentAccess;
+  contentType: string;
+  byteSize: number;
+  etag: string | null;
 }
 
 export interface ReadFileList {
@@ -92,6 +116,11 @@ export interface ReadChangeItem {
   message: string;
   size: number;
   createdAt: string;
+  representation: Representation;
+  contentAccess: ContentAccess;
+  contentType: string;
+  byteSize: number;
+  etag: string | null;
 }
 
 export type ReadChangesPage =
@@ -126,6 +155,8 @@ export interface StashReads {
     options?: GetFileOptions,
   ): Promise<ReadFileSource | null>;
   materializeFile(source: ReadFileSource): Promise<ReadFileRecord>;
+  materializeText(source: ReadFileSource): Promise<string>;
+  getByteObject(source: ReadFileSource, range?: ByteRange): Promise<ByteObject>;
   getFile(stash: string, path: string, options?: GetFileOptions): Promise<ReadFileRecord | null>;
   listFiles(stash: string, options?: ListFilesOptions): Promise<ReadFileList>;
   listHistory(
@@ -201,7 +232,53 @@ function toIso(value: number): string {
   return new Date(value).toISOString();
 }
 
-function mapFileMetadata(row: FileReadRow): ReadFileMetadata {
+function applicationEtag(
+  hash: string | null,
+  stored: string | null,
+  deleted: boolean,
+): string | null {
+  if (deleted) {
+    if (hash !== null || stored !== null) return internalReadError();
+    return null;
+  }
+  if (hash === null || (stored !== null && stored !== hash)) return internalReadError();
+  return stored ?? hash;
+}
+
+function contentAccess(
+  representation: Representation,
+  deleted: boolean,
+  size: number,
+  jsonInlineMaxBytes: number,
+): ContentAccess {
+  if (deleted) return "deleted";
+  return representation === "text" && size <= jsonInlineMaxBytes ? "inline" : "raw";
+}
+
+function contentFields(
+  row: {
+    hash: string | null;
+    size: number;
+    kind: VersionKind;
+    representation: Representation;
+    content_type: string;
+    application_etag: string | null;
+  },
+  jsonInlineMaxBytes: number,
+) {
+  if (!Number.isSafeInteger(row.size) || row.size < 0) return internalReadError();
+  const deleted = row.kind === "delete";
+  return {
+    representation: row.representation,
+    contentAccess: contentAccess(row.representation, deleted, row.size, jsonInlineMaxBytes),
+    contentType: row.content_type,
+    byteSize: row.size,
+    etag: applicationEtag(row.hash, row.application_etag, deleted),
+  };
+}
+
+function mapFileMetadata(row: FileReadRow, jsonInlineMaxBytes: number): ReadFileMetadata {
+  const deleted = row.deleted === 1;
   return {
     path: row.path,
     version: row.version,
@@ -213,55 +290,53 @@ function mapFileMetadata(row: FileReadRow): ReadFileMetadata {
     message: row.message,
     meta: parseMeta(row.meta_json),
     createdAt: toIso(row.created_at),
-    deleted: row.deleted === 1,
-    contentType: row.content_type,
+    deleted,
+    ...contentFields(row, jsonInlineMaxBytes),
+    contentStorage: row.content_storage,
+    contentRemote: row.stored_r2_key !== null,
   };
 }
 
 function assertReadFileSource(source: ReadFileSource): void {
-  const { metadata, blob } = source;
+  const { metadata } = source;
   if (!Number.isSafeInteger(metadata.size) || metadata.size < 0) return internalReadError();
 
   if (metadata.deleted) {
-    if (metadata.hash !== null || metadata.size !== 0 || blob !== null) return internalReadError();
+    if (
+      metadata.hash !== null ||
+      metadata.size !== 0 ||
+      metadata.contentAccess !== "deleted" ||
+      metadata.etag !== null
+    ) {
+      return internalReadError();
+    }
     return;
   }
 
-  if (
-    metadata.hash === null ||
-    blob === null ||
-    blob.hash !== metadata.hash ||
-    blob.size_bytes !== metadata.size
-  ) {
+  if (metadata.hash === null || metadata.etag === null || metadata.contentAccess === "deleted") {
     return internalReadError();
   }
-  assertBlobRowShape(blob);
 }
 
-function mapFileSource(row: FileReadRow): ReadFileSource {
-  const metadata = mapFileMetadata(row);
-  const hasBlobColumns =
-    row.blob_hash !== null ||
-    row.blob_body !== null ||
-    row.blob_r2_key !== null ||
-    row.blob_size !== null;
-  let blob: BlobCodecRow | null = null;
-  if (hasBlobColumns) {
-    if (row.blob_hash === null || row.blob_size === null) return internalReadError();
-    blob = {
-      hash: row.blob_hash,
-      body: row.blob_body,
-      r2_key: row.blob_r2_key,
-      size_bytes: row.blob_size,
-    };
+function mapFileSource(
+  stash: string,
+  row: FileReadRow,
+  jsonInlineMaxBytes: number,
+): ReadFileSource {
+  const metadata = mapFileMetadata(row, jsonInlineMaxBytes);
+  if (metadata.deleted) {
+    if (row.stored_hash !== null || row.stored_size !== null || row.stored_r2_key !== null) {
+      return internalReadError();
+    }
+  } else if (row.stored_hash !== metadata.hash || row.stored_size !== metadata.size) {
+    return internalReadError();
   }
-
-  const source = { metadata, blob } satisfies ReadFileSource;
+  const source = { stash, metadata } satisfies ReadFileSource;
   assertReadFileSource(source);
   return source;
 }
 
-function mapVersion(row: HistoryVersionRow): ReadVersionRecord {
+function mapVersion(row: HistoryVersionRow, jsonInlineMaxBytes: number): ReadVersionRecord {
   return {
     version: row.version,
     kind: row.kind,
@@ -272,10 +347,11 @@ function mapVersion(row: HistoryVersionRow): ReadVersionRecord {
     message: row.message,
     meta: parseMeta(row.meta_json),
     createdAt: toIso(row.created_at),
+    ...contentFields(row, jsonInlineMaxBytes),
   };
 }
 
-function mapFileSummary(row: FileSummaryRow): ReadFileSummary {
+function mapFileSummary(row: FileSummaryRow, jsonInlineMaxBytes: number): ReadFileSummary {
   return {
     path: row.path,
     headVersion: row.head_version,
@@ -283,10 +359,11 @@ function mapFileSummary(row: FileSummaryRow): ReadFileSummary {
     size: row.size,
     deleted: row.deleted === 1,
     updatedAt: toIso(row.updated_at),
+    ...contentFields({ ...row, kind: row.deleted === 1 ? "delete" : "put" }, jsonInlineMaxBytes),
   };
 }
 
-function mapChange(row: ChangeRow): ReadChangeItem {
+function mapChange(row: ChangeRow, jsonInlineMaxBytes: number): ReadChangeItem {
   return {
     changeId: row.change_id,
     stash: row.stash,
@@ -297,10 +374,13 @@ function mapChange(row: ChangeRow): ReadChangeItem {
     message: row.message,
     size: row.size,
     createdAt: toIso(row.created_at),
+    ...contentFields(row, jsonInlineMaxBytes),
   };
 }
 
 export function createReads(env: Env, _deps?: StoreDependencies): StashReads {
+  const { jsonInlineMaxBytes } = parseBinarySettings(env);
+  const byteReader = createByteStorageReader(env);
   const getFileSource: StashReads["getFileSource"] = async (stash, path, options = {}) => {
     const stashName = validateString(stash, "stash");
     const filePath = validateString(path, "path");
@@ -313,15 +393,55 @@ export function createReads(env: Env, _deps?: StoreDependencies): StashReads {
       version === undefined
         ? await statement.bind(stashName, filePath).first<FileReadRow>()
         : await statement.bind(stashName, filePath, version).first<FileReadRow>();
-    return row === null ? null : mapFileSource(row);
+    return row === null ? null : mapFileSource(stashName, row, jsonInlineMaxBytes);
+  };
+
+  const getByteObject: StashReads["getByteObject"] = async (source, range) => {
+    assertReadFileSource(source);
+    const { metadata } = source;
+    if (metadata.deleted || metadata.hash === null || metadata.etag === null) {
+      return internalReadError();
+    }
+    const object = await byteReader.get({
+      stash: source.stash,
+      hash: metadata.hash,
+      storage: metadata.contentStorage,
+      size: metadata.size,
+      etag: metadata.etag,
+      contentType: metadata.contentType,
+      ...(range === undefined ? {} : { range }),
+    });
+    return object ?? internalReadError();
+  };
+
+  const materializeText: StashReads["materializeText"] = async (source) => {
+    assertReadFileSource(source);
+    if (source.metadata.deleted || source.metadata.representation !== "text") {
+      return internalReadError();
+    }
+    const object = await getByteObject(source);
+    const bytes = await new Response(object.stream).arrayBuffer();
+    if (bytes.byteLength !== source.metadata.size) return internalReadError();
+    if (source.metadata.contentRemote && (await sha256Hex(bytes)) !== source.metadata.hash) {
+      return internalReadError();
+    }
+    try {
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+    } catch {
+      return internalReadError();
+    }
   };
 
   const materializeFile: StashReads["materializeFile"] = async (source) => {
     assertReadFileSource(source);
-    if (source.metadata.deleted) return { ...source.metadata, body: null };
-    if (source.blob === null) return internalReadError();
-    const body = await readBlob(env, source.blob);
-    return { ...source.metadata, body };
+    const {
+      contentStorage: _contentStorage,
+      contentRemote: _contentRemote,
+      ...metadata
+    } = source.metadata;
+    if (source.metadata.deleted) return { ...metadata, body: null };
+    if (source.metadata.contentAccess === "raw") return { ...metadata, body: null };
+    return { ...metadata, body: await materializeText(source) };
   };
 
   const getFile: StashReads["getFile"] = async (stash, path, options = {}) => {
@@ -332,6 +452,8 @@ export function createReads(env: Env, _deps?: StoreDependencies): StashReads {
   return {
     getFileSource,
     materializeFile,
+    materializeText,
+    getByteObject,
     getFile,
 
     async listFiles(stash, options = {}) {
@@ -352,7 +474,7 @@ export function createReads(env: Env, _deps?: StoreDependencies): StashReads {
       const hasMore = rows.length > limit;
       if (hasMore) rows.pop();
       return {
-        files: rows.map(mapFileSummary),
+        files: rows.map((row) => mapFileSummary(row, jsonInlineMaxBytes)),
         nextAfter: hasMore ? (rows.at(-1)?.path ?? null) : null,
       };
     },
@@ -381,7 +503,7 @@ export function createReads(env: Env, _deps?: StoreDependencies): StashReads {
         headVersion: head.head_version,
         deleted: head.deleted === 1,
         total: head.total,
-        versions: rows.map(mapVersion),
+        versions: rows.map((row) => mapVersion(row, jsonInlineMaxBytes)),
         nextBefore: hasMore ? (rows.at(-1)?.version ?? null) : null,
       };
     },
@@ -406,7 +528,7 @@ export function createReads(env: Env, _deps?: StoreDependencies): StashReads {
       const rows = result.results;
       const hasMore = rows.length > limit;
       if (hasMore) rows.pop();
-      const changes = rows.map(mapChange);
+      const changes = rows.map((row) => mapChange(row, jsonInlineMaxBytes));
       if (since !== undefined) {
         return {
           changes,

--- a/workers/stash/src/d1/sql/reads.ts
+++ b/workers/stash/src/d1/sql/reads.ts
@@ -17,19 +17,26 @@ export const SELECT_FILE_HEAD = `
     v.meta_json AS meta_json,
     v.created_at AS created_at,
     v.content_type AS content_type,
+    v.representation AS representation,
+    v.application_etag AS application_etag,
+    v.content_storage AS content_storage,
     CASE WHEN v.kind = 'delete' THEN 1 ELSE 0 END AS deleted,
-    b.hash AS blob_hash,
-    b.body AS blob_body,
-    b.r2_key AS blob_r2_key,
-    b.size_bytes AS blob_size
+    CASE v.content_storage WHEN 'legacy' THEN lb.hash ELSE bb.hash END AS stored_hash,
+    CASE v.content_storage WHEN 'legacy' THEN lb.size_bytes ELSE bb.size_bytes END AS stored_size,
+    CASE v.content_storage WHEN 'legacy' THEN lb.r2_key ELSE bb.r2_key END AS stored_r2_key
   FROM files AS f
   JOIN versions AS v
     ON v.stash_name = f.stash_name
    AND v.path = f.path
    AND v.version = f.head_version
-  LEFT JOIN blobs AS b
-    ON b.stash_name = v.stash_name
-   AND b.hash = v.blob_hash
+  LEFT JOIN blobs AS lb
+    ON v.content_storage = 'legacy'
+   AND lb.stash_name = v.stash_name
+   AND lb.hash = v.blob_hash
+  LEFT JOIN byte_blobs AS bb
+    ON v.content_storage = 'bytes'
+   AND bb.stash_name = v.stash_name
+   AND bb.hash = v.blob_hash
   WHERE f.stash_name = ?
     AND f.path = ?
   LIMIT 1
@@ -48,18 +55,25 @@ export const SELECT_FILE_VERSION = `
     v.meta_json AS meta_json,
     v.created_at AS created_at,
     v.content_type AS content_type,
+    v.representation AS representation,
+    v.application_etag AS application_etag,
+    v.content_storage AS content_storage,
     CASE WHEN v.kind = 'delete' THEN 1 ELSE 0 END AS deleted,
-    b.hash AS blob_hash,
-    b.body AS blob_body,
-    b.r2_key AS blob_r2_key,
-    b.size_bytes AS blob_size
+    CASE v.content_storage WHEN 'legacy' THEN lb.hash ELSE bb.hash END AS stored_hash,
+    CASE v.content_storage WHEN 'legacy' THEN lb.size_bytes ELSE bb.size_bytes END AS stored_size,
+    CASE v.content_storage WHEN 'legacy' THEN lb.r2_key ELSE bb.r2_key END AS stored_r2_key
   FROM files AS f
   JOIN versions AS v
     ON v.stash_name = f.stash_name
    AND v.path = f.path
-  LEFT JOIN blobs AS b
-    ON b.stash_name = v.stash_name
-   AND b.hash = v.blob_hash
+  LEFT JOIN blobs AS lb
+    ON v.content_storage = 'legacy'
+   AND lb.stash_name = v.stash_name
+   AND lb.hash = v.blob_hash
+  LEFT JOIN byte_blobs AS bb
+    ON v.content_storage = 'bytes'
+   AND bb.stash_name = v.stash_name
+   AND bb.hash = v.blob_hash
   WHERE f.stash_name = ?
     AND f.path = ?
     AND v.version = ?
@@ -73,7 +87,10 @@ export const SELECT_FILES = `
     f.head_hash AS hash,
     v.size_bytes AS size,
     f.deleted AS deleted,
-    f.updated_at AS updated_at
+    f.updated_at AS updated_at,
+    v.content_type AS content_type,
+    v.representation AS representation,
+    v.application_etag AS application_etag
   FROM files AS f
   JOIN versions AS v
     ON v.stash_name = f.stash_name
@@ -111,7 +128,10 @@ export const SELECT_HISTORY_VERSIONS = `
     v.author AS author,
     v.message AS message,
     v.meta_json AS meta_json,
-    v.created_at AS created_at
+    v.created_at AS created_at,
+    v.content_type AS content_type,
+    v.representation AS representation,
+    v.application_etag AS application_etag
   FROM versions AS v
   WHERE v.stash_name = ?
     AND v.path = ?
@@ -127,10 +147,14 @@ export const SELECT_CHANGES_ASC = `
     v.path AS path,
     v.version AS version,
     v.kind AS kind,
+    v.blob_hash AS hash,
     v.author AS author,
     v.message AS message,
     v.size_bytes AS size,
-    v.created_at AS created_at
+    v.created_at AS created_at,
+    v.content_type AS content_type,
+    v.representation AS representation,
+    v.application_etag AS application_etag
   FROM versions AS v
   WHERE v.stash_name = ?
     AND v.id > ?
@@ -145,10 +169,14 @@ export const SELECT_CHANGES_BEFORE = `
     v.path AS path,
     v.version AS version,
     v.kind AS kind,
+    v.blob_hash AS hash,
     v.author AS author,
     v.message AS message,
     v.size_bytes AS size,
-    v.created_at AS created_at
+    v.created_at AS created_at,
+    v.content_type AS content_type,
+    v.representation AS representation,
+    v.application_etag AS application_etag
   FROM versions AS v
   WHERE v.stash_name = ?
     AND v.id < ?
@@ -163,10 +191,14 @@ export const SELECT_CHANGES_NEWEST = `
     v.path AS path,
     v.version AS version,
     v.kind AS kind,
+    v.blob_hash AS hash,
     v.author AS author,
     v.message AS message,
     v.size_bytes AS size,
-    v.created_at AS created_at
+    v.created_at AS created_at,
+    v.content_type AS content_type,
+    v.representation AS representation,
+    v.application_etag AS application_etag
   FROM versions AS v
   WHERE v.stash_name = ?
   ORDER BY v.id DESC
@@ -185,11 +217,13 @@ export interface FileReadRow {
   meta_json: string;
   created_at: number;
   content_type: string;
+  representation: "text" | "binary";
+  application_etag: string | null;
+  content_storage: "legacy" | "bytes";
   deleted: number;
-  blob_hash: string | null;
-  blob_body: string | null;
-  blob_r2_key: string | null;
-  blob_size: number | null;
+  stored_hash: string | null;
+  stored_size: number | null;
+  stored_r2_key: string | null;
 }
 
 export interface FileSummaryRow {
@@ -199,6 +233,9 @@ export interface FileSummaryRow {
   size: number;
   deleted: number;
   updated_at: number;
+  content_type: string;
+  representation: "text" | "binary";
+  application_etag: string | null;
 }
 
 export interface HistoryHeadRow {
@@ -217,6 +254,9 @@ export interface HistoryVersionRow {
   message: string;
   meta_json: string;
   created_at: number;
+  content_type: string;
+  representation: "text" | "binary";
+  application_etag: string | null;
 }
 
 export interface ChangeRow {
@@ -225,8 +265,12 @@ export interface ChangeRow {
   path: string;
   version: number;
   kind: "put" | "delete" | "rollback";
+  hash: string | null;
   author: string;
   message: string;
   size: number;
   created_at: number;
+  content_type: string;
+  representation: "text" | "binary";
+  application_etag: string | null;
 }

--- a/workers/stash/src/d1/sql/writes.ts
+++ b/workers/stash/src/d1/sql/writes.ts
@@ -121,7 +121,8 @@ export const fence = {
 };
 
 export const selectHeadForWrite = `
-  SELECT f.head_version, f.head_hash, f.deleted, v.kind, v.author, v.created_at
+  SELECT f.head_version, f.head_hash, f.deleted, v.kind, v.author, v.created_at,
+    v.representation, v.content_type
   FROM files f
   JOIN versions v ON v.stash_name = f.stash_name AND v.path = f.path
     AND v.version = f.head_version
@@ -131,7 +132,10 @@ export const selectHeadForWrite = `
 export const selectVersionMeta = `
   SELECT v.id, v.version, v.kind, v.blob_hash, v.size_bytes, v.content_type,
     v.rollback_of, v.author, v.message, v.meta_json, v.created_at,
-    previous.blob_hash AS previous_blob_hash
+    v.representation, v.application_etag, v.content_storage,
+    previous.blob_hash AS previous_blob_hash,
+    previous.representation AS previous_representation,
+    previous.content_type AS previous_content_type
   FROM versions v
   LEFT JOIN versions previous ON previous.stash_name = v.stash_name
     AND previous.path = v.path AND previous.version = v.version - 1
@@ -322,9 +326,13 @@ export function deleteBatch(db: Preparer, input: DeleteBatchInput): D1PreparedSt
       .prepare(
         `INSERT INTO versions
           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-           rollback_of, author, message, meta_json, created_at)
-         SELECT ?, ?, ?, 'delete', NULL, 0, 'text/plain; charset=utf-8',
-           NULL, ?, ?, '{}', ? WHERE ${operationFence.sql}`,
+           rollback_of, author, message, meta_json, created_at,
+           representation, application_etag, content_storage)
+         SELECT ?, ?, ?, 'delete', NULL, 0, current.content_type,
+           NULL, ?, ?, '{}', ?, current.representation, NULL, current.content_storage
+         FROM versions AS current
+         WHERE current.stash_name = ? AND current.path = ? AND current.version = ?
+           AND ${operationFence.sql}`,
       )
       .bind(
         input.stash,
@@ -333,6 +341,9 @@ export function deleteBatch(db: Preparer, input: DeleteBatchInput): D1PreparedSt
         input.author,
         input.message,
         input.createdAt,
+        input.stash,
+        input.path,
+        input.expectedVersion,
         ...operationFence.params,
       ),
     ...ledgerStatement(db, input, version, operationFence),
@@ -371,9 +382,11 @@ export function rollbackBatch(db: Preparer, input: RollbackBatchInput): D1Prepar
       .prepare(
         `INSERT INTO versions
           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-           rollback_of, author, message, meta_json, created_at)
+           rollback_of, author, message, meta_json, created_at,
+           representation, application_etag, content_storage)
          SELECT ?, ?, ?, 'rollback', target.blob_hash, target.size_bytes, target.content_type,
-           target.version, ?, COALESCE(NULLIF(?, ''), 'Rollback to v' || target.version), ?, ?
+           target.version, ?, COALESCE(NULLIF(?, ''), 'Rollback to v' || target.version), ?, ?,
+           target.representation, target.application_etag, target.content_storage
          FROM versions target
          WHERE target.stash_name = ? AND target.path = ? AND target.version = ?
            AND ${operationFence.sql}`,

--- a/workers/stash/src/d1/writes.ts
+++ b/workers/stash/src/d1/writes.ts
@@ -42,10 +42,14 @@ interface HeadForWriteRow {
   kind: "put" | "delete" | "rollback";
   author: string;
   created_at: number;
+  representation: "text" | "binary";
+  content_type: string;
 }
 
 interface VersionMetaRow extends VersionRow {
   previous_blob_hash: string | null;
+  previous_representation: "text" | "binary" | null;
+  previous_content_type: string | null;
 }
 
 export interface WriteOptions {
@@ -185,7 +189,14 @@ async function replay<T>(
       ...base,
       hash: row.blob_hash,
       rollbackOf: row.rollback_of,
-      identicalToHead: row.blob_hash === row.previous_blob_hash,
+      identicalToHead:
+        row.blob_hash === row.previous_blob_hash &&
+        row.representation === row.previous_representation &&
+        row.content_type === row.previous_content_type,
+      representation: row.representation,
+      contentType: row.content_type,
+      byteSize: row.size_bytes,
+      etag: row.application_etag ?? row.blob_hash,
     };
   } else {
     if (row.blob_hash === null) return failure("internal", 500, "Invalid put ledger result");
@@ -274,7 +285,14 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
     } else if (head.head_version !== input.expectedVersion) {
       return failure("stale", 409, "Expected version is stale", currentFromHead(head));
     }
-    if (input.skipIfUnchanged && head && head.deleted === 0 && head.head_hash === hash) {
+    if (
+      input.skipIfUnchanged &&
+      head &&
+      head.deleted === 0 &&
+      head.head_hash === hash &&
+      head.representation === "text" &&
+      head.content_type === contentType
+    ) {
       return created({ unchanged: true, version: head.head_version }, 200);
     }
 
@@ -507,9 +525,16 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
             version: input.expectedVersion + 1,
             hash: target.blob_hash,
             rollbackOf: input.toVersion,
-            identicalToHead: target.blob_hash === head.head_hash,
+            identicalToHead:
+              target.blob_hash === head.head_hash &&
+              target.representation === head.representation &&
+              target.content_type === head.content_type,
             changeId: id,
             createdAt: new Date(createdAt).toISOString(),
+            representation: target.representation,
+            contentType: target.content_type,
+            byteSize: target.size_bytes,
+            etag: target.application_etag ?? target.blob_hash,
           },
           201,
         );

--- a/workers/stash/src/routes/diff.ts
+++ b/workers/stash/src/routes/diff.ts
@@ -1,5 +1,4 @@
 import {
-  DIFF_MAX_BYTES,
   DiffCandidateBody,
   DiffQuery,
   MAX_BODY_BYTES,
@@ -12,6 +11,7 @@ import {
 } from "@takazudo/zudo-history-stash-core";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { parseBinarySettings } from "../binary-config.js";
 import type { AppEnv } from "../context.js";
 import type { StashReads, ReadVersionRecord } from "../d1/reads.js";
 import { createStashStore } from "../d1/store.js";
@@ -46,7 +46,7 @@ const DiffCandidateRouteBody = DiffCandidateBody.superRefine((value, context) =>
   }
 });
 
-type DiffReads = Pick<StashReads, "getFile" | "listHistory">;
+type DiffReads = Pick<StashReads, "getFileSource" | "materializeText" | "listHistory">;
 
 export interface DiffRouteDependencies {
   createReads?: (env: Env) => DiffReads;
@@ -83,6 +83,11 @@ function toResolvedSide(version: ReadVersionRecord): ResolvedSide {
       version: version.version,
       hash: version.hash,
       deleted: version.kind === "delete",
+      representation: version.representation,
+      contentAccess: version.contentAccess,
+      contentType: version.contentType,
+      byteSize: version.byteSize,
+      etag: version.etag,
     },
     size: version.size,
   };
@@ -124,18 +129,19 @@ async function loadText(
 ): Promise<string> {
   const { side, size } = resolved;
   if (side.deleted) return "";
-  const file = await reads.getFile(stash, path, { version: side.version });
-  if (file === null) return versionNotFound();
+  const source = await reads.getFileSource(stash, path, { version: side.version });
+  if (source === null) return versionNotFound();
+  const file = source.metadata;
   if (
     file.version !== side.version ||
     file.deleted ||
-    file.body === null ||
+    file.representation !== "text" ||
     file.hash !== side.hash ||
     file.size !== size
   ) {
     return internalReadError();
   }
-  return file.body;
+  return reads.materializeText(source);
 }
 
 function candidateValidationError(result: {
@@ -172,11 +178,19 @@ export function createDiffRoutes(dependencies: DiffRouteDependencies = {}): Hono
       const toVersion = query.to === "head" ? head.side.version : query.to;
       const to = await resolveSide(reads, stash, path, toVersion, head);
 
+      if (
+        (!from.side.deleted && from.side.representation === "binary") ||
+        (!to.side.deleted && to.side.representation === "binary")
+      ) {
+        return c.json({ state: "binary" as const, from: from.side, to: to.side });
+      }
+
       if (from.side.hash === to.side.hash) {
         return c.json({ state: "same" as const, from: from.side, to: to.side });
       }
 
-      if (from.size > DIFF_MAX_BYTES || to.size > DIFF_MAX_BYTES) {
+      const diffMaxBytes = parseBinarySettings(c.env).diffMaxBytes;
+      if (from.size > diffMaxBytes || to.size > diffMaxBytes) {
         return c.json({
           state: "oversized" as const,
           reason: "bytes" as const,
@@ -217,9 +231,14 @@ export function createDiffRoutes(dependencies: DiffRouteDependencies = {}): Hono
       const candidateHash = await sha256Hex(input.body);
       const candidateSize = utf8ByteLength(input.body);
 
+      if (!from.side.deleted && from.side.representation === "binary") {
+        return c.json({ state: "binary" as const });
+      }
+
       if (candidateHash === from.side.hash) return c.json({ state: "same" as const });
 
-      if (from.size > DIFF_MAX_BYTES || candidateSize > DIFF_MAX_BYTES) {
+      const diffMaxBytes = parseBinarySettings(c.env).diffMaxBytes;
+      if (from.size > diffMaxBytes || candidateSize > diffMaxBytes) {
         return c.json({ state: "oversized" as const, reason: "bytes" as const });
       }
 

--- a/workers/stash/src/routes/files.ts
+++ b/workers/stash/src/routes/files.ts
@@ -115,6 +115,11 @@ function responseFile(record: ReadFileRecord): FileRecord {
     createdAt: record.createdAt,
     deleted: record.deleted,
     body: record.body,
+    representation: record.representation,
+    contentAccess: record.contentAccess,
+    contentType: record.contentType,
+    byteSize: record.byteSize,
+    etag: record.etag,
   };
 }
 

--- a/workers/stash/src/routes/index.ts
+++ b/workers/stash/src/routes/index.ts
@@ -13,6 +13,7 @@ import importRoutes from "./import.js";
 import lifecycle from "./lifecycle.js";
 import meta from "./meta.js";
 import proposals from "./proposals.js";
+import rawContent from "./raw-content.js";
 
 function middlewarePath(route: (typeof ROUTES)[number]): string {
   // Diff handlers accept Hono's empty wildcard; other wildcard handlers require a file path.
@@ -36,6 +37,7 @@ routes.route("/", importRoutes);
 routes.route("/", lifecycle);
 routes.route("/", proposals);
 routes.route("/", events);
+routes.route("/", rawContent);
 routes.all("/v1/*", (c) =>
   c.json(
     { error: { code: "not-implemented", message: "This route is not implemented yet." } },

--- a/workers/stash/src/routes/raw-content.ts
+++ b/workers/stash/src/routes/raw-content.ts
@@ -1,0 +1,206 @@
+import {
+  StashError,
+  ifNoneMatchMatches,
+  validatePath,
+  type ByteRange,
+} from "@takazudo/zudo-history-stash-core";
+import { Hono, type Context } from "hono";
+import type { AppEnv } from "../context.js";
+import { createStashStore } from "../d1/store.js";
+
+const rawContent = new Hono<AppEnv>();
+const INTEGER = /^(0|[1-9]\d*)$/;
+const DIGITS = /^\d+$/;
+
+function rawPath(c: Context<AppEnv>): string {
+  const path = c.req.param("path");
+  if (path === undefined) throw new StashError("invalid-path", "Invalid file path.");
+  const result = validatePath(path);
+  if (!result.ok) throw new StashError(result.error, result.message);
+  return path;
+}
+
+function historicalVersion(c: Context<AppEnv>): number {
+  const value = c.req.param("version");
+  const version = value !== undefined && INTEGER.test(value) ? Number(value) : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw new StashError("version-not-found", "Version not found.");
+  }
+  return version;
+}
+
+function quotedEtag(etag: string): string {
+  return `"${etag}"`;
+}
+
+function validContentType(value: string): string {
+  const trimmed = value.trim();
+  const safe = Array.from(trimmed).every((character) => {
+    const code = character.codePointAt(0) ?? 0;
+    return code >= 0x20 && code !== 0x7f;
+  });
+  return trimmed !== "" && safe ? trimmed : "application/octet-stream";
+}
+
+function extendedFilename(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (character) => `%${character.codePointAt(0)?.toString(16).toUpperCase()}`,
+  );
+}
+
+/** Builds an attachment-only disposition without reflecting unsafe filename bytes. */
+export function contentDisposition(path: string): string {
+  const basename = path.split(/[\\/]/).at(-1) ?? "";
+  const clean = Array.from(basename)
+    .filter((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code >= 0x20 && code !== 0x7f;
+    })
+    .join("");
+  const fallback = clean
+    .replace(/[^A-Za-z0-9._-]+/g, "_")
+    .replace(/^\.+$/, "")
+    .slice(0, 180);
+  const safeFallback = fallback === "" ? "download" : fallback;
+  const extended = clean === "" ? safeFallback : Array.from(clean).slice(0, 180).join("");
+  return `attachment; filename="${safeFallback}"; filename*=UTF-8''${extendedFilename(extended)}`;
+}
+
+/** Parses exactly one satisfiable byte range, clamping a closed end to the object size. */
+export function parseByteRange(value: string, size: number): ByteRange | null {
+  if (!Number.isSafeInteger(size) || size <= 0 || value.includes(",")) return null;
+  const match = /^bytes=(\d*)-(\d*)$/i.exec(value.trim());
+  if (match === null) return null;
+  const left = match[1] ?? "";
+  const right = match[2] ?? "";
+  if (left === "" && right === "") return null;
+
+  if (left === "") {
+    if (!DIGITS.test(right)) return null;
+    const suffix = BigInt(right);
+    if (suffix < 1n) return null;
+    return { start: suffix >= BigInt(size) ? 0 : size - Number(suffix), end: size - 1 };
+  }
+
+  if (!DIGITS.test(left)) return null;
+  const startValue = BigInt(left);
+  if (startValue >= BigInt(size)) return null;
+  const start = Number(startValue);
+  if (right === "") return { start, end: size - 1 };
+  if (!DIGITS.test(right)) return null;
+  const requestedEnd = BigInt(right);
+  if (requestedEnd < startValue) return null;
+  return {
+    start,
+    end: requestedEnd >= BigInt(size) ? size - 1 : Number(requestedEnd),
+  };
+}
+
+function ifRangeMatches(value: string | undefined, etag: string): boolean {
+  if (value === undefined) return true;
+  const trimmed = value.trim();
+  return !/^W\//i.test(trimmed) && trimmed === etag;
+}
+
+function commonHeaders(input: {
+  etag: string;
+  version: number;
+  contentType: string;
+  contentLength: number;
+  path: string;
+  range?: ByteRange;
+  totalSize: number;
+}): Headers {
+  const headers = new Headers({
+    ETag: input.etag,
+    "X-Stash-Version": String(input.version),
+    "Accept-Ranges": "bytes",
+    "Content-Length": String(input.contentLength),
+    "Content-Type": validContentType(input.contentType),
+    "Content-Disposition": contentDisposition(input.path),
+    "X-Content-Type-Options": "nosniff",
+  });
+  if (input.range !== undefined) {
+    headers.set(
+      "Content-Range",
+      `bytes ${input.range.start}-${input.range.end}/${input.totalSize}`,
+    );
+  }
+  return headers;
+}
+
+function rangeError(c: Context<AppEnv>, size: number): Response {
+  const payload = JSON.stringify({
+    error: { code: "range-not-satisfiable", message: "The byte range is not satisfiable." },
+  });
+  return new Response(c.req.method === "HEAD" ? null : payload, {
+    status: 416,
+    headers: {
+      "Accept-Ranges": "bytes",
+      "Content-Range": `bytes */${size}`,
+      "Content-Type": "application/json; charset=UTF-8",
+      "Content-Length": String(new TextEncoder().encode(payload).byteLength),
+    },
+  });
+}
+
+async function serve(c: Context<AppEnv>, version: number | undefined): Promise<Response> {
+  const stash = c.get("routeStash").name;
+  const path = rawPath(c);
+  const reads = createStashStore(c.env).reads;
+  const source = await reads.getFileSource(stash, path, version === undefined ? {} : { version });
+  if (source === null) {
+    throw new StashError(
+      version === undefined ? "not-found" : "version-not-found",
+      version === undefined ? "File not found." : "Version not found.",
+    );
+  }
+  const metadata = source.metadata;
+  if (metadata.deleted) throw new StashError("file-deleted", "The file version is deleted.");
+  if (metadata.etag === null) throw new StashError("internal", "Stored content has no validator.");
+
+  const etag = quotedEtag(metadata.etag);
+  const baseHeaders = commonHeaders({
+    etag,
+    version: metadata.version,
+    contentType: metadata.contentType,
+    contentLength: metadata.size,
+    path,
+    totalSize: metadata.size,
+  });
+  if (ifNoneMatchMatches(c.req.header("If-None-Match"), etag)) {
+    return new Response(null, { status: 304, headers: baseHeaders });
+  }
+
+  const rangeHeader = c.req.header("Range");
+  let range: ByteRange | undefined;
+  if (rangeHeader !== undefined && ifRangeMatches(c.req.header("If-Range"), etag)) {
+    range = parseByteRange(rangeHeader, metadata.size) ?? undefined;
+    if (range === undefined) return rangeError(c, metadata.size);
+  }
+
+  const object = await reads.getByteObject(source, range);
+  const headers = commonHeaders({
+    etag,
+    version: metadata.version,
+    contentType: object.contentType,
+    contentLength: range === undefined ? metadata.size : range.end - range.start + 1,
+    path,
+    range,
+    totalSize: metadata.size,
+  });
+  const isHead = c.req.method === "HEAD";
+  if (isHead) await object.stream.cancel().catch(() => undefined);
+  return new Response(isHead ? null : object.stream, {
+    status: range === undefined ? 200 : 206,
+    headers,
+  });
+}
+
+rawContent.on(["GET", "HEAD"], "/v1/stashes/:stash/raw/:path{.+}", (c) => serve(c, undefined));
+rawContent.on(["GET", "HEAD"], "/v1/stashes/:stash/versions/:version/raw/:path{.+}", (c) =>
+  serve(c, historicalVersion(c)),
+);
+
+export default rawContent;

--- a/workers/stash/test/concealment.test.ts
+++ b/workers/stash/test/concealment.test.ts
@@ -105,15 +105,23 @@ describe("deleted stash concealment matrix", () => {
     const url = `http://stash.test${routePath(route)}`;
     const formerResponse = await request(app, url, routeInit(route, former.token));
     expect(formerResponse.status).toBe(401);
-    await expect(formerResponse.json()).resolves.toMatchObject({
-      error: { code: "unauthorized" },
-    });
+    if (route.method === "HEAD") {
+      await expect(formerResponse.text()).resolves.toBe("");
+    } else {
+      await expect(formerResponse.json()).resolves.toMatchObject({
+        error: { code: "unauthorized" },
+      });
+    }
 
     const otherResponse = await request(app, url, routeInit(route, other.token));
     expect(otherResponse.status).toBe(404);
-    await expect(otherResponse.json()).resolves.toMatchObject({
-      error: { code: "not-found" },
-    });
+    if (route.method === "HEAD") {
+      await expect(otherResponse.text()).resolves.toBe("");
+    } else {
+      await expect(otherResponse.json()).resolves.toMatchObject({
+        error: { code: "not-found" },
+      });
+    }
 
     const adminResponse = await request(app, url, routeInit(route, "test-admin"));
     const expected =
@@ -126,9 +134,13 @@ describe("deleted stash concealment matrix", () => {
             : 404;
     expect(adminResponse.status).toBe(expected);
     if (expected === 404) {
-      await expect(adminResponse.json()).resolves.toMatchObject({
-        error: { code: "not-found" },
-      });
+      if (route.method === "HEAD") {
+        await expect(adminResponse.text()).resolves.toBe("");
+      } else {
+        await expect(adminResponse.json()).resolves.toMatchObject({
+          error: { code: "not-found" },
+        });
+      }
     }
   });
 

--- a/workers/stash/test/cors.test.ts
+++ b/workers/stash/test/cors.test.ts
@@ -14,10 +14,10 @@ describe("CORS", () => {
     expect(response.status).toBe(204);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
     expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
-      "Authorization,Content-Type,If-None-Match,Idempotency-Key,X-Stash-Client-Id",
+      "Authorization,Content-Type,If-None-Match,If-Range,Range,Idempotency-Key,X-Stash-Client-Id",
     );
     expect(response.headers.get("Access-Control-Expose-Headers")).toBe(
-      "ETag,X-Stash-Version,Idempotent-Replayed,Retry-After",
+      "ETag,X-Stash-Version,Idempotent-Replayed,Retry-After,Accept-Ranges,Content-Length,Content-Range,Content-Disposition,X-Content-Type-Options",
     );
   });
 

--- a/workers/stash/test/rate-limit.test.ts
+++ b/workers/stash/test/rate-limit.test.ts
@@ -66,6 +66,7 @@ describe("rate-limit route buckets", () => {
   it("keeps every route in its capability bucket", () => {
     expect(RATE_LIMIT_BINDING_BY_ROUTE).toEqual({
       health: null,
+      getCapabilities: null,
       me: "RL_READ",
       listStashes: null,
       createStash: null,
@@ -96,6 +97,17 @@ describe("rate-limit route buckets", () => {
       getDiff: "RL_DIFF",
       diffCandidate: "RL_DIFF",
       getStashChanges: "RL_READ",
+      getRawFile: "RL_READ",
+      headRawFile: "RL_READ",
+      getRawVersion: "RL_READ",
+      headRawVersion: "RL_READ",
+      createUploadSession: "RL_WRITE",
+      getUploadSession: "RL_WRITE",
+      abortUploadSession: "RL_WRITE",
+      uploadSingleContent: "RL_WRITE",
+      uploadPart: "RL_WRITE",
+      completeUploadSession: "RL_WRITE",
+      resumeUploadSession: "RL_WRITE",
     });
   });
 
@@ -536,7 +548,7 @@ describe("rate-limit control flow", () => {
 
     expect(response.status).toBe(204);
     expect(response.headers.get("Access-Control-Expose-Headers")).toBe(
-      "ETag,X-Stash-Version,Idempotent-Replayed,Retry-After",
+      "ETag,X-Stash-Version,Idempotent-Replayed,Retry-After,Accept-Ranges,Content-Length,Content-Range,Content-Disposition,X-Content-Type-Options",
     );
     expect(read.limit).not.toHaveBeenCalled();
   });

--- a/workers/stash/test/routes/admin.test.ts
+++ b/workers/stash/test/routes/admin.test.ts
@@ -865,7 +865,7 @@ describe("cross-stash changes", () => {
     expect(newest.changes.map(({ changeId }) => changeId)).toEqual(descending.slice(0, 2));
     expect(newest).toMatchObject({ nextBefore: descending[1], hasMore: true });
     expect(newest).not.toHaveProperty("nextSince");
-    expect(newest.changes[0]).toEqual({
+    expect(newest.changes[0]).toMatchObject({
       changeId: ids[4],
       stash: "alpha",
       path: "five.txt",
@@ -875,6 +875,11 @@ describe("cross-stash changes", () => {
       message: "message",
       size: 5,
       createdAt: new Date(5_000).toISOString(),
+      representation: "text",
+      contentAccess: "inline",
+      contentType: "text/plain; charset=utf-8",
+      byteSize: 5,
+      etag: "sha256-five.txt",
     });
 
     const olderResponse = await adminRequest(

--- a/workers/stash/test/routes/diff.test.ts
+++ b/workers/stash/test/routes/diff.test.ts
@@ -87,6 +87,11 @@ function version(versionNumber: number, hash: string): ReadVersionRecord {
     message: "",
     meta: {},
     createdAt: new Date(versionNumber).toISOString(),
+    representation: "text",
+    contentAccess: "inline",
+    contentType: "text/plain; charset=utf-8",
+    byteSize: 5,
+    etag: hash,
   };
 }
 
@@ -115,8 +120,26 @@ describe("GET stash diff", () => {
     >();
     expect(json).toEqual({
       ...expected,
-      from: { version: 1, hash: "sha256-alpha-one", deleted: false },
-      to: { version: 2, hash: "sha256-alpha-two", deleted: false },
+      from: {
+        version: 1,
+        hash: "sha256-alpha-one",
+        deleted: false,
+        representation: "text",
+        contentAccess: "inline",
+        contentType: "text/plain; charset=utf-8",
+        byteSize: 9,
+        etag: "sha256-alpha-one",
+      },
+      to: {
+        version: 2,
+        hash: "sha256-alpha-two",
+        deleted: false,
+        representation: "text",
+        contentAccess: "inline",
+        contentType: "text/markdown",
+        byteSize: 9,
+        etag: "sha256-alpha-two",
+      },
     });
     expect(json.state).toBe("ready");
     if (json.state !== "ready" || expected.state !== "ready") {
@@ -174,7 +197,8 @@ describe("GET stash diff", () => {
 
   it("returns same for equal hashes without loading either body", async () => {
     const versions = [version(2, "same-hash"), version(1, "same-hash")];
-    const getFile: StashReads["getFile"] = vi.fn(async () => null);
+    const getFileSource: StashReads["getFileSource"] = vi.fn(async () => null);
+    const materializeText: StashReads["materializeText"] = vi.fn(async () => "");
     const listHistory: StashReads["listHistory"] = vi.fn(async (_stash, path, options = {}) => {
       const before = options.before ?? Number.POSITIVE_INFINITY;
       return {
@@ -200,25 +224,30 @@ describe("GET stash diff", () => {
       });
       await next();
     });
-    routeApp.route("/", createDiffRoutes({ createReads: () => ({ getFile, listHistory }) }));
+    routeApp.route(
+      "/",
+      createDiffRoutes({ createReads: () => ({ getFileSource, materializeText, listHistory }) }),
+    );
 
     const response = await request(
       routeApp,
       "http://example.test/v1/stashes/fake/diff/equal.txt?from=1&to=head",
     );
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       state: "same",
       from: { version: 1, hash: "same-hash", deleted: false },
       to: { version: 2, hash: "same-hash", deleted: false },
     });
-    expect(getFile).not.toHaveBeenCalled();
+    expect(getFileSource).not.toHaveBeenCalled();
+    expect(materializeText).not.toHaveBeenCalled();
   });
 
   it("retries a head observation interrupted by a concurrent commit", async () => {
     const versions = [version(2, "same-hash"), version(1, "same-hash")];
     let observations = 0;
-    const getFile: StashReads["getFile"] = vi.fn(async () => null);
+    const getFileSource: StashReads["getFileSource"] = vi.fn(async () => null);
+    const materializeText: StashReads["materializeText"] = vi.fn(async () => "");
     const listHistory: StashReads["listHistory"] = vi.fn(async (_stash, path, options = {}) => {
       observations += 1;
       if (observations === 1) {
@@ -255,7 +284,10 @@ describe("GET stash diff", () => {
       });
       await next();
     });
-    routeApp.route("/", createDiffRoutes({ createReads: () => ({ getFile, listHistory }) }));
+    routeApp.route(
+      "/",
+      createDiffRoutes({ createReads: () => ({ getFileSource, materializeText, listHistory }) }),
+    );
 
     const response = await request(
       routeApp,
@@ -264,7 +296,8 @@ describe("GET stash diff", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ state: "same" });
     expect(listHistory).toHaveBeenCalledTimes(3);
-    expect(getFile).not.toHaveBeenCalled();
+    expect(getFileSource).not.toHaveBeenCalled();
+    expect(materializeText).not.toHaveBeenCalled();
   });
 
   it("returns both byte and complexity oversized states", async () => {

--- a/workers/stash/test/routes/files.test.ts
+++ b/workers/stash/test/routes/files.test.ts
@@ -126,7 +126,13 @@ describe("file route reads", () => {
       expect(response.status).toBe(200);
       const record = await response.json<Record<string, unknown>>();
       expect(record).toMatchObject({ path, version: 1, body, deleted: false, kind: "put" });
-      expect(record).not.toHaveProperty("contentType");
+      expect(record).toMatchObject({
+        representation: "text",
+        contentAccess: "inline",
+        contentType: "text/plain; charset=utf-8",
+        byteSize: new TextEncoder().encode(body).byteLength,
+        etag: expect.stringMatching(/^sha256-/),
+      });
       expect(record).not.toHaveProperty("rollbackOf");
     }
   });
@@ -331,13 +337,17 @@ describe("file route writes", () => {
     });
     expect(first.status).toBe(201);
     const firstBody = await first.json();
-    expect(firstBody).toEqual({
+    expect(firstBody).toMatchObject({
       version: 4,
       hash: expect.stringMatching(/^sha256-/),
       rollbackOf: 1,
       identicalToHead: false,
       changeId: expect.any(Number),
       createdAt: expect.stringMatching(/Z$/),
+      representation: "text",
+      contentType: "text/plain; charset=utf-8",
+      byteSize: 3,
+      etag: expect.stringMatching(/^sha256-/),
     });
     const replay = await jsonApi("POST", "/rollback/rollback.txt", input, {
       headers: { "Idempotency-Key": "rollback-ledger" },

--- a/workers/stash/test/routes/history.test.ts
+++ b/workers/stash/test/routes/history.test.ts
@@ -75,7 +75,7 @@ describe("file history route", () => {
       ],
       nextBefore: 2,
     });
-    expect(firstPage.versions[0]).toEqual({
+    expect(firstPage.versions[0]).toMatchObject({
       version: 3,
       kind: "rollback",
       hash: expect.stringMatching(/^sha256-/),
@@ -85,6 +85,11 @@ describe("file history route", () => {
       message: "Rollback to v1",
       meta: {},
       createdAt: expect.stringMatching(/Z$/),
+      representation: "text",
+      contentAccess: "inline",
+      contentType: "text/plain; charset=utf-8",
+      byteSize: "ZHS_HISTORY_BODY_MUST_NOT_LEAK_ONE".length,
+      etag: expect.stringMatching(/^sha256-/),
     });
 
     const second = await get(`/history/docs/history.txt?limit=2&before=${firstPage.nextBefore}`);
@@ -158,7 +163,7 @@ describe("per-stash changes route", () => {
       nextSince: ids[1],
       hasMore: true,
     });
-    expect(ascendingPage.changes[0]).toEqual({
+    expect(ascendingPage.changes[0]).toMatchObject({
       changeId: ids[0],
       stash: STASH,
       path: "a.txt",
@@ -168,6 +173,11 @@ describe("per-stash changes route", () => {
       message: "",
       size: 2,
       createdAt: expect.stringMatching(/Z$/),
+      representation: "text",
+      contentAccess: "inline",
+      contentType: "text/plain; charset=utf-8",
+      byteSize: 2,
+      etag: expect.stringMatching(/^sha256-/),
     });
     const ascendingNext = await get(`/changes?since=${ascendingPage.nextSince}&limit=2`);
     await expect(ascendingNext.json()).resolves.toMatchObject({

--- a/workers/stash/test/routes/raw-content.test.ts
+++ b/workers/stash/test/routes/raw-content.test.ts
@@ -1,0 +1,526 @@
+import { sha256Hex } from "@takazudo/zudo-history-stash-core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { app } from "../../src/app.js";
+import { contentDisposition, parseByteRange } from "../../src/routes/raw-content.js";
+import type { Env } from "../../src/env.js";
+import { bearer, mintToken, request, resetDatabase, seedStash } from "../helpers/app.js";
+import { createTestEnv, wrapBlobs, type BlobCallCounts } from "../helpers/env.js";
+
+const STASH = "raw-content";
+const BASE = `http://stash.test/v1/stashes/${STASH}`;
+const encoder = new TextEncoder();
+
+interface SeedInput {
+  bytes: Uint8Array;
+  representation: "text" | "binary";
+  contentType: string;
+  storage: "legacy" | "bytes";
+  r2?: boolean;
+  kind?: "put" | "delete";
+}
+
+async function raw(path: string, init: RequestInit = {}, env?: Env): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", "Bearer test-admin");
+  return request(app, `${BASE}${path}`, { ...init, headers }, env);
+}
+
+async function seedPath(path: string, inputs: readonly SeedInput[]): Promise<string[]> {
+  const env = createTestEnv().env;
+  const hashes: string[] = [];
+  for (const [index, input] of inputs.entries()) {
+    const version = index + 1;
+    const deleted = input.kind === "delete";
+    const hash = deleted ? null : await sha256Hex(input.bytes.slice().buffer as ArrayBuffer);
+    hashes.push(hash ?? "");
+    if (!deleted && hash !== null) {
+      if (input.storage === "legacy") {
+        const body = new TextDecoder().decode(input.bytes);
+        const key = input.r2 ? `${STASH}/${hash}` : null;
+        if (key !== null) await env.BLOBS.put(key, input.bytes);
+        await env.DB.prepare(
+          `INSERT INTO blobs (stash_name, hash, body, r2_key, size_bytes, created_at)
+           VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(stash_name, hash) DO NOTHING`,
+        )
+          .bind(STASH, hash, key === null ? body : null, key, input.bytes.byteLength, version)
+          .run();
+      } else {
+        const key = input.r2 ? `committed/${STASH}/${hash}/${version}` : null;
+        if (key !== null) await env.BLOBS.put(key, input.bytes);
+        await env.DB.prepare(
+          `INSERT INTO byte_blobs
+             (stash_name, hash, body_bytes, r2_key, size_bytes, created_at)
+           VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(stash_name, hash) DO NOTHING`,
+        )
+          .bind(
+            STASH,
+            hash,
+            key === null ? input.bytes.buffer : null,
+            key,
+            input.bytes.byteLength,
+            version,
+          )
+          .run();
+      }
+    }
+    await env.DB.prepare(
+      `INSERT INTO versions
+         (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
+          author, message, meta_json, created_at, representation, application_etag,
+          content_storage)
+       VALUES (?, ?, ?, ?, ?, ?, ?, '', '', '{}', ?, ?, ?, ?)`,
+    )
+      .bind(
+        STASH,
+        path,
+        version,
+        deleted ? "delete" : "put",
+        hash,
+        deleted ? 0 : input.bytes.byteLength,
+        input.contentType,
+        version,
+        input.representation,
+        hash,
+        input.storage,
+      )
+      .run();
+  }
+  const headVersion = inputs.length;
+  const head = inputs.at(-1);
+  if (head === undefined) throw new Error("Missing head fixture");
+  await env.DB.prepare(
+    `INSERT INTO files
+       (stash_name, path, head_version, head_hash, deleted, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 1, ?)`,
+  )
+    .bind(
+      STASH,
+      path,
+      headVersion,
+      head.kind === "delete" ? null : hashes.at(-1),
+      head.kind === "delete" ? 1 : 0,
+      headVersion,
+    )
+    .run();
+  return hashes;
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  await seedStash(STASH);
+});
+
+describe("raw byte delivery", () => {
+  it("returns arbitrary D1 binary exactly with download-safe metadata", async () => {
+    const bytes = Uint8Array.from([0, 255, 1, 128, 10]);
+    const [hash] = await seedPath("arbitrary.bin", [
+      {
+        bytes,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+      },
+    ]);
+
+    const response = await raw("/raw/arbitrary.bin");
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
+    expect(response.headers.get("ETag")).toBe(`"${hash}"`);
+    expect(response.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(response.headers.get("Content-Length")).toBe(String(bytes.byteLength));
+    expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Content-Disposition")).toContain("attachment;");
+  });
+
+  it("selects legacy and byte tables deterministically for the same SHA", async () => {
+    const bytes = encoder.encode("same bytes");
+    const [legacyHash] = await seedPath("legacy.txt", [
+      {
+        bytes,
+        representation: "text",
+        contentType: "text/plain; charset=utf-8",
+        storage: "legacy",
+      },
+    ]);
+    const [byteHash] = await seedPath("byte.bin", [
+      {
+        bytes,
+        representation: "binary",
+        contentType: "application/x-byte-fixture",
+        storage: "bytes",
+      },
+    ]);
+    expect(byteHash).toBe(legacyHash);
+    await expect((await raw("/raw/legacy.txt")).text()).resolves.toBe("same bytes");
+    const binary = await raw("/raw/byte.bin");
+    expect(binary.headers.get("Content-Type")).toBe("application/x-byte-fixture");
+    expect(new Uint8Array(await binary.arrayBuffer())).toEqual(bytes);
+  });
+
+  it.each([false, true])(
+    "marks oversized valid UTF-8 as raw-only and preserves its %s bytes",
+    async (r2) => {
+      const bytes = encoder.encode("valid UTF-8 日本語");
+      await seedPath(r2 ? "raw-r2.txt" : "raw-d1.txt", [
+        {
+          bytes,
+          representation: "text",
+          contentType: "text/plain; charset=utf-8",
+          storage: r2 ? "legacy" : "bytes",
+          r2,
+        },
+      ]);
+      const path = r2 ? "raw-r2.txt" : "raw-d1.txt";
+      const env = createTestEnv({ env: { JSON_INLINE_MAX_BYTES: "4" } }).env;
+      const json = await raw(`/files/${path}`, {}, env);
+      await expect(json.json()).resolves.toMatchObject({
+        body: null,
+        deleted: false,
+        representation: "text",
+        contentAccess: "raw",
+        byteSize: bytes.byteLength,
+      });
+      const response = await raw(`/raw/${path}`, {}, env);
+      expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
+    },
+  );
+
+  it("diffs raw-only text below the configured diff bound", async () => {
+    await seedPath("raw-diff.txt", [
+      {
+        bytes: encoder.encode("before raw text\n"),
+        representation: "text",
+        contentType: "text/plain; charset=utf-8",
+        storage: "bytes",
+      },
+      {
+        bytes: encoder.encode("after raw text\n"),
+        representation: "text",
+        contentType: "text/plain; charset=utf-8",
+        storage: "bytes",
+      },
+    ]);
+    const env = createTestEnv({ env: { JSON_INLINE_MAX_BYTES: "4" } }).env;
+    const response = await raw("/diff/raw-diff.txt?from=1&to=2", {}, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      state: "ready",
+      from: { contentAccess: "raw", representation: "text" },
+      to: { contentAccess: "raw", representation: "text" },
+    });
+  });
+
+  it("streams private R2 bytes and requests only a selected range", async () => {
+    const bytes = Uint8Array.from({ length: 32 }, (_, index) => index);
+    await seedPath("remote.bin", [
+      {
+        bytes,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+        r2: true,
+      },
+    ]);
+    const counts: BlobCallCounts = { get: 0, put: 0 };
+    const env = wrapBlobs(createTestEnv().env, { count: counts });
+    const response = await raw("/raw/remote.bin", { headers: { Range: "bytes=7-11" } }, env);
+    expect(response.status).toBe(206);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes.slice(7, 12));
+    expect(response.headers.get("Content-Range")).toBe("bytes 7-11/32");
+    expect(counts.get).toBe(1);
+  });
+
+  it.each([
+    ["bytes=0-0", [0]],
+    ["bytes=5-5", [5]],
+    ["bytes=1-3", [1, 2, 3]],
+    ["bytes=2-", [2, 3, 4, 5]],
+    ["bytes=-2", [4, 5]],
+    ["bytes=3-99", [3, 4, 5]],
+  ] as const)("serves one range %s", async (header, expected) => {
+    await seedPath("ranges.bin", [
+      {
+        bytes: Uint8Array.from([0, 1, 2, 3, 4, 5]),
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+      },
+    ]);
+    const response = await raw("/raw/ranges.bin", { headers: { Range: header } });
+    expect(response.status).toBe(206);
+    expect(Array.from(new Uint8Array(await response.arrayBuffer()))).toEqual(expected);
+  });
+
+  it.each(["bytes=", "items=0-1", "bytes=2-1", "bytes=-0", "bytes=8-", "bytes=0-1,3-4"])(
+    "rejects invalid or unsatisfiable range %s",
+    async (header) => {
+      await seedPath("invalid-range.bin", [
+        {
+          bytes: Uint8Array.from([1, 2, 3]),
+          representation: "binary",
+          contentType: "application/octet-stream",
+          storage: "bytes",
+        },
+      ]);
+      const response = await raw("/raw/invalid-range.bin", { headers: { Range: header } });
+      expect(response.status).toBe(416);
+      expect(response.headers.get("Content-Range")).toBe("bytes */3");
+    },
+  );
+
+  it("rejects every range on an empty object", async () => {
+    await seedPath("empty.bin", [
+      {
+        bytes: new Uint8Array(),
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+      },
+    ]);
+    const response = await raw("/raw/empty.bin", { headers: { Range: "bytes=0-0" } });
+    expect(response.status).toBe(416);
+    expect(response.headers.get("Content-Range")).toBe("bytes */0");
+  });
+
+  it("honors If-None-Match and application-validator If-Range", async () => {
+    const bytes = encoder.encode("conditional");
+    const [hash] = await seedPath("conditional.txt", [
+      {
+        bytes,
+        representation: "text",
+        contentType: "text/plain; charset=utf-8",
+        storage: "legacy",
+      },
+    ]);
+    const etag = `"${hash}"`;
+    const notModified = await raw("/raw/conditional.txt", {
+      headers: { "If-None-Match": `W/${etag}` },
+    });
+    expect(notModified.status).toBe(304);
+    expect(await notModified.text()).toBe("");
+
+    const matched = await raw("/raw/conditional.txt", {
+      headers: { Range: "bytes=0-2", "If-Range": etag },
+    });
+    expect(matched.status).toBe(206);
+    await expect(matched.text()).resolves.toBe("con");
+
+    for (const mismatch of [`"other"`, `W/${etag}`, new Date().toUTCString()]) {
+      const response = await raw("/raw/conditional.txt", {
+        headers: { Range: "bytes=0-2", "If-Range": mismatch },
+      });
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toBe("conditional");
+    }
+  });
+
+  it("matches GET headers/status for HEAD and never emits a body", async () => {
+    await seedPath("head.bin", [
+      {
+        bytes: Uint8Array.from([10, 11, 12, 13]),
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+      },
+    ]);
+    const cases: HeadersInit[] = [{}, { Range: "bytes=1-2" }, { Range: "bytes=99-" }];
+    for (const headers of cases) {
+      const get = await raw("/raw/head.bin", { headers });
+      const head = await raw("/raw/head.bin", { method: "HEAD", headers });
+      expect(head.status).toBe(get.status);
+      for (const name of ["ETag", "Content-Length", "Content-Range", "Accept-Ranges"]) {
+        expect(head.headers.get(name), name).toBe(get.headers.get(name));
+      }
+      expect(await head.text()).toBe("");
+    }
+  });
+
+  it("serves historical bytes and reports tombstones explicitly", async () => {
+    const old = Uint8Array.from([255, 0, 9]);
+    await seedPath("history.bin", [
+      {
+        bytes: old,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+      },
+      {
+        bytes: new Uint8Array(),
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+        kind: "delete",
+      },
+    ]);
+    const historical = await raw("/versions/1/raw/history.bin");
+    expect(new Uint8Array(await historical.arrayBuffer())).toEqual(old);
+    const tombstone = await raw("/versions/2/raw/history.bin");
+    expect(tombstone.status).toBe(404);
+    await expect(tombstone.json()).resolves.toMatchObject({ error: { code: "file-deleted" } });
+    const current = await raw("/raw/history.bin");
+    await expect(current.json()).resolves.toMatchObject({ error: { code: "file-deleted" } });
+  });
+
+  it("propagates binary and tombstone metadata through every JSON read surface", async () => {
+    const bytes = Uint8Array.from([0, 255, 3]);
+    const [hash] = await seedPath("mapped.bin", [
+      {
+        bytes,
+        representation: "binary",
+        contentType: "application/x-mapped",
+        storage: "bytes",
+      },
+    ]);
+    expect(
+      (
+        await raw("/delete/mapped.bin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ expectedVersion: 1 }),
+        })
+      ).status,
+    ).toBe(200);
+
+    const live = await raw("/files/mapped.bin?version=1");
+    await expect(live.json()).resolves.toMatchObject({
+      hash,
+      body: null,
+      deleted: false,
+      representation: "binary",
+      contentAccess: "raw",
+      contentType: "application/x-mapped",
+      byteSize: 3,
+      etag: hash,
+    });
+    const tombstone = await raw("/files/mapped.bin?version=2");
+    await expect(tombstone.json()).resolves.toMatchObject({
+      hash: null,
+      body: null,
+      deleted: true,
+      representation: "binary",
+      contentAccess: "deleted",
+      byteSize: 0,
+      etag: null,
+    });
+    await expect((await raw("/files?includeDeleted=true")).json()).resolves.toMatchObject({
+      files: [
+        {
+          path: "mapped.bin",
+          representation: "binary",
+          contentAccess: "deleted",
+          etag: null,
+        },
+      ],
+    });
+    await expect((await raw("/history/mapped.bin")).json()).resolves.toMatchObject({
+      versions: [
+        { version: 2, representation: "binary", contentAccess: "deleted", etag: null },
+        { version: 1, representation: "binary", contentAccess: "raw", etag: hash },
+      ],
+    });
+    await expect((await raw("/changes?since=0")).json()).resolves.toMatchObject({
+      changes: [
+        { version: 1, representation: "binary", contentAccess: "raw", etag: hash },
+        { version: 2, representation: "binary", contentAccess: "deleted", etag: null },
+      ],
+    });
+    await expect((await raw("/diff/mapped.bin?from=1&to=2")).json()).resolves.toMatchObject({
+      state: "binary",
+      from: { representation: "binary", contentAccess: "raw", etag: hash },
+      to: { representation: "binary", contentAccess: "deleted", etag: null },
+    });
+  });
+
+  it("rolls a deleted binary back by one immutable pointer without copying bytes", async () => {
+    const bytes = Uint8Array.from([222, 173, 0, 190, 239]);
+    const [hash] = await seedPath("rollback.bin", [
+      {
+        bytes,
+        representation: "binary",
+        contentType: "application/x-rollback",
+        storage: "bytes",
+      },
+    ]);
+    expect(
+      (
+        await raw("/delete/rollback.bin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ expectedVersion: 1 }),
+        })
+      ).status,
+    ).toBe(200);
+    const response = await raw("/rollback/rollback.bin", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Idempotency-Key": "binary-rollback" },
+      body: JSON.stringify({ expectedVersion: 2, toVersion: 1 }),
+    });
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      version: 3,
+      hash,
+      rollbackOf: 1,
+      representation: "binary",
+      contentType: "application/x-rollback",
+      byteSize: bytes.byteLength,
+      etag: hash,
+    });
+    const counts = await createTestEnv()
+      .env.DB.prepare(
+        `SELECT
+         (SELECT COUNT(*) FROM versions WHERE stash_name = ? AND path = ?) AS versions,
+         (SELECT COUNT(*) FROM byte_blobs WHERE stash_name = ? AND hash = ?) AS blobs`,
+      )
+      .bind(STASH, "rollback.bin", STASH, hash)
+      .first<{ versions: number; blobs: number }>();
+    expect(counts).toEqual({ versions: 3, blobs: 1 });
+    const pointer = await createTestEnv()
+      .env.DB.prepare(
+        `SELECT representation, content_type, application_etag, content_storage
+       FROM versions WHERE stash_name = ? AND path = ? AND version = 3`,
+      )
+      .bind(STASH, "rollback.bin")
+      .first();
+    expect(pointer).toEqual({
+      representation: "binary",
+      content_type: "application/x-rollback",
+      application_etag: hash,
+      content_storage: "bytes",
+    });
+    expect(new Uint8Array(await (await raw("/raw/rollback.bin")).arrayBuffer())).toEqual(bytes);
+  });
+
+  it("conceals a raw path from a foreign stash token", async () => {
+    await seedPath("private.bin", [
+      {
+        bytes: Uint8Array.from([1]),
+        representation: "binary",
+        contentType: "application/octet-stream",
+        storage: "bytes",
+      },
+    ]);
+    await seedStash("other-raw");
+    const foreign = await mintToken("other-raw", "read");
+    const response = await request(app, `${BASE}/raw/private.bin`, {
+      headers: bearer(foreign.token),
+    });
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("raw helpers", () => {
+  it("sanitizes separators, quotes, controls, and non-ASCII filenames", () => {
+    const value = contentDisposition(`unsafe/日本語 "x"\n..\\report.html`);
+    expect(value).toContain('filename="report.html"');
+    expect(value).toContain("filename*=UTF-8''report.html");
+    expect(value).not.toContain("\n");
+    expect(contentDisposition("///")).toContain('filename="download"');
+  });
+
+  it("parses closed, open, suffix, and leading-zero ranges", () => {
+    expect(parseByteRange("bytes=01-03", 8)).toEqual({ start: 1, end: 3 });
+    expect(parseByteRange("bytes=4-", 8)).toEqual({ start: 4, end: 7 });
+    expect(parseByteRange("bytes=-99", 8)).toEqual({ start: 0, end: 7 });
+  });
+});

--- a/workers/stash/test/routes/spilled-read.test.ts
+++ b/workers/stash/test/routes/spilled-read.test.ts
@@ -196,7 +196,7 @@ describe("spilled file reads", () => {
       formatEtag({ version: 2, hash: headVersion.hash, deleted: false }),
     );
     expect(headResponse.headers.get("X-Stash-Version")).toBe("2");
-    await expect(headResponse.json()).resolves.toEqual({
+    await expect(headResponse.json()).resolves.toMatchObject({
       path: "exact.txt",
       version: 2,
       hash: headVersion.hash,
@@ -223,7 +223,7 @@ describe("spilled file reads", () => {
     );
     expect(versionResponse.headers.get("X-Stash-Version")).toBe("1");
     const historical = await versionResponse.json<Record<string, unknown>>();
-    expect(historical).toEqual({
+    expect(historical).toMatchObject({
       path: "exact.txt",
       version: 1,
       hash: oldVersion.hash,
@@ -239,7 +239,13 @@ describe("spilled file reads", () => {
     expect(historical.body?.toString().codePointAt(0)).toBe(0xfeff);
     expect(historical).not.toHaveProperty("r2_key");
     expect(historical).not.toHaveProperty("blob");
-    expect(historical).not.toHaveProperty("contentType");
+    expect(historical).toMatchObject({
+      representation: "text",
+      contentAccess: "inline",
+      contentType: "text/plain; charset=utf-8",
+      byteSize: oldVersion.size,
+      etag: oldVersion.hash,
+    });
     expect(versionCounts).toEqual({ get: 1, put: 0 });
   });
 
@@ -340,7 +346,7 @@ describe("metadata-first spilled diffs", () => {
 
     const response = await api("/diff/equal.txt?from=1&to=2", {}, read.bindings);
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       state: "same",
       from: { version: 1, hash: from.hash, deleted: false },
       to: { version: 2, hash: to.hash, deleted: false },
@@ -356,7 +362,7 @@ describe("metadata-first spilled diffs", () => {
 
     const response = await api("/diff/oversized.txt?from=1&to=2", {}, read.bindings);
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
       state: "oversized",
       reason: "bytes",
       from: { version: 1, hash: from.hash, deleted: false },

--- a/workers/stash/test/store/reads/reads.test.ts
+++ b/workers/stash/test/store/reads/reads.test.ts
@@ -19,7 +19,7 @@ describe("StashStore reads", () => {
     it("reads a live head, an older version, a rollback head, and a tombstone", async () => {
       const reads = await createFixtureReads();
 
-      await expect(reads.getFile(READ_FIXTURE_STASH, "gamma.txt")).resolves.toEqual({
+      await expect(reads.getFile(READ_FIXTURE_STASH, "gamma.txt")).resolves.toMatchObject({
         path: "gamma.txt",
         version: 1,
         hash: "sha256-gamma-one",
@@ -33,6 +33,10 @@ describe("StashStore reads", () => {
         deleted: false,
         body: "gamma v1\n",
         contentType: "text/plain; charset=utf-8",
+        representation: "text",
+        contentAccess: "inline",
+        byteSize: 9,
+        etag: "sha256-gamma-one",
       });
 
       await expect(reads.getFile(READ_FIXTURE_STASH, "alpha.txt", { version: 2 })).resolves.toEqual(

--- a/workers/stash/test/store/writes/acceptance.test.ts
+++ b/workers/stash/test/store/writes/acceptance.test.ts
@@ -76,6 +76,17 @@ describe("stash writes", () => {
       statusCode: 200,
       value: { unchanged: true, version: 1 },
     });
+    const metadataChange = await writes.put(stash, "cas.txt", {
+      body: "same",
+      expectedVersion: 1,
+      contentType: "text/markdown; charset=utf-8",
+      skipIfUnchanged: true,
+    });
+    expect(metadataChange).toMatchObject({
+      ok: true,
+      statusCode: 201,
+      value: { version: 2 },
+    });
   });
 
   it("covers deletion, tombstone resurrection, and missing outcomes", async () => {


### PR DESCRIPTION
Closes #190
Part of #188

## Summary

- preserve exact text or binary bytes in D1 or private immutable R2 objects
- add authenticated current and historical raw `GET`/`HEAD` routes
- support application ETags, conditional requests, one byte range, safe disposition, and `nosniff`
- keep deleted, inline text, raw text, and raw binary states distinct

## Validation

- D1/R2 exact-byte, range, conditional, tombstone, history, and rollback tests
- Worker typecheck/lint/build and Wrangler dry-run
- final integrated `pnpm b4push`
