### PR TITLE
[Binary Objects][Sub] Add resumable multipart upload sessions

### DIFF
--- a/workers/stash/migrations/0007_multipart_runtime.sql
+++ b/workers/stash/migrations/0007_multipart_runtime.sql
@@ -1,0 +1,10 @@
+CREATE TABLE upload_part_writes (
+  session_id  TEXT NOT NULL REFERENCES upload_sessions(id),
+  generation  INTEGER NOT NULL CHECK (generation >= 0),
+  part_number INTEGER NOT NULL CHECK (part_number BETWEEN 1 AND 10000),
+  owner       TEXT NOT NULL,
+  started_at  INTEGER NOT NULL,
+  PRIMARY KEY (session_id, generation, part_number)
+);
+
+CREATE INDEX upload_part_writes_started ON upload_part_writes (started_at);

--- a/workers/stash/package.json
+++ b/workers/stash/package.json
@@ -7,6 +7,7 @@
     "build": "wrangler deploy --dry-run --outdir=dist",
     "test": "bash test/run-with-reaper.sh",
     "test:contract": "vitest run --config vitest.contract.config.ts",
+    "smoke:multipart": "node scripts/multipart-smoke.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },

--- a/workers/stash/scripts/multipart-smoke.mjs
+++ b/workers/stash/scripts/multipart-smoke.mjs
@@ -1,0 +1,97 @@
+import { createHash, randomUUID } from "node:crypto";
+
+const baseUrl = process.env.MULTIPART_SMOKE_BASE_URL?.replace(/\/$/, "");
+const token = process.env.MULTIPART_SMOKE_TOKEN;
+const stash = process.env.MULTIPART_SMOKE_STASH;
+
+if (!baseUrl || !token || !stash) {
+  throw new Error("Set MULTIPART_SMOKE_BASE_URL, MULTIPART_SMOKE_TOKEN, and MULTIPART_SMOKE_STASH");
+}
+
+const authorization = { Authorization: `Bearer ${token}` };
+const capabilitiesResponse = await fetch(`${baseUrl}/v1/capabilities`);
+if (!capabilitiesResponse.ok)
+  throw new Error(`Capabilities failed: ${capabilitiesResponse.status}`);
+const capabilities = await capabilitiesResponse.json();
+const partSize = capabilities.limits?.multipartPartBytes;
+if (!Number.isSafeInteger(partSize) || partSize < 1) throw new Error("Invalid multipart part size");
+
+const first = new Uint8Array(partSize);
+for (let index = 0; index < first.length; index += 1) first[index] = index % 251;
+const final = new TextEncoder().encode("multipart-smoke");
+const hash = createHash("sha256").update(first).update(final).digest("hex");
+const path = `multipart-smoke/${Date.now()}-${randomUUID()}.bin`;
+const idempotency = randomUUID();
+
+const createResponse = await fetch(
+  `${baseUrl}/v1/stashes/${encodeURIComponent(stash)}/uploads/${path}`,
+  {
+    method: "POST",
+    headers: {
+      ...authorization,
+      "Content-Type": "application/json",
+      "Idempotency-Key": `create-${idempotency}`,
+    },
+    body: JSON.stringify({
+      expectedVersion: null,
+      size: first.byteLength + final.byteLength,
+      hash: `sha256-${hash}`,
+      representation: "binary",
+      contentType: "application/octet-stream",
+      mode: "multipart",
+      resumable: true,
+    }),
+  },
+);
+if (!createResponse.ok) throw new Error(`Create failed: ${createResponse.status}`);
+const session = await createResponse.json();
+
+async function abort() {
+  await fetch(`${baseUrl}/v1/stashes/${encodeURIComponent(stash)}/uploads/${session.id}`, {
+    method: "DELETE",
+    headers: {
+      ...authorization,
+      "Content-Type": "application/json",
+      "Idempotency-Key": `abort-${idempotency}`,
+    },
+    body: JSON.stringify({ generation: session.attemptGeneration }),
+  }).catch(() => undefined);
+}
+
+try {
+  for (const [index, bytes] of [first, final].entries()) {
+    const response = await fetch(
+      `${baseUrl}/v1/stashes/${encodeURIComponent(stash)}/uploads/${session.id}/parts/${index + 1}?generation=${session.attemptGeneration}`,
+      { method: "PUT", headers: authorization, body: bytes },
+    );
+    if (!response.ok) throw new Error(`Part ${index + 1} failed: ${response.status}`);
+  }
+  const completeResponse = await fetch(
+    `${baseUrl}/v1/stashes/${encodeURIComponent(stash)}/uploads/${session.id}/complete`,
+    {
+      method: "POST",
+      headers: {
+        ...authorization,
+        "Content-Type": "application/json",
+        "Idempotency-Key": `complete-${idempotency}`,
+      },
+      body: JSON.stringify({ generation: session.attemptGeneration }),
+    },
+  );
+  if (!completeResponse.ok) throw new Error(`Complete failed: ${completeResponse.status}`);
+  const rawResponse = await fetch(
+    `${baseUrl}/v1/stashes/${encodeURIComponent(stash)}/raw/${path}`,
+    { headers: authorization },
+  );
+  if (!rawResponse.ok) throw new Error(`Raw verification failed: ${rawResponse.status}`);
+  const actual = createHash("sha256")
+    .update(new Uint8Array(await rawResponse.arrayBuffer()))
+    .digest("hex");
+  if (actual !== hash) throw new Error("Raw verification hash mismatch");
+  process.stdout.write(
+    `${JSON.stringify({ path, sessionId: session.id, hash: `sha256-${hash}` })}\n`,
+  );
+} catch (error) {
+  await abort();
+  throw error;
+}

--- a/workers/stash/src/byte-writes.ts
+++ b/workers/stash/src/byte-writes.ts
@@ -31,9 +31,36 @@ export function isStagingObjectKey(key: string): boolean {
   );
 }
 
-interface StreamResult {
+export interface StreamResult {
   size: number;
   hash: string;
+}
+
+export async function verifyByteStream(input: {
+  stream: ReadableStream<Uint8Array>;
+  declaredSize: number;
+  maximumBytes: number;
+  representation: Representation;
+}): Promise<StreamResult> {
+  const state = {
+    size: 0,
+    hash: new IncrementalSha256(),
+    decoder: validator(input.representation),
+  };
+  const reader = input.stream.getReader();
+  try {
+    for (;;) {
+      const read = await reader.read();
+      if (read.done) break;
+      consumeChunk(read.value, state, input.maximumBytes, input.declaredSize);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (state.size !== input.declaredSize) {
+    throw new StashError("upload-size-mismatch", "Upload size does not match its declaration.");
+  }
+  return finish(state);
 }
 
 function validator(representation: Representation): TextDecoder | null {

--- a/workers/stash/src/context.ts
+++ b/workers/stash/src/context.ts
@@ -1,4 +1,5 @@
 import type { Env } from "./env.js";
+import type { BinarySettingOverrides } from "./binary-config.js";
 import type { StoreDependencies } from "./d1/store.js";
 import type { StashRow } from "./d1/schema.js";
 
@@ -14,8 +15,11 @@ export type Principal =
 
 export type AppDependencies = Pick<StoreDependencies, "now" | "createId"> & {
   uploadLeaseMs: number;
+  binarySettingOverrides?: BinarySettingOverrides;
   uploadHooks: {
     afterStage?: () => void | Promise<void>;
+    afterMultipartComplete?: () => void | Promise<void>;
+    afterMultipartPart?: () => void | Promise<void>;
     duringFinalizing?: () => void | Promise<void>;
     afterCommit?: () => void | Promise<void>;
     beforeEventPublish?: () => void | Promise<void>;

--- a/workers/stash/src/d1/gc-store.ts
+++ b/workers/stash/src/d1/gc-store.ts
@@ -89,6 +89,14 @@ export interface LedgerRow {
   created_at: number;
 }
 
+export interface MultipartCleanupRow {
+  id: string;
+  attempt_generation: number;
+  staged_r2_key: string;
+  r2_upload_id: string;
+  r2_completed_at: number | null;
+}
+
 function changed(result: D1Result): number {
   return result.meta.changes;
 }
@@ -240,33 +248,77 @@ export function createGcStore(env: Env, budget: StorageOperationBudget) {
         rows.length === 0 ? [] : deleteLedgerRows(session, rows, ledgerCutoff);
       const results = await session.batch([
         ...ledgerStatements,
-        session.prepare(
-          `UPDATE upload_sessions SET state = 'expired', reservation_released_at = ?,
+        session
+          .prepare(
+            `UPDATE upload_sessions SET state = 'expired', reservation_released_at = ?,
                updated_at = ?
-             WHERE state IN ('open','uploaded') AND expires_at <= ?`,
-        ).bind(now, now, now),
-        session.prepare(
-          `DELETE FROM upload_staged_bytes
+             WHERE state IN ('open','uploaded') AND expires_at <= ?
+               AND NOT EXISTS (SELECT 1 FROM upload_part_writes
+                 WHERE session_id = upload_sessions.id
+                   AND generation = upload_sessions.attempt_generation)`,
+          )
+          .bind(now, now, now),
+        session
+          .prepare(
+            `DELETE FROM upload_staged_bytes
            WHERE created_at < ? AND EXISTS (
              SELECT 1 FROM upload_sessions sessions
              WHERE sessions.id = upload_staged_bytes.session_id
                AND sessions.attempt_generation = upload_staged_bytes.generation
                AND sessions.state IN ('committed','aborted','expired','stale','failed')
            )`,
-        ).bind(stagingCutoff),
-        session.prepare(
-          `DELETE FROM upload_parts
+          )
+          .bind(stagingCutoff),
+        session
+          .prepare(
+            `DELETE FROM upload_parts
            WHERE recorded_at < ? AND EXISTS (
              SELECT 1 FROM upload_sessions sessions
              WHERE sessions.id = upload_parts.session_id
                AND sessions.attempt_generation = upload_parts.generation
                AND sessions.state IN ('committed','aborted','expired','stale','failed')
            )`,
-        ).bind(stagingCutoff),
+          )
+          .bind(stagingCutoff),
       ]);
       return [...results.slice(0, ledgerStatements.length), ...results.slice(-2)].reduce(
         (total, result) => total + changed(result),
         0,
+      );
+    },
+
+    async multipartCleanupCandidates(limit: number): Promise<MultipartCleanupRow[]> {
+      if (limit < 1) return [];
+      budget.charge();
+      const rows = await env.DB.withSession("first-primary")
+        .prepare(
+          `SELECT id, attempt_generation, staged_r2_key, r2_upload_id, r2_completed_at
+           FROM upload_sessions
+           WHERE upload_mode = 'multipart' AND staged_r2_key IS NOT NULL
+             AND r2_upload_id IS NOT NULL
+             AND state IN ('aborted','expired','stale','failed')
+             AND NOT EXISTS (SELECT 1 FROM upload_part_writes
+               WHERE session_id = upload_sessions.id
+                 AND generation = upload_sessions.attempt_generation)
+           ORDER BY updated_at, id LIMIT ?`,
+        )
+        .bind(limit)
+        .all<MultipartCleanupRow>();
+      return rows.results;
+    },
+
+    async removeMultipartCleanupRows(rows: readonly MultipartCleanupRow[]): Promise<void> {
+      if (rows.length === 0) return;
+      budget.charge();
+      await env.DB.batch(
+        rows.map((row) =>
+          env.DB.prepare(
+            `DELETE FROM upload_objects WHERE session_id = ? AND generation = ?
+               AND purpose IN ('multipart','staging')
+               AND EXISTS (SELECT 1 FROM upload_sessions WHERE id = ?
+                 AND state IN ('aborted','expired','stale','failed'))`,
+          ).bind(row.id, row.attempt_generation, row.id),
+        ),
       );
     },
 

--- a/workers/stash/src/d1/schema.ts
+++ b/workers/stash/src/d1/schema.ts
@@ -130,6 +130,14 @@ export interface UploadPartRow {
   recorded_at: number;
 }
 
+export interface UploadPartWriteRow {
+  session_id: string;
+  generation: number;
+  part_number: number;
+  owner: string;
+  started_at: number;
+}
+
 export interface UploadObjectRow {
   object_key: string;
   session_id: string;
@@ -212,6 +220,7 @@ export const TABLE_NAMES = [
   "upload_sessions",
   "upload_staged_bytes",
   "upload_parts",
+  "upload_part_writes",
   "upload_objects",
 ] as const;
 
@@ -354,6 +363,7 @@ export const TABLE_COLUMNS = {
     "created_at",
   ],
   upload_parts: ["session_id", "generation", "part_number", "size_bytes", "r2_etag", "recorded_at"],
+  upload_part_writes: ["session_id", "generation", "part_number", "owner", "started_at"],
   upload_objects: [
     "object_key",
     "session_id",
@@ -378,5 +388,6 @@ export interface DatabaseSchema {
   upload_sessions: UploadSessionRow;
   upload_staged_bytes: UploadStagedBytesRow;
   upload_parts: UploadPartRow;
+  upload_part_writes: UploadPartWriteRow;
   upload_objects: UploadObjectRow;
 }

--- a/workers/stash/src/d1/upload-sessions.ts
+++ b/workers/stash/src/d1/upload-sessions.ts
@@ -144,6 +144,231 @@ export class D1UploadSessionStore implements UploadSessionMutationStore {
     return rows.results;
   }
 
+  async bindMultipart(input: {
+    sessionId: string;
+    generation: number;
+    objectKey: string;
+    uploadId: string;
+    now: number;
+  }): Promise<boolean> {
+    const predicate = `EXISTS (SELECT 1 FROM upload_sessions
+      WHERE id = ? AND state = 'open' AND upload_mode = 'multipart'
+        AND attempt_generation = ? AND r2_upload_id IS NULL)`;
+    const results = await this.db.batch([
+      this.db
+        .prepare(
+          `INSERT INTO upload_objects
+             (object_key, session_id, generation, purpose, created_at, completed_at)
+           SELECT ?, ?, ?, 'multipart', ?, NULL WHERE ${predicate}`,
+        )
+        .bind(
+          input.objectKey,
+          input.sessionId,
+          input.generation,
+          input.now,
+          input.sessionId,
+          input.generation,
+        ),
+      this.db
+        .prepare(
+          `UPDATE upload_sessions SET staged_r2_key = ?, r2_upload_id = ?, updated_at = ?
+           WHERE id = ? AND state = 'open' AND upload_mode = 'multipart'
+             AND attempt_generation = ? AND r2_upload_id IS NULL`,
+        )
+        .bind(input.objectKey, input.uploadId, input.now, input.sessionId, input.generation),
+    ]);
+    return results[0]?.meta.changes === 1 && results[1]?.meta.changes === 1;
+  }
+
+  async claimPart(input: {
+    sessionId: string;
+    generation: number;
+    partNumber: number;
+    owner: string;
+    now: number;
+    staleBefore: number;
+  }): Promise<boolean> {
+    await this.db
+      .prepare(
+        `DELETE FROM upload_part_writes WHERE session_id = ? AND generation = ?
+           AND part_number = ? AND started_at <= ?`,
+      )
+      .bind(input.sessionId, input.generation, input.partNumber, input.staleBefore)
+      .run();
+    const result = await this.db
+      .prepare(
+        `INSERT INTO upload_part_writes (session_id, generation, part_number, owner, started_at)
+         SELECT id, attempt_generation, ?, ?, ? FROM upload_sessions
+         WHERE id = ? AND state = 'open' AND upload_mode = 'multipart'
+           AND attempt_generation = ? AND r2_upload_id IS NOT NULL
+         ON CONFLICT(session_id, generation, part_number) DO NOTHING`,
+      )
+      .bind(input.partNumber, input.owner, input.now, input.sessionId, input.generation)
+      .run();
+    return result.meta.changes === 1;
+  }
+
+  async releasePartClaim(input: {
+    sessionId: string;
+    generation: number;
+    partNumber: number;
+    owner: string;
+  }): Promise<void> {
+    await this.db
+      .prepare(
+        `DELETE FROM upload_part_writes WHERE session_id = ? AND generation = ?
+           AND part_number = ? AND owner = ?`,
+      )
+      .bind(input.sessionId, input.generation, input.partNumber, input.owner)
+      .run();
+  }
+
+  async recordClaimedPart(input: {
+    sessionId: string;
+    generation: number;
+    partNumber: number;
+    owner: string;
+    size: number;
+    etag: string;
+    now: number;
+  }): Promise<boolean> {
+    const claim = `EXISTS (SELECT 1 FROM upload_part_writes writes
+      JOIN upload_sessions sessions ON sessions.id = writes.session_id
+      WHERE writes.session_id = ? AND writes.generation = ? AND writes.part_number = ?
+        AND writes.owner = ? AND sessions.state = 'open'
+        AND sessions.attempt_generation = writes.generation)`;
+    const results = await this.db.batch([
+      this.db
+        .prepare(
+          `INSERT INTO upload_parts
+             (session_id, generation, part_number, size_bytes, r2_etag, recorded_at)
+           SELECT ?, ?, ?, ?, ?, ? WHERE ${claim}
+           ON CONFLICT(session_id, generation, part_number) DO UPDATE SET
+             size_bytes = excluded.size_bytes, r2_etag = excluded.r2_etag,
+             recorded_at = excluded.recorded_at`,
+        )
+        .bind(
+          input.sessionId,
+          input.generation,
+          input.partNumber,
+          input.size,
+          input.etag,
+          input.now,
+          input.sessionId,
+          input.generation,
+          input.partNumber,
+          input.owner,
+        ),
+      this.db
+        .prepare(
+          `DELETE FROM upload_part_writes WHERE session_id = ? AND generation = ?
+             AND part_number = ? AND owner = ?`,
+        )
+        .bind(input.sessionId, input.generation, input.partNumber, input.owner),
+    ]);
+    return results[0]?.meta.changes === 1;
+  }
+
+  async sealMultipart(sessionId: string, generation: number, now: number): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        `UPDATE upload_sessions SET state = 'uploaded', uploaded_size = declared_size, updated_at = ?
+         WHERE id = ? AND state = 'open' AND upload_mode = 'multipart'
+           AND attempt_generation = ? AND r2_upload_id IS NOT NULL
+           AND NOT EXISTS (SELECT 1 FROM upload_part_writes
+             WHERE session_id = upload_sessions.id AND generation = upload_sessions.attempt_generation)`,
+      )
+      .bind(now, sessionId, generation)
+      .run();
+    return result.meta.changes === 1;
+  }
+
+  async renewFinalizationLease(
+    lease: FinalizationLease,
+    now: number,
+    leaseUntil: number,
+  ): Promise<FinalizationLease | null> {
+    const result = await this.db
+      .prepare(
+        `UPDATE upload_sessions SET finalization_lease_until = ?, updated_at = ?
+         WHERE id = ? AND state = 'finalizing' AND attempt_generation = ?
+           AND finalization_lease_owner = ? AND finalization_lease_until = ?
+           AND finalization_lease_until > ?`,
+      )
+      .bind(leaseUntil, now, lease.sessionId, lease.generation, lease.owner, lease.expiresAt, now)
+      .run();
+    return result.meta.changes === 1 ? { ...lease, expiresAt: leaseUntil } : null;
+  }
+
+  async markMultipartCompleted(input: { lease: FinalizationLease; now: number }): Promise<boolean> {
+    const results = await this.db.batch([
+      this.db
+        .prepare(
+          `UPDATE upload_objects SET purpose = 'staging', completed_at = ?
+           WHERE session_id = ? AND generation = ? AND purpose = 'multipart'
+             AND EXISTS (SELECT 1 FROM upload_sessions WHERE id = ? AND state = 'finalizing'
+               AND attempt_generation = ? AND finalization_lease_owner = ?
+               AND finalization_lease_until = ? AND finalization_lease_until > ?)`,
+        )
+        .bind(
+          input.now,
+          input.lease.sessionId,
+          input.lease.generation,
+          input.lease.sessionId,
+          input.lease.generation,
+          input.lease.owner,
+          input.lease.expiresAt,
+          input.now,
+        ),
+      this.db
+        .prepare(
+          `UPDATE upload_sessions SET r2_completed_at = COALESCE(r2_completed_at, ?), updated_at = ?
+           WHERE id = ? AND state = 'finalizing' AND attempt_generation = ?
+             AND finalization_lease_owner = ? AND finalization_lease_until = ?
+             AND finalization_lease_until > ?`,
+        )
+        .bind(
+          input.now,
+          input.now,
+          input.lease.sessionId,
+          input.lease.generation,
+          input.lease.owner,
+          input.lease.expiresAt,
+          input.now,
+        ),
+    ]);
+    return results[0]?.meta.changes === 1 && results[1]?.meta.changes === 1;
+  }
+
+  async markMultipartVerified(input: {
+    lease: FinalizationLease;
+    size: number;
+    hash: string;
+    now: number;
+  }): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        `UPDATE upload_sessions SET uploaded_size = ?, uploaded_hash = ?,
+           verification_completed_at = ?, updated_at = ?
+         WHERE id = ? AND state = 'finalizing' AND attempt_generation = ?
+           AND finalization_lease_owner = ? AND finalization_lease_until = ?
+           AND finalization_lease_until > ? AND r2_completed_at IS NOT NULL`,
+      )
+      .bind(
+        input.size,
+        input.hash,
+        input.now,
+        input.now,
+        input.lease.sessionId,
+        input.lease.generation,
+        input.lease.owner,
+        input.lease.expiresAt,
+        input.now,
+      )
+      .run();
+    return result.meta.changes === 1;
+  }
+
   async recordStagedBytes(input: {
     sessionId: string;
     generation: number;
@@ -234,7 +459,10 @@ export class D1UploadSessionStore implements UploadSessionMutationStore {
     const result = await this.db
       .prepare(
         `UPDATE upload_sessions SET state = 'expired', reservation_released_at = ?, updated_at = ?
-         WHERE id = ? AND state IN ('open','uploaded') AND expires_at <= ?`,
+         WHERE id = ? AND state IN ('open','uploaded') AND expires_at <= ?
+           AND NOT EXISTS (SELECT 1 FROM upload_part_writes
+             WHERE session_id = upload_sessions.id
+               AND generation = upload_sessions.attempt_generation)`,
       )
       .bind(now, now, sessionId, now)
       .run();
@@ -273,7 +501,10 @@ export class D1UploadSessionStore implements UploadSessionMutationStore {
          WHERE id = ? AND attempt_generation = ?
            AND (state IN ('open','uploaded') OR
                 (state = 'finalizing' AND finalization_lease_until <= ?))
-           AND (complete_fingerprint IS NULL OR complete_fingerprint = ?)`,
+           AND (complete_fingerprint IS NULL OR complete_fingerprint = ?)
+           AND NOT EXISTS (SELECT 1 FROM upload_part_writes
+             WHERE session_id = upload_sessions.id
+               AND generation = upload_sessions.attempt_generation)`,
       )
       .bind(
         input.fingerprint,

--- a/workers/stash/src/gc.ts
+++ b/workers/stash/src/gc.ts
@@ -266,6 +266,26 @@ export function createGcEngine(env: Env, overrides: Partial<GcDependencies> = {}
           dependencies.now() - orphanMinAgeMs,
           dependencies.now(),
         );
+    if (!run.dryRun) {
+      const cleanupLimit = Math.min(
+        input.maxObjects,
+        Math.floor(Math.max(0, dependencies.budget.remaining - 3) / 2),
+      );
+      const cleanup = await store.multipartCleanupCandidates(cleanupLimit);
+      const cleaned = [];
+      for (const row of cleanup) {
+        dependencies.budget.charge();
+        const completed = await env.BLOBS.head(row.staged_r2_key);
+        dependencies.budget.charge();
+        if (completed !== null) {
+          await env.BLOBS.delete(row.staged_r2_key);
+        } else {
+          await env.BLOBS.resumeMultipartUpload(row.staged_r2_key, row.r2_upload_id).abort();
+        }
+        cleaned.push(row);
+      }
+      await store.removeMultipartCleanupRows(cleaned);
+    }
     return store.finish(run, {
       nextCursor,
       scanned: page.length,

--- a/workers/stash/src/routes/uploads.ts
+++ b/workers/stash/src/routes/uploads.ts
@@ -2,6 +2,8 @@ import {
   AbortUploadSessionBody,
   CompleteUploadSessionBody,
   CreateUploadSessionBody,
+  MAX_MULTIPART_PARTS,
+  UploadPartQuery,
   IDEMPOTENCY_KEY_MAX_CHARS,
   StashError,
   canonicalJson,
@@ -12,7 +14,12 @@ import {
 } from "@takazudo/zudo-history-stash-core";
 import { Hono, type Context } from "hono";
 import { parseBinarySettings } from "../binary-config.js";
-import { discardStagedBytes, stageSingleBytes } from "../byte-writes.js";
+import {
+  discardStagedBytes,
+  stageSingleBytes,
+  stagingObjectKey,
+  verifyByteStream,
+} from "../byte-writes.js";
 import type { AppEnv, Principal } from "../context.js";
 import { finalizeUnchanged, finalizeUpload } from "../d1/upload-finalize.js";
 import { D1UploadSessionStore } from "../d1/upload-sessions.js";
@@ -147,6 +154,43 @@ function sameCreate(
   );
 }
 
+function settings(c: Context<AppEnv>) {
+  return parseBinarySettings(c.env, c.get("deps").binarySettingOverrides);
+}
+
+async function ensureMultipart(
+  c: Context<AppEnv>,
+  row: UploadSessionRow,
+): Promise<UploadSessionRow> {
+  if (row.upload_mode !== "multipart") return row;
+  if (row.r2_upload_id !== null && row.staged_r2_key !== null) return row;
+  if (row.state !== "open") {
+    throw new StashError(
+      "upload-session-not-open",
+      "Upload session cannot initialize multipart state.",
+    );
+  }
+  const objectKey = stagingObjectKey(row.id, row.attempt_generation, c.get("deps").createId());
+  const multipart = await c.env.BLOBS.createMultipartUpload(objectKey, {
+    httpMetadata: { contentType: "application/octet-stream" },
+    customMetadata: { session: row.id, generation: String(row.attempt_generation) },
+  });
+  const store = new D1UploadSessionStore(c.env.DB);
+  const bound = await store.bindMultipart({
+    sessionId: row.id,
+    generation: row.attempt_generation,
+    objectKey,
+    uploadId: multipart.uploadId,
+    now: c.get("deps").now(),
+  });
+  if (!bound) await multipart.abort().catch(() => undefined);
+  const current = requireOwned(await store.get(row.id), c);
+  if (current.r2_upload_id === null || current.staged_r2_key === null) {
+    throw new StashError("internal", "Multipart upload initialization failed.");
+  }
+  return current;
+}
+
 async function assertCreateCas(
   c: Context<AppEnv>,
   path: string,
@@ -167,21 +211,24 @@ async function createSession(c: Context<AppEnv>) {
   const parsed = CreateUploadSessionBody.safeParse(await json(c));
   if (!parsed.success) throw new StashError("validation", "Invalid upload session input.");
   const path = uploadPath(c);
-  const settings = parseBinarySettings(c.env);
-  if (parsed.data.size > settings.maxFileBytes) {
+  const policy = settings(c);
+  if (parsed.data.size > policy.maxFileBytes) {
     throw new StashError("payload-too-large", "The declared file size is too large.");
   }
   const mode =
     parsed.data.mode === "auto"
-      ? !parsed.data.resumable && parsed.data.size <= settings.singleUploadMaxBytes
+      ? !parsed.data.resumable && parsed.data.size <= policy.singleUploadMaxBytes
         ? "single"
         : "multipart"
       : parsed.data.mode;
   if (mode === "single" && parsed.data.resumable) {
     throw new StashError("validation", "A resumable upload must use multipart mode.");
   }
-  if (mode === "single" && parsed.data.size > settings.singleUploadMaxBytes) {
+  if (mode === "single" && parsed.data.size > policy.singleUploadMaxBytes) {
     throw new StashError("payload-too-large", "The declared single upload size is too large.");
+  }
+  if (mode === "multipart" && parsed.data.size === 0) {
+    throw new StashError("validation", "An empty file must use single upload mode.");
   }
   const stash = c.get("routeStash").name;
   const principal = principalColumns(c.get("principal"));
@@ -196,7 +243,7 @@ async function createSession(c: Context<AppEnv>) {
       throw new StashError("idempotency-key-reused", "Idempotency-Key was reused.");
     }
     c.header("Idempotent-Replayed", "true");
-    return c.json(record(existing), 201);
+    return c.json(record(await ensureMultipart(c, existing)), 201);
   }
   await assertCreateCas(c, path, parsed.data.expectedVersion);
   const now = c.get("deps").now();
@@ -212,13 +259,13 @@ async function createSession(c: Context<AppEnv>) {
     representation: parsed.data.representation,
     contentType: parsed.data.contentType,
     mode,
-    tier: parsed.data.size <= settings.d1InlineMaxBytes ? "d1" : "r2",
-    partSize: mode === "multipart" ? settings.multipartPartBytes : null,
+    tier: mode === "multipart" || parsed.data.size > policy.d1InlineMaxBytes ? "r2" : "d1",
+    partSize: mode === "multipart" ? policy.multipartPartBytes : null,
     fingerprint: createFingerprint,
-    expiresAt: now + settings.uploadSessionTtlSeconds * 1_000,
+    expiresAt: now + policy.uploadSessionTtlSeconds * 1_000,
     now,
-    maxOpenSessions: settings.maxOpenUploadSessions,
-    maxReservedBytes: settings.maxReservedUploadBytes,
+    maxOpenSessions: policy.maxOpenUploadSessions,
+    maxReservedBytes: policy.maxReservedUploadBytes,
     skipIfUnchanged: parsed.data.skipIfUnchanged,
   });
   if (!created) {
@@ -229,12 +276,13 @@ async function createSession(c: Context<AppEnv>) {
       sameCreate(raced, parsed.data, path, mode)
     ) {
       c.header("Idempotent-Replayed", "true");
-      return c.json(record(raced), 201);
+      return c.json(record(await ensureMultipart(c, raced)), 201);
     }
     throw new StashError("payload-too-large", "Upload reservation capacity is exhausted.");
   }
-  const row = await store.getByCreateFingerprint(stash, createFingerprint);
+  let row = await store.getByCreateFingerprint(stash, createFingerprint);
   if (row === null) throw new StashError("internal", "Created upload session is unavailable.");
+  row = await ensureMultipart(c, row);
   return c.json(record(row), 201);
 }
 
@@ -278,7 +326,7 @@ uploads.put("/v1/stashes/:stash/uploads/:sessionId/content", async (c) => {
   if (row.state !== "open" || row.upload_mode !== "single") {
     throw new StashError("upload-session-not-open", "Upload session does not accept content.");
   }
-  const settings = parseBinarySettings(c.env);
+  const settings = parseBinarySettings(c.env, c.get("deps").binarySettingOverrides);
   const declaredLength = contentLength(c);
   if (declaredLength !== null) {
     if (declaredLength > settings.httpRequestMaxBytes || declaredLength > settings.maxFileBytes) {
@@ -358,6 +406,157 @@ uploads.put("/v1/stashes/:stash/uploads/:sessionId/content", async (c) => {
   return c.json(record(uploaded), 202);
 });
 
+function partNumber(c: Context<AppEnv>): number {
+  const raw = c.req.param("partNumber");
+  if (raw === undefined || !/^[1-9]\d*$/.test(raw)) {
+    throw new StashError("validation", "Invalid multipart part number.");
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value > MAX_MULTIPART_PARTS) {
+    throw new StashError("validation", "Invalid multipart part number.");
+  }
+  return value;
+}
+
+async function uploadMultipartBody(input: {
+  upload: R2MultipartUpload;
+  partNumber: number;
+  body: ReadableStream<Uint8Array>;
+  expectedSize: number;
+  maximumBytes: number;
+}): Promise<R2UploadedPart> {
+  const fixed = new FixedLengthStream(input.expectedSize);
+  const reader = input.body.getReader();
+  const writer = fixed.writable.getWriter();
+  const uploaded = input.upload.uploadPart(input.partNumber, fixed.readable);
+  let size = 0;
+  try {
+    for (;;) {
+      const read = await reader.read();
+      if (read.done) break;
+      size += read.value.byteLength;
+      if (size > input.maximumBytes) {
+        throw new StashError("payload-too-large", "The upload part is too large.");
+      }
+      if (size > input.expectedSize) {
+        throw new StashError("upload-size-mismatch", "Upload part size is incorrect.");
+      }
+      await writer.write(read.value);
+    }
+    if (size !== input.expectedSize) {
+      throw new StashError("upload-size-mismatch", "Upload part size is incorrect.");
+    }
+    await writer.close();
+    return await uploaded;
+  } catch (error) {
+    await writer.abort(error).catch(() => undefined);
+    await uploaded.catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+    writer.releaseLock();
+  }
+}
+
+uploads.put("/v1/stashes/:stash/uploads/:sessionId/parts/:partNumber", async (c) => {
+  const parsedQuery = UploadPartQuery.safeParse(c.req.query());
+  if (!parsedQuery.success) throw new StashError("validation", "Invalid multipart generation.");
+  const store = new D1UploadSessionStore(c.env.DB);
+  let row = requireOwned(await store.get(sessionId(c)), c);
+  if (row.expires_at <= c.get("deps").now()) {
+    if (await store.expire(row.id, c.get("deps").now())) {
+      row = requireOwned(await store.get(row.id), c);
+      await cleanupMultipart(c, row);
+    }
+    throw new StashError("upload-session-expired", "Upload session expired.");
+  }
+  if (
+    row.state !== "open" ||
+    row.upload_mode !== "multipart" ||
+    parsedQuery.data.generation !== row.attempt_generation
+  ) {
+    throw new StashError("upload-session-not-open", "Upload session does not accept parts.");
+  }
+  row = await ensureMultipart(c, row);
+  const number = partNumber(c);
+  const partSize = row.part_size!;
+  const expectedParts = Math.ceil(row.declared_size / partSize);
+  if (number > expectedParts || expectedParts > MAX_MULTIPART_PARTS) {
+    throw new StashError("validation", "Multipart part number is outside the declared file.");
+  }
+  const expectedSize =
+    number === expectedParts ? row.declared_size - partSize * (expectedParts - 1) : partSize;
+  const policy = settings(c);
+  const length = contentLength(c);
+  if (length !== null && length !== expectedSize) {
+    throw new StashError("upload-size-mismatch", "Upload part size is incorrect.");
+  }
+  if (expectedSize > policy.httpRequestMaxBytes || expectedSize > policy.multipartPartBytes) {
+    throw new StashError("payload-too-large", "The upload part is too large.");
+  }
+  const owner = c.get("deps").createId();
+  const claimed = await store.claimPart({
+    sessionId: row.id,
+    generation: row.attempt_generation,
+    partNumber: number,
+    owner,
+    now: c.get("deps").now(),
+    staleBefore: c.get("deps").now() - c.get("deps").uploadLeaseMs,
+  });
+  if (!claimed) {
+    throw new StashError("upload-session-not-open", "The multipart part is already being written.");
+  }
+  try {
+    const body = c.req.raw.body;
+    if (body === null)
+      throw new StashError("upload-size-mismatch", "Upload part size is incorrect.");
+    const upload = c.env.BLOBS.resumeMultipartUpload(row.staged_r2_key!, row.r2_upload_id!);
+    const part = await uploadMultipartBody({
+      upload,
+      partNumber: number,
+      body,
+      expectedSize,
+      maximumBytes: Math.min(policy.httpRequestMaxBytes, policy.multipartPartBytes),
+    });
+    await c.get("deps").uploadHooks.afterMultipartPart?.();
+    const recorded = await store.recordClaimedPart({
+      sessionId: row.id,
+      generation: row.attempt_generation,
+      partNumber: number,
+      owner,
+      size: expectedSize,
+      etag: part.etag,
+      now: c.get("deps").now(),
+    });
+    if (!recorded) {
+      throw new StashError("upload-session-not-open", "Upload session no longer accepts parts.");
+    }
+  } catch (error) {
+    await store.releasePartClaim({
+      sessionId: row.id,
+      generation: row.attempt_generation,
+      partNumber: number,
+      owner,
+    });
+    if (error instanceof StashError) throw error;
+    throw new StashError("internal", "Multipart part upload failed.");
+  }
+  row = requireOwned(await store.get(row.id), c);
+  const parts = await store.listParts(row.id, row.attempt_generation);
+  return c.json(
+    {
+      ...record(row),
+      parts: parts.map((part) => ({
+        partNumber: part.part_number,
+        size: part.size_bytes,
+        generation: part.generation,
+        etag: part.r2_etag,
+      })),
+    },
+    202,
+  );
+});
+
 function replayResponse(row: UploadSessionRow, fingerprintValue: string): Response | null {
   if (row.result_status === null || row.result_json === null) return null;
   if (row.complete_fingerprint !== fingerprintValue) {
@@ -367,6 +566,40 @@ function replayResponse(row: UploadSessionRow, fingerprintValue: string): Respon
     status: row.result_status,
     headers: { "Content-Type": "application/json; charset=UTF-8", "Idempotent-Replayed": "true" },
   });
+}
+
+async function cleanupMultipart(c: Context<AppEnv>, row: UploadSessionRow): Promise<void> {
+  if (
+    row.upload_mode !== "multipart" ||
+    row.staged_r2_key === null ||
+    row.r2_upload_id === null ||
+    row.state === "committed"
+  ) {
+    return;
+  }
+  const objectKey = row.staged_r2_key;
+  const uploadId = row.r2_upload_id;
+  const tracked = await c.env.DB.prepare(
+    `SELECT 1 AS tracked FROM upload_objects WHERE session_id = ? AND generation = ?
+       AND purpose IN ('multipart','staging')`,
+  )
+    .bind(row.id, row.attempt_generation)
+    .first<{ tracked: 1 }>();
+  if (tracked === null) return;
+  const head = await c.env.BLOBS.head(objectKey);
+  if (head !== null) {
+    await c.env.BLOBS.delete(objectKey);
+  } else {
+    await c.env.BLOBS.resumeMultipartUpload(objectKey, uploadId).abort();
+  }
+  await c.env.DB.prepare(
+    `DELETE FROM upload_objects WHERE session_id = ? AND generation = ?
+       AND purpose IN ('multipart','staging')
+       AND NOT EXISTS (SELECT 1 FROM upload_sessions
+         WHERE id = ? AND state IN ('open','uploaded','finalizing','committed'))`,
+  )
+    .bind(row.id, row.attempt_generation, row.id)
+    .run();
 }
 
 async function publishCommitted(c: Context<AppEnv>, row: UploadSessionRow): Promise<void> {
@@ -442,19 +675,55 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
     return replayed;
   }
   const now = c.get("deps").now();
+  let finalizationNow = now;
   if (row.expires_at <= now && row.state !== "finalizing") {
-    await store.expire(row.id, now);
+    if (await store.expire(row.id, now)) {
+      row = requireOwned(await store.get(row.id), c);
+      await cleanupMultipart(c, row);
+    }
     throw new StashError("upload-session-expired", "Upload session expired.");
   }
-  if (
-    parsed.data.generation !== row.attempt_generation ||
-    row.uploaded_size === null ||
-    row.uploaded_hash === null
-  ) {
+  if (parsed.data.generation !== row.attempt_generation) {
+    throw new StashError("upload-session-not-open", "Upload session is not ready to complete.");
+  }
+  let multipartParts: { partNumber: number; etag: string }[] | null = null;
+  if (row.upload_mode === "multipart") {
+    const durable = await store.listParts(row.id, row.attempt_generation);
+    const partSize = row.part_size!;
+    const expectedCount = Math.ceil(row.declared_size / partSize);
+    const valid =
+      expectedCount > 0 &&
+      expectedCount <= MAX_MULTIPART_PARTS &&
+      durable.length === expectedCount &&
+      durable.every((part, index) => {
+        const number = index + 1;
+        const expectedSize =
+          number === expectedCount ? row.declared_size - partSize * (expectedCount - 1) : partSize;
+        return (
+          part.part_number === number &&
+          part.generation === row.attempt_generation &&
+          part.size_bytes === expectedSize &&
+          part.r2_etag.length > 0
+        );
+      });
+    if (!valid) {
+      throw new StashError("upload-size-mismatch", "Multipart upload is incomplete.");
+    }
+    multipartParts = durable.map((part) => ({
+      partNumber: part.part_number,
+      etag: part.r2_etag,
+    }));
+    if (row.state === "open") {
+      if (!(await store.sealMultipart(row.id, row.attempt_generation, now))) {
+        throw new StashError("upload-session-not-open", "Multipart upload has active part writes.");
+      }
+      row = requireOwned(await store.get(row.id), c);
+    }
+  } else if (row.uploaded_size === null || row.uploaded_hash === null) {
     throw new StashError("upload-session-not-open", "Upload session is not ready to complete.");
   }
   const owner = c.get("deps").createId();
-  const lease = await store.acquireFinalizationLease({
+  let lease = await store.acquireFinalizationLease({
     sessionId: row.id,
     generation: parsed.data.generation,
     owner,
@@ -473,15 +742,131 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
   }
   row = requireOwned(await store.get(row.id), c);
   await c.get("deps").uploadHooks.duringFinalizing?.();
+  if (row.upload_mode === "multipart") {
+    const renewed = await store.renewFinalizationLease(
+      lease,
+      c.get("deps").now(),
+      c.get("deps").now() + c.get("deps").uploadLeaseMs,
+    );
+    if (renewed === null) {
+      throw new StashError("upload-session-not-open", "Upload finalization lease was lost.");
+    }
+    lease = renewed;
+    row = requireOwned(await store.get(row.id), c);
+    const key = row.staged_r2_key;
+    if (key === null || row.r2_upload_id === null || multipartParts === null) {
+      await store.finish({ lease, state: "failed", errorCode: "staging-unavailable", now });
+      throw new StashError("internal", "Multipart staging is unavailable.");
+    }
+    let completed = await c.env.BLOBS.head(key);
+    if (completed === null) {
+      try {
+        completed = await c.env.BLOBS.resumeMultipartUpload(key, row.r2_upload_id).complete(
+          multipartParts,
+        );
+      } catch {
+        completed = await c.env.BLOBS.head(key);
+        if (completed === null) {
+          await store.finish({
+            lease,
+            state: "failed",
+            errorCode: "multipart-complete-failed",
+            now,
+          });
+          throw new StashError("internal", "Multipart completion failed.");
+        }
+      }
+      await c.get("deps").uploadHooks.afterMultipartComplete?.();
+    }
+    if (
+      completed.size !== row.declared_size ||
+      completed.customMetadata?.session !== row.id ||
+      completed.customMetadata.generation !== String(row.attempt_generation)
+    ) {
+      await store.finish({ lease, state: "failed", errorCode: "staging-unavailable", now });
+      throw new StashError("internal", "Completed multipart staging is invalid.");
+    }
+    if (row.r2_completed_at === null) {
+      if (!(await store.markMultipartCompleted({ lease, now: c.get("deps").now() }))) {
+        throw new StashError("upload-session-not-open", "Upload finalization lease was lost.");
+      }
+    }
+    const verificationLease = await store.renewFinalizationLease(
+      lease,
+      c.get("deps").now(),
+      c.get("deps").now() + c.get("deps").uploadLeaseMs,
+    );
+    if (verificationLease === null) {
+      throw new StashError("upload-session-not-open", "Upload finalization lease was lost.");
+    }
+    lease = verificationLease;
+    const object = await c.env.BLOBS.get(key);
+    if (object === null) {
+      await store.finish({
+        lease,
+        state: "failed",
+        errorCode: "staging-unavailable",
+        now: c.get("deps").now(),
+      });
+      throw new StashError("internal", "Completed multipart staging is unavailable.");
+    }
+    try {
+      const verified = await verifyByteStream({
+        stream: object.body,
+        declaredSize: row.declared_size,
+        maximumBytes: settings(c).maxFileBytes,
+        representation: row.representation,
+      });
+      if (row.declared_hash !== null && verified.hash !== row.declared_hash) {
+        throw new StashError("upload-hash-mismatch", "Upload hash does not match its declaration.");
+      }
+      if (
+        !(await store.markMultipartVerified({
+          lease,
+          size: verified.size,
+          hash: verified.hash,
+          now: c.get("deps").now(),
+        }))
+      ) {
+        throw new StashError("upload-session-not-open", "Upload finalization lease was lost.");
+      }
+    } catch (error) {
+      if (error instanceof StashError && error.code !== "upload-session-not-open") {
+        await store.finish({
+          lease,
+          state: "failed",
+          errorCode: error.code,
+          now: c.get("deps").now(),
+        });
+      }
+      throw error;
+    }
+    row = requireOwned(await store.get(row.id), c);
+    finalizationNow = c.get("deps").now();
+    const commitLease = await store.renewFinalizationLease(
+      lease,
+      finalizationNow,
+      finalizationNow + c.get("deps").uploadLeaseMs,
+    );
+    if (commitLease === null) {
+      throw new StashError("upload-session-not-open", "Upload finalization lease was lost.");
+    }
+    lease = commitLease;
+  }
   if (!(await verifyR2Staging(c, row))) {
-    await store.finish({ lease, state: "failed", errorCode: "staging-unavailable", now });
+    await store.finish({
+      lease,
+      state: "failed",
+      errorCode: "staging-unavailable",
+      now: finalizationNow,
+    });
     throw new StashError("internal", "Durable upload staging is unavailable.");
   }
   const origin = eventOrigin(c.req.raw);
   const unchanged = await finalizeUnchanged(c.env.DB, {
     session: row,
     lease,
-    createdAt: now,
+    createdAt: finalizationNow,
     eventOrigin: origin,
   });
   if (unchanged !== null) {
@@ -493,7 +878,7 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
   const committed = await finalizeUpload(c.env.DB, {
     session: row,
     lease,
-    createdAt: now,
+    createdAt: finalizationNow,
     eventOrigin: origin,
   });
   if (committed !== null) {
@@ -525,7 +910,12 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
       deleted_at: number | null;
     }>();
   if (current === null || current.deleted_at !== null) {
-    await store.finish({ lease, state: "failed", errorCode: "stash-unavailable", now });
+    await store.finish({
+      lease,
+      state: "failed",
+      errorCode: "stash-unavailable",
+      now: finalizationNow,
+    });
     throw new StashError("not-found", "The requested resource was not found.");
   }
   const casIsStale =
@@ -533,7 +923,12 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
       ? current.head_version !== null
       : current.head_version !== row.expected_version;
   if (!casIsStale) {
-    await store.finish({ lease, state: "failed", errorCode: "staging-unavailable", now });
+    await store.finish({
+      lease,
+      state: "failed",
+      errorCode: "staging-unavailable",
+      now: finalizationNow,
+    });
     throw new StashError("internal", "Upload finalization could not reference durable staging.");
   }
   const staleJson = JSON.stringify({
@@ -561,7 +956,7 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
     resultStatus: 409,
     resultJson: staleJson,
     errorCode: "stale",
-    now,
+    now: finalizationNow,
   });
   if (!stale)
     throw new StashError("upload-session-not-open", "Upload finalization lease was lost.");
@@ -574,7 +969,7 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
 uploads.post("/v1/stashes/:stash/uploads/:sessionId/complete", complete);
 uploads.post("/v1/stashes/:stash/uploads/:sessionId/resume", async (c) => {
   const store = new D1UploadSessionStore(c.env.DB);
-  const before = requireOwned(await store.get(sessionId(c)), c);
+  let before = requireOwned(await store.get(sessionId(c)), c);
   if (before.state === "open") {
     idempotencyKey(c);
     if (!JSON_CONTENT_TYPE.test(c.req.header("Content-Type") ?? "")) {
@@ -590,6 +985,7 @@ uploads.post("/v1/stashes/:stash/uploads/:sessionId/resume", async (c) => {
     if (!parsed.success || parsed.data.generation !== before.attempt_generation) {
       throw new StashError("validation", "Invalid upload resume input.");
     }
+    before = await ensureMultipart(c, before);
     return c.json(record(before), 200);
   }
   const completion = await complete(c);
@@ -609,7 +1005,10 @@ uploads.delete("/v1/stashes/:stash/uploads/:sessionId", async (c) => {
   let row = requireOwned(await store.get(sessionId(c)), c);
   const abortFingerprint = await fingerprint(c, "abort", row.id, parsed.data);
   const replayed = replayResponse(row, abortFingerprint);
-  if (replayed !== null) return replayed;
+  if (replayed !== null) {
+    await cleanupMultipart(c, row);
+    return replayed;
+  }
   const won = await store.abort({
     sessionId: row.id,
     generation: parsed.data.generation,
@@ -623,6 +1022,7 @@ uploads.delete("/v1/stashes/:stash/uploads/:sessionId", async (c) => {
     throw new StashError("upload-session-not-open", "Upload session cannot be aborted.");
   }
   row = requireOwned(await store.get(row.id), c);
+  await cleanupMultipart(c, row);
   return new Response(row.result_json!, {
     status: 200,
     headers: { "Content-Type": "application/json; charset=UTF-8" },

--- a/workers/stash/test/gc.test.ts
+++ b/workers/stash/test/gc.test.ts
@@ -436,7 +436,7 @@ describe("ledger collection", () => {
       expect(await ledgerKeys()).toEqual([]);
       expect(calls.d1BatchSizes).toEqual([deleteStatements + 3, 4]);
       expect(calls.d1).toBe(budget.used);
-      expect(budget.used).toBe(6);
+      expect(budget.used).toBe(7);
     },
   );
 
@@ -545,7 +545,7 @@ describe("ledger collection", () => {
     expect(orphanRun).toMatchObject({ scanned: 24, eligible: 24, deleted: 24 });
     expect(ledgerRun).toMatchObject({ scanned: 500, eligible: 500, deleted: 500 });
     expect(calls).toEqual({
-      d1: 11,
+      d1: 12,
       d1BatchSizes: [4, 9, 4],
       list: 1,
       head: 24,

--- a/workers/stash/test/helpers/app.ts
+++ b/workers/stash/test/helpers/app.ts
@@ -28,6 +28,7 @@ export async function seedStash(name: string): Promise<void> {
 export async function resetDatabase(): Promise<void> {
   const { DB: db, BLOBS: blobs } = createTestEnv().env;
   for (const table of [
+    "upload_part_writes",
     "upload_parts",
     "upload_staged_bytes",
     "upload_objects",

--- a/workers/stash/test/helpers/env.ts
+++ b/workers/stash/test/helpers/env.ts
@@ -20,6 +20,103 @@ export interface WrapBlobsOptions {
   count?: BlobCallCounts;
 }
 
+export interface MultipartBucketStats {
+  creates: number;
+  completes: number;
+  aborts: number;
+  abortFailuresRemaining?: number;
+}
+
+/** Synthetic multipart seam for correctness tests; deliberately does not emulate R2's 5 MiB floor. */
+export function withSyntheticMultipart(
+  bindings: Env,
+  stats: MultipartBucketStats = { creates: 0, completes: 0, aborts: 0 },
+): Env {
+  const uploads = new Map<
+    string,
+    {
+      key: string;
+      options?: R2MultipartOptions;
+      parts: Map<number, { bytes: Uint8Array; etag: string }>;
+      aborted: boolean;
+      completed: boolean;
+    }
+  >();
+  let serial = 0;
+
+  function resumed(key: string, uploadId: string): R2MultipartUpload {
+    const state = uploads.get(uploadId);
+    if (state === undefined || state.key !== key) throw new Error("Unknown multipart upload");
+    return {
+      key,
+      uploadId,
+      async uploadPart(partNumber, value) {
+        if (state.aborted || state.completed) throw new Error("Multipart upload is terminal");
+        const bytes =
+          value instanceof ReadableStream
+            ? new Uint8Array(await new Response(value).arrayBuffer())
+            : new Uint8Array(await new Response(value as BodyInit).arrayBuffer());
+        const etag = `fake-${uploadId}-${partNumber}-${++serial}`;
+        state.parts.set(partNumber, { bytes, etag });
+        return { partNumber, etag };
+      },
+      async abort() {
+        if ((stats.abortFailuresRemaining ?? 0) > 0) {
+          stats.abortFailuresRemaining = (stats.abortFailuresRemaining ?? 0) - 1;
+          throw new Error("Injected multipart abort failure");
+        }
+        if (!state.aborted && !state.completed) stats.aborts += 1;
+        state.aborted = true;
+        state.parts.clear();
+      },
+      async complete(parts) {
+        if (state.aborted || state.completed) throw new Error("Multipart upload is terminal");
+        const chunks = parts.map(({ partNumber, etag }) => {
+          const part = state.parts.get(partNumber);
+          if (part === undefined || part.etag !== etag)
+            throw new Error("Invalid multipart manifest");
+          return part.bytes;
+        });
+        const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+        const bytes = new Uint8Array(size);
+        let offset = 0;
+        for (const chunk of chunks) {
+          bytes.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+        const object = await bindings.BLOBS.put(key, bytes, state.options);
+        if (object === null) throw new Error("Synthetic multipart put failed");
+        state.completed = true;
+        stats.completes += 1;
+        return object;
+      },
+    };
+  }
+
+  const blobs = new Proxy(bindings.BLOBS, {
+    get(target, property) {
+      if (property === "createMultipartUpload") {
+        return async (key: string, options?: R2MultipartOptions) => {
+          const uploadId = `fake-upload-${++serial}`;
+          uploads.set(uploadId, {
+            key,
+            options,
+            parts: new Map(),
+            aborted: false,
+            completed: false,
+          });
+          stats.creates += 1;
+          return resumed(key, uploadId);
+        };
+      }
+      if (property === "resumeMultipartUpload") return resumed;
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  return { ...bindings, BLOBS: blobs };
+}
+
 function allowAllRateLimiter(): RateLimiter {
   return {
     limit: () => Promise.resolve({ success: true }),

--- a/workers/stash/test/routes/multipart-uploads.test.ts
+++ b/workers/stash/test/routes/multipart-uploads.test.ts
@@ -1,0 +1,334 @@
+import { env } from "cloudflare:workers";
+import { sha256Hex } from "@takazudo/zudo-history-stash-core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../../src/app.js";
+import { bearer, request, resetDatabase, seedStash } from "../helpers/app.js";
+import {
+  createTestEnv,
+  withSyntheticMultipart,
+  type MultipartBucketStats,
+} from "../helpers/env.js";
+import type { Env } from "../../src/env.js";
+import { createGcEngine } from "../../src/gc.js";
+
+const STASH = "multipart-upload";
+const BASE = `http://stash.test/v1/stashes/${STASH}/uploads`;
+const policy = {
+  jsonInlineMaxBytes: 1,
+  d1InlineMaxBytes: 1,
+  httpRequestMaxBytes: 3,
+  singleUploadMaxBytes: 2,
+  maxFileBytes: 12,
+  multipartPartBytes: 3,
+  maxReservedUploadBytes: 24,
+};
+
+let runtimeEnv: Env;
+let multipartStats: MultipartBucketStats;
+
+function bindings() {
+  return runtimeEnv;
+}
+
+function headers(key: string): HeadersInit {
+  return { ...bearer("test-admin"), "Content-Type": "application/json", "Idempotency-Key": key };
+}
+
+async function createMultipart(
+  bytes: Uint8Array,
+  options: { representation?: "text" | "binary"; hash?: string } = {},
+  application = createApp({ binarySettingOverrides: policy }),
+) {
+  const response = await request(
+    application,
+    `${BASE}/asset.bin`,
+    {
+      method: "POST",
+      headers: headers("create-multipart"),
+      body: JSON.stringify({
+        expectedVersion: null,
+        size: bytes.byteLength,
+        ...(options.hash === undefined ? {} : { hash: options.hash }),
+        representation: options.representation ?? "binary",
+        contentType: "application/octet-stream",
+        mode: "multipart",
+        resumable: true,
+      }),
+    },
+    bindings(),
+  );
+  expect(response.status).toBe(201);
+  return response.json<{ id: string; partSize: number; storageTier: string }>();
+}
+
+async function putPart(
+  application: ReturnType<typeof createApp>,
+  id: string,
+  number: number,
+  bytes: Uint8Array,
+) {
+  return request(
+    application,
+    `${BASE}/${id}/parts/${number}?generation=0`,
+    {
+      method: "PUT",
+      headers: { ...bearer("test-admin"), "Content-Length": String(bytes.byteLength) },
+      body: bytes as BodyInit,
+    },
+    bindings(),
+  );
+}
+
+async function finish(application: ReturnType<typeof createApp>, id: string) {
+  return request(
+    application,
+    `${BASE}/${id}/complete`,
+    {
+      method: "POST",
+      headers: headers("complete-multipart"),
+      body: JSON.stringify({ generation: 0 }),
+    },
+    bindings(),
+  );
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  await seedStash(STASH);
+  multipartStats = { creates: 0, completes: 0, aborts: 0 };
+  runtimeEnv = withSyntheticMultipart(createTestEnv().env, multipartStats);
+});
+
+describe("multipart raw upload lifecycle", () => {
+  it("records out-of-order and parallel parts, replaces a part, and commits recorded ETags", async () => {
+    const application = createApp({ binarySettingOverrides: policy });
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7]);
+    const session = await createMultipart(bytes, {}, application);
+    expect(session).toMatchObject({ partSize: 3, storageTier: "r2" });
+
+    const [third, first] = await Promise.all([
+      putPart(application, session.id, 3, bytes.slice(6)),
+      putPart(application, session.id, 1, new Uint8Array([9, 9, 9])),
+    ]);
+    expect([third.status, first.status]).toEqual([202, 202]);
+    expect((await putPart(application, session.id, 1, bytes.slice(0, 3))).status).toBe(202);
+    expect((await putPart(application, session.id, 2, bytes.slice(3, 6))).status).toBe(202);
+
+    const committed = await finish(application, session.id);
+    expect(committed.status).toBe(201);
+    await expect(committed.json()).resolves.toMatchObject({
+      version: 1,
+      hash: await sha256Hex(bytes),
+      size: bytes.byteLength,
+    });
+    const raw = await request(
+      application,
+      `http://stash.test/v1/stashes/${STASH}/raw/asset.bin`,
+      { headers: bearer("test-admin") },
+      bindings(),
+    );
+    expect(new Uint8Array(await raw.arrayBuffer())).toEqual(bytes);
+    expect((await finish(application, session.id)).headers.get("Idempotent-Replayed")).toBe("true");
+    await expect(env.DB.prepare("SELECT COUNT(*) AS count FROM versions").first()).resolves.toEqual(
+      { count: 1 },
+    );
+  });
+
+  it("enforces exact intermediate/final sizes and rejects completion with missing parts", async () => {
+    const application = createApp({ binarySettingOverrides: policy });
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const session = await createMultipart(bytes, {}, application);
+    expect((await putPart(application, session.id, 1, bytes.slice(0, 2))).status).toBe(422);
+    expect((await putPart(application, session.id, 2, bytes.slice(3))).status).toBe(202);
+    expect((await finish(application, session.id)).status).toBe(422);
+    expect((await putPart(application, session.id, 1, bytes.slice(0, 3))).status).toBe(202);
+    expect((await finish(application, session.id)).status).toBe(201);
+  });
+
+  it("validates UTF-8 across assembled part boundaries and rejects a wrong declared hash", async () => {
+    const application = createApp({ binarySettingOverrides: policy });
+    const splitEuro = new Uint8Array([0x61, 0x62, 0xe2, 0x82, 0xac]);
+    const text = await createMultipart(splitEuro, { representation: "text" }, application);
+    await putPart(application, text.id, 1, splitEuro.slice(0, 3));
+    await putPart(application, text.id, 2, splitEuro.slice(3));
+    expect((await finish(application, text.id)).status).toBe(201);
+
+    await resetDatabase();
+    await seedStash(STASH);
+    const wrong = await createMultipart(
+      new Uint8Array([1, 2, 3]),
+      { hash: `sha256-${"0".repeat(64)}` },
+      application,
+    );
+    await putPart(application, wrong.id, 1, new Uint8Array([1, 2, 3]));
+    const rejected = await finish(application, wrong.id);
+    expect(rejected.status).toBe(422);
+    await expect(env.DB.prepare("SELECT COUNT(*) AS count FROM versions").first()).resolves.toEqual(
+      { count: 0 },
+    );
+  });
+
+  it("recovers the R2-complete/D1 gap after lease takeover without a second commit", async () => {
+    let now = 1_900_000_000_000;
+    let crash = true;
+    const application = createApp({
+      now: () => now,
+      uploadLeaseMs: 10,
+      binarySettingOverrides: policy,
+      uploadHooks: {
+        afterMultipartComplete() {
+          if (crash) {
+            crash = false;
+            throw new Error("crash after R2 completion");
+          }
+        },
+      },
+    });
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const session = await createMultipart(bytes, {}, application);
+    await putPart(application, session.id, 1, bytes.slice(0, 3));
+    await putPart(application, session.id, 2, bytes.slice(3));
+    expect((await finish(application, session.id)).status).toBe(500);
+    expect((await finish(application, session.id)).status).toBe(409);
+    now += 11;
+    expect((await finish(application, session.id)).status).toBe(201);
+    await expect(env.DB.prepare("SELECT COUNT(*) AS count FROM versions").first()).resolves.toEqual(
+      { count: 1 },
+    );
+  });
+
+  it("replaces an unrecorded R2 part after the first response path is lost", async () => {
+    let lose = true;
+    const application = createApp({
+      binarySettingOverrides: policy,
+      uploadHooks: {
+        afterMultipartPart() {
+          if (lose) {
+            lose = false;
+            throw new Error("lost before durable part record");
+          }
+        },
+      },
+    });
+    const bytes = new Uint8Array([1, 2, 3]);
+    const session = await createMultipart(bytes, {}, application);
+    expect((await putPart(application, session.id, 1, bytes)).status).toBe(500);
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM upload_parts WHERE session_id = ?")
+        .bind(session.id)
+        .first(),
+    ).resolves.toEqual({ count: 0 });
+    expect((await putPart(application, session.id, 1, bytes)).status).toBe(202);
+    expect((await finish(application, session.id)).status).toBe(201);
+  });
+
+  it("actively aborts incomplete multipart state and fences late parts", async () => {
+    const application = createApp({ binarySettingOverrides: policy });
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const session = await createMultipart(bytes, {}, application);
+    await putPart(application, session.id, 1, bytes.slice(0, 3));
+    const aborted = await request(
+      application,
+      `${BASE}/${session.id}`,
+      {
+        method: "DELETE",
+        headers: headers("abort-multipart"),
+        body: JSON.stringify({ generation: 0 }),
+      },
+      bindings(),
+    );
+    expect(aborted.status).toBe(200);
+    expect((await putPart(application, session.id, 2, bytes.slice(3))).status).toBe(409);
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM upload_objects WHERE session_id = ?")
+        .bind(session.id)
+        .first(),
+    ).resolves.toEqual({ count: 0 });
+    expect(multipartStats.aborts).toBe(1);
+  });
+
+  it("keeps failed abort cleanup durable so an idempotent retry can finish it", async () => {
+    multipartStats.abortFailuresRemaining = 1;
+    const application = createApp({ binarySettingOverrides: policy });
+    const session = await createMultipart(new Uint8Array([1, 2, 3]), {}, application);
+    const abort = () =>
+      request(
+        application,
+        `${BASE}/${session.id}`,
+        {
+          method: "DELETE",
+          headers: headers("abort-retry"),
+          body: JSON.stringify({ generation: 0 }),
+        },
+        bindings(),
+      );
+    expect((await abort()).status).toBe(500);
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM upload_objects WHERE session_id = ?")
+        .bind(session.id)
+        .first(),
+    ).resolves.toEqual({ count: 1 });
+    expect((await abort()).status).toBe(200);
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM upload_objects WHERE session_id = ?")
+        .bind(session.id)
+        .first(),
+    ).resolves.toEqual({ count: 0 });
+    expect(multipartStats.aborts).toBe(1);
+  });
+
+  it("actively aborts expired multipart resources during normal GC cleanup", async () => {
+    const startedAt = 2_000_000_000_000;
+    const application = createApp({ now: () => startedAt, binarySettingOverrides: policy });
+    const session = await createMultipart(new Uint8Array([1, 2, 3]), {}, application);
+    const gc = createGcEngine(runtimeEnv, { now: () => startedAt + 86_400_001 });
+    await gc.run({ kind: "ledger", dryRun: false, maxObjects: 100 });
+    await expect(
+      env.DB.prepare("SELECT state FROM upload_sessions WHERE id = ?").bind(session.id).first(),
+    ).resolves.toEqual({ state: "expired" });
+    expect(multipartStats.aborts).toBe(1);
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM upload_objects WHERE session_id = ?")
+        .bind(session.id)
+        .first(),
+    ).resolves.toEqual({ count: 0 });
+  });
+
+  it("selects multipart at the 1 GiB settings ceiling without allocating the payload", async () => {
+    const gib = 1_073_741_824;
+    const application = createApp({
+      binarySettingOverrides: {
+        maxFileBytes: gib,
+        maxReservedUploadBytes: gib,
+        httpRequestMaxBytes: 32 * 1_024 * 1_024,
+        multipartPartBytes: 131_072,
+        singleUploadMaxBytes: 32 * 1_024 * 1_024,
+      },
+    });
+    const response = await request(
+      application,
+      `${BASE}/large.txt`,
+      {
+        method: "POST",
+        headers: headers("create-1gib-boundary"),
+        body: JSON.stringify({
+          expectedVersion: null,
+          size: gib,
+          representation: "text",
+          contentType: "text/plain; charset=utf-8",
+          mode: "auto",
+          resumable: false,
+        }),
+      },
+      bindings(),
+    );
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      mode: "multipart",
+      representation: "text",
+      declaredSize: gib,
+      partSize: 131_072,
+    });
+    expect(multipartStats.creates).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #192
Part of #188

## Summary

- implement resumable multipart R2 sessions with server-owned keys and recorded R2 part ETags
- support part replacement, durable status, completion replay, recovery/resume, and explicit abort
- fence part writers, finalizers, aborts, stale generations, and late work
- add a bounded opt-in real-R2 smoke command

## Validation

- multipart ordering/replacement, race, lease-takeover, exact-byte, UTF-8, hash, abort, and GC tests
- generated config/OpenAPI and Wrangler dry-run checks
- final integrated `pnpm b4push`
