### PR TITLE
[Binary Objects][Sub] Extend SDK, RPC, fake, and conformance

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -12,3 +12,6 @@ The format is based on Keep a Changelog, and release notes are generated from th
   routes with typed business outcomes.
 - Add representation-cache handling, automatic idempotency keys, replay metadata, and bounded
   `putLatest` conflict retries.
+- Add capability-selected binary/large-object uploads, streamed current/historical downloads,
+  resumable session controls, bounded materializers, observed progress, and Request/Response RPC
+  stream flow control.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -60,6 +60,49 @@ const client = createStashClient({
 `{ idempotencyKey: "…" }` to make a retry use a stable key. A replayed response has
 `replayed: true`; a representation cache hit is `{ ok: true, notModified: true }`.
 
+## Binary and large objects
+
+`client.capabilities()` returns the server's current transfer and file-size limits. The high-level
+`files(stash).upload(path, source, options)` API accepts `Blob`, `ArrayBuffer`, typed-array/DataView
+views, byte `ReadableStream`, and strings. Representation is always explicit; transfer mode, MIME
+type, and size never change `text` into `binary` or the reverse.
+
+```ts
+const files = client.files("assets");
+const uploaded = await files.upload("icons/logo.png", pngBlob, {
+  expectedVersion: null,
+  representation: "binary",
+  contentType: "image/png",
+  resumable: true,
+  onProgress: ({ observedBytes, durableParts }) => {
+    // observedBytes are source bytes consumed; durableParts are server-recorded parts.
+  },
+});
+
+const download = await files.raw.get("icons/logo.png", { range: "bytes=0-1023" });
+if (download.ok && "value" in download) {
+  const bytes = await download.value.bytes(1024); // explicit materialization bound
+  // download.value.body is the unbuffered ReadableStream for larger consumers.
+}
+```
+
+Mode selection is capability-driven: eligible replayable small text uses legacy JSON, a source at
+or below `singleUploadMaxBytes` uses one raw request, and larger or explicitly resumable sources use
+multipart. An explicit `mode` is checked against current capabilities. Binary is never base64
+encoded. Large valid UTF-8 stays `text` but uses raw content access.
+
+A `ReadableStream` is caller-owned and one-shot. Supply its exact `size`; cancellation is forwarded
+to Fetch/RPC where supported, and the client never automatically replays a consumed stream.
+Blob/buffer sources are replayable and may use `retries`; keep mutable ArrayBuffers/views unchanged
+until the operation settles. Multipart retries only the current failed part.
+Use `files.uploads` to create, inspect, resume, abort, upload/replace individual parts, or idempotently
+complete a durable session yourself. Progress reports bytes observed while consuming known sources
+and durable multipart part counts—it does not claim browser network acknowledgement.
+
+Raw current and historical downloads use `files.raw.get(path, { version? })`; `head` provides the
+same validator/version metadata without a body. Convenience `bytes(maxBytes)` and
+`text(maxBytes)` methods deliberately require a bound and cancel reads that exceed it.
+
 Write tokens are full-stash credentials and should not be embedded in browser code. Use a read
 token for browser-direct consumers.
 
@@ -90,12 +133,12 @@ const client = createStashClient({
 });
 ```
 
-`fake.state` exposes the in-memory stash, token, blob, file, version, and idempotency tables for
+`fake.state` exposes the in-memory stash, token, blob, file, version, upload-session, and idempotency tables for
 direct fixture setup and assertions. `fake.reset()` clears those tables without replacing the
 state object. Pass `now` to control timestamps and token expiry; pass `rateLimit` to inject
 Cloudflare-shaped capability/key verdicts (rejections fail open, matching the Worker).
 
-The fake implements the SDK route surface, including proposals and the authenticated fetch-only
+The fake implements the SDK route surface, including exact binary bytes, upload sessions, raw ranges, proposals, and the authenticated fetch-only
 stash event stream, except for health, import, and cross-stash changes. Those unsupported routes
 and unknown routes return `501 not-implemented`.
 `await fake.mintToken()` remains available for direct fixture setup, accepts `expiresAt` or

--- a/packages/client/src/binary.test.ts
+++ b/packages/client/src/binary.test.ts
@@ -92,6 +92,16 @@ describe("binary SDK", () => {
   it("keeps oversized valid UTF-8 text as text while selecting raw transfer", async () => {
     const { client } = fixture({ jsonInlineMaxBytes: 3, singleUploadMaxBytes: 16 });
     await expect(
+      client.files("demo").upload("docs/small.txt", "hi", {
+        expectedVersion: null,
+        representation: "text",
+        contentType: "text/plain; charset=utf-8",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { representation: "text", contentType: "text/plain; charset=utf-8", size: 2 },
+    });
+    await expect(
       client.files("demo").upload("docs/large.txt", "hello", {
         expectedVersion: null,
         representation: "text",
@@ -184,6 +194,13 @@ describe("binary SDK", () => {
         { representation: "binary" },
       ),
     ).toBe("multipart");
+    expect(() =>
+      selectUploadMode({ size: 2, replayable: true, text: true }, capabilities(), {
+        representation: "text",
+        mode: "json",
+        resumable: true,
+      }),
+    ).toThrow("resumable upload must use multipart");
   });
 
   it("requires exact stream size and never replays a consumed one-shot stream", async () => {

--- a/packages/client/src/binary.test.ts
+++ b/packages/client/src/binary.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CapabilitiesResponse } from "@takazudo/zudo-history-stash-core";
+import { createStashClient } from "./client.js";
+import { selectUploadMode } from "./binary.js";
+import { createFakeStash } from "./testing/fake.js";
+
+function capabilities(
+  overrides: Partial<CapabilitiesResponse["limits"]> = {},
+): CapabilitiesResponse {
+  return {
+    representations: ["text", "binary"],
+    contentAccess: ["inline", "raw", "deleted"],
+    transferModes: ["json", "single", "multipart"],
+    storageTiers: ["d1", "r2"],
+    limits: {
+      jsonInlineMaxBytes: 3,
+      d1InlineMaxBytes: 8,
+      httpRequestMaxBytes: 16,
+      singleUploadMaxBytes: 8,
+      maxFileBytes: 1_073_741_824,
+      diffMaxBytesPerSide: 8,
+      multipartPartBytes: 2,
+      maxMultipartParts: 10_000,
+      maxOpenUploadSessionsPerStash: 32,
+      maxReservedUploadBytesPerStash: 2_147_483_648,
+      uploadSessionTtlSeconds: 60,
+      ...overrides,
+    },
+  };
+}
+
+function fixture(overrides: Partial<CapabilitiesResponse["limits"]> = {}) {
+  const fake = createFakeStash({ adminToken: "admin", capabilities: capabilities(overrides) });
+  fake.createStash("demo");
+  const client = createStashClient({
+    baseUrl: "https://fake.invalid",
+    token: "admin",
+    fetch: fake.fetch,
+    idempotencyKey: () => crypto.randomUUID(),
+  });
+  return { fake, client };
+}
+
+describe("binary SDK", () => {
+  it("round-trips arbitrary bytes and historical ranges without UTF-8 coercion", async () => {
+    const { client } = fixture();
+    const bytes = new Uint8Array([0x89, 0x50, 0x00, 0xff, 0x0d, 0x0a]);
+    const uploaded = await client.files("demo").upload("images/sample.bin", bytes, {
+      expectedVersion: null,
+      representation: "binary",
+      contentType: "application/octet-stream",
+    });
+    expect(uploaded.ok).toBe(true);
+
+    const downloaded = await client.files("demo").raw.get("images/sample.bin", {
+      range: "bytes=1-3",
+    });
+    expect(downloaded.ok).toBe(true);
+    if (!downloaded.ok || "notModified" in downloaded) return;
+    expect([...(await downloaded.value.bytes(3))]).toEqual([0x50, 0x00, 0xff]);
+
+    const metadata = await client.files("demo").get("images/sample.bin");
+    expect(metadata).toMatchObject({
+      ok: true,
+      value: { representation: "binary", contentAccess: "raw", body: null, byteSize: 6 },
+    });
+
+    await expect(
+      client.files("demo").delete("images/sample.bin", { expectedVersion: 1 }),
+    ).resolves.toMatchObject({ ok: true, value: { version: 2 } });
+    await expect(client.files("demo").raw.get("images/sample.bin")).resolves.toMatchObject({
+      ok: false,
+      error: { code: "file-deleted" },
+    });
+    const historical = await client.files("demo").raw.get("images/sample.bin", { version: 1 });
+    expect(historical.ok).toBe(true);
+    if (historical.ok && !("notModified" in historical)) {
+      await expect(historical.value.bytes(6)).resolves.toEqual(bytes);
+    }
+    await expect(
+      client.files("demo").rollback("images/sample.bin", {
+        expectedVersion: 2,
+        toVersion: 1,
+      }),
+    ).resolves.toMatchObject({ ok: true, value: { representation: "binary", rollbackOf: 1 } });
+    await expect(client.files("demo").get("images/sample.bin")).resolves.toMatchObject({
+      ok: true,
+      value: { representation: "binary", contentAccess: "raw", body: null },
+    });
+  });
+
+  it("keeps oversized valid UTF-8 text as text while selecting raw transfer", async () => {
+    const { client } = fixture({ jsonInlineMaxBytes: 3, singleUploadMaxBytes: 16 });
+    await expect(
+      client.files("demo").upload("docs/large.txt", "hello", {
+        expectedVersion: null,
+        representation: "text",
+        contentType: "text/plain; charset=utf-8",
+      }),
+    ).resolves.toMatchObject({ ok: true, value: { representation: "text" } });
+    await expect(client.files("demo").get("docs/large.txt")).resolves.toMatchObject({
+      ok: true,
+      value: { representation: "text", contentAccess: "raw", body: null },
+    });
+  });
+
+  it("uploads only durable multipart parts and reports observed progress", async () => {
+    const { client } = fixture({ singleUploadMaxBytes: 2, multipartPartBytes: 2 });
+    const progress = vi.fn();
+    const result = await client
+      .files("demo")
+      .upload("archives/sample.zip", new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0xaa]), {
+        expectedVersion: null,
+        representation: "binary",
+        contentType: "application/zip",
+        onProgress: progress,
+      });
+    expect(result.ok).toBe(true);
+    expect(
+      progress.mock.calls.some(([value]) => value.phase === "part" && value.durableParts === 3),
+    ).toBe(true);
+    expect(progress).toHaveBeenLastCalledWith({
+      observedBytes: 5,
+      totalBytes: 5,
+      phase: "complete",
+    });
+
+    const oneShot = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.enqueue(new Uint8Array([4, 5]));
+        controller.close();
+      },
+    });
+    await expect(
+      client.files("demo").upload("streams/large.bin", oneShot, {
+        expectedVersion: null,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        size: 5,
+      }),
+    ).resolves.toMatchObject({ ok: true, value: { size: 5 } });
+  });
+
+  it("retries a replayable source with stable operation keys", async () => {
+    const fake = createFakeStash({
+      adminToken: "admin",
+      capabilities: capabilities({ singleUploadMaxBytes: 16 }),
+    });
+    fake.createStash("demo");
+    let contentRequests = 0;
+    const fetcher: typeof fetch = async (input, init) => {
+      if (new URL(String(input)).pathname.endsWith("/content") && contentRequests++ === 0) {
+        if (init?.body !== undefined) await new Response(init.body).arrayBuffer();
+        return Response.json(
+          { error: { code: "internal", message: "simulated" } },
+          { status: 500 },
+        );
+      }
+      return fake.fetch(input, init);
+    };
+    const client = createStashClient({
+      baseUrl: "https://fake.invalid",
+      token: "admin",
+      fetch: fetcher,
+    });
+    await expect(
+      client.files("demo").upload("replayed.bin", new Blob([new Uint8Array([1, 2, 3])]), {
+        expectedVersion: null,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        retries: 1,
+      }),
+    ).resolves.toMatchObject({ ok: true, value: { size: 3 } });
+    expect(contentRequests).toBe(2);
+    expect(fake.state.versions).toHaveLength(1);
+  });
+
+  it("selects a synthetic 1 GiB source as multipart without allocating it", () => {
+    expect(
+      selectUploadMode(
+        { size: 1_073_741_824, replayable: true, text: false },
+        capabilities({ maxFileBytes: 1_073_741_824, singleUploadMaxBytes: 32_000_000 }),
+        { representation: "binary" },
+      ),
+    ).toBe("multipart");
+  });
+
+  it("requires exact stream size and never replays a consumed one-shot stream", async () => {
+    const fake = createFakeStash({
+      adminToken: "admin",
+      capabilities: capabilities({ singleUploadMaxBytes: 16 }),
+    });
+    fake.createStash("demo");
+    let contentRequests = 0;
+    const fetcher: typeof fetch = async (input, init) => {
+      if (new URL(String(input)).pathname.endsWith("/content")) {
+        contentRequests += 1;
+        if (init?.body !== undefined) await new Response(init.body).arrayBuffer();
+        return Response.json(
+          { error: { code: "internal", message: "simulated" } },
+          { status: 500 },
+        );
+      }
+      return fake.fetch(input, init);
+    };
+    const client = createStashClient({
+      baseUrl: "https://fake.invalid",
+      token: "admin",
+      fetch: fetcher,
+    });
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    });
+    await expect(
+      client.files("demo").upload("missing-size.bin", stream, {
+        expectedVersion: null,
+        representation: "binary",
+        contentType: "application/octet-stream",
+      }),
+    ).rejects.toThrow("requires an exact non-negative size");
+    await expect(
+      client.files("demo").upload("one-shot.bin", stream, {
+        expectedVersion: null,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        size: 3,
+        retries: 3,
+      }),
+    ).rejects.toMatchObject({ status: 500 });
+    expect(contentRequests).toBe(1);
+  });
+});

--- a/packages/client/src/binary.ts
+++ b/packages/client/src/binary.ts
@@ -1,4 +1,4 @@
-import { IDEMPOTENCY_KEY_MAX_CHARS } from "@takazudo/zudo-history-stash-core";
+import { IDEMPOTENCY_KEY_MAX_CHARS, sha256Hex } from "@takazudo/zudo-history-stash-core";
 import type {
   AbortUploadResult,
   CapabilitiesResponse,
@@ -10,6 +10,7 @@ import type {
   UploadMode,
   UploadPartRecord,
   UploadSessionRecord,
+  PutResult,
 } from "@takazudo/zudo-history-stash-core";
 import { parseClientResponse, StashHttpError } from "./parse.js";
 import type { ClientResult, NotModifiedResult } from "./client.js";
@@ -205,7 +206,7 @@ export function selectUploadMode(
   if (selected === "json" && !eligibleJson) {
     throw new TypeError("JSON upload requires replayable UTF-8 text within jsonInlineMaxBytes");
   }
-  if (selected === "single" && options.resumable) {
+  if (options.resumable && selected !== "multipart") {
     throw new TypeError("A resumable upload must use multipart mode");
   }
   if (selected === "single" && source.size > capabilities.limits.singleUploadMaxBytes) {
@@ -561,7 +562,7 @@ export async function upload(
   sourceValue: UploadSource,
   options: UploadOptions,
   capabilities: CapabilitiesResponse,
-  putJson: (body: string, idempotencyKey: string) => Promise<ClientResult<CompleteUploadResult>>,
+  putJson: (body: string, idempotencyKey: string) => Promise<ClientResult<PutResult>>,
 ): Promise<ClientResult<CompleteUploadResult>> {
   const source = normalizeSource(sourceValue, options.size);
   const text =
@@ -575,7 +576,28 @@ export async function upload(
   );
   const retries = Math.max(0, options.retries ?? 0);
   const key = await context.mintKey(options.idempotencyKey);
-  if (mode === "json") return putJson(text!, key);
+  if (mode === "json") {
+    const result = await putJson(text!, key);
+    if (!result.ok) return result;
+    const hash = await sha256Hex(text!);
+    return {
+      ...result,
+      value:
+        "unchanged" in result.value
+          ? {
+              ...result.value,
+              hash,
+              size: source.size,
+              representation: "text",
+              contentType: options.contentType,
+            }
+          : {
+              ...result.value,
+              representation: "text",
+              contentType: options.contentType,
+            },
+    };
+  }
 
   const sessions = createUploadSessionsClient(context, stash);
   const created = await attempt(async () => {

--- a/packages/client/src/binary.ts
+++ b/packages/client/src/binary.ts
@@ -1,0 +1,691 @@
+import { IDEMPOTENCY_KEY_MAX_CHARS } from "@takazudo/zudo-history-stash-core";
+import type {
+  AbortUploadResult,
+  CapabilitiesResponse,
+  CompleteUploadResult,
+  CreateUploadSessionInput,
+  GetUploadSessionResult,
+  Representation,
+  RouteId,
+  UploadMode,
+  UploadPartRecord,
+  UploadSessionRecord,
+} from "@takazudo/zudo-history-stash-core";
+import { parseClientResponse, StashHttpError } from "./parse.js";
+import type { ClientResult, NotModifiedResult } from "./client.js";
+import type { Send } from "./transport.js";
+
+export type ByteSource = Blob | ArrayBuffer | ArrayBufferView | ReadableStream<Uint8Array>;
+export type UploadSource = string | ByteSource;
+export type UploadTransferMode = "auto" | "json" | UploadMode;
+
+export interface UploadProgress {
+  /** Bytes read from the caller-owned source, not bytes acknowledged by the network. */
+  observedBytes: number;
+  totalBytes: number;
+  partNumber?: number;
+  durableParts?: number;
+  phase: "source" | "part" | "complete";
+}
+
+export interface UploadOptions {
+  expectedVersion: number | null;
+  representation: Representation;
+  contentType: string;
+  /** Required for a one-shot ReadableStream. */
+  size?: number;
+  sha256?: string;
+  mode?: UploadTransferMode;
+  resumable?: boolean;
+  skipIfUnchanged?: boolean;
+  idempotencyKey?: string;
+  retries?: number;
+  signal?: AbortSignal;
+  onProgress?: (progress: UploadProgress) => void;
+}
+
+export interface RawDownloadOptions {
+  version?: number;
+  range?: string;
+  ifRange?: string;
+  ifNoneMatch?: string;
+  signal?: AbortSignal;
+}
+
+export interface RawDownload {
+  response: Response;
+  body: ReadableStream<Uint8Array> | null;
+  version: number;
+  etag: string;
+  contentType: string;
+  size: number;
+  contentRange: string | null;
+  bytes(maxBytes: number): Promise<Uint8Array>;
+  text(maxBytes: number, encoding?: string): Promise<string>;
+}
+
+export type RawDownloadResult = ClientResult<RawDownload> | NotModifiedResult;
+
+export interface UploadSessionCreateOptions extends CreateUploadSessionInput {
+  idempotencyKey?: string;
+  signal?: AbortSignal;
+}
+
+export interface UploadPartOptions {
+  generation: number;
+  size: number;
+  idempotencyKey?: string;
+  signal?: AbortSignal;
+  onProgress?: (progress: UploadProgress) => void;
+}
+
+export interface StashUploadSessionsClient {
+  create(
+    path: string,
+    input: UploadSessionCreateOptions,
+  ): Promise<ClientResult<UploadSessionRecord>>;
+  status(sessionId: string, signal?: AbortSignal): Promise<ClientResult<GetUploadSessionResult>>;
+  uploadSingle(
+    sessionId: string,
+    source: ByteSource,
+    options: UploadPartOptions,
+  ): Promise<ClientResult<UploadSessionRecord>>;
+  uploadPart(
+    sessionId: string,
+    partNumber: number,
+    source: ByteSource,
+    options: UploadPartOptions,
+  ): Promise<ClientResult<GetUploadSessionResult>>;
+  complete(
+    sessionId: string,
+    generation: number,
+    options?: { idempotencyKey?: string; signal?: AbortSignal },
+  ): Promise<ClientResult<CompleteUploadResult>>;
+  resume(
+    sessionId: string,
+    generation: number,
+    options?: { idempotencyKey?: string; signal?: AbortSignal },
+  ): Promise<ClientResult<UploadSessionRecord>>;
+  abort(
+    sessionId: string,
+    generation: number,
+    options?: { idempotencyKey?: string; signal?: AbortSignal },
+  ): Promise<ClientResult<AbortUploadResult>>;
+}
+
+export interface BinaryClientContext {
+  send: Send;
+  authorizationToken?: string;
+  clientId?: string;
+  mintKey(supplied?: string): Promise<string>;
+}
+
+interface NormalizedSource {
+  size: number;
+  replayable: boolean;
+  text?: string;
+  stream(start?: number, end?: number): ReadableStream<Uint8Array>;
+}
+
+function byteStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+function normalizeSource(source: UploadSource, declaredSize?: number): NormalizedSource {
+  if (typeof source === "string") {
+    const bytes = new TextEncoder().encode(source);
+    return {
+      size: bytes.byteLength,
+      replayable: true,
+      text: source,
+      stream: (start = 0, end = bytes.byteLength) => byteStream(bytes.slice(start, end)),
+    };
+  }
+  if (source instanceof Blob) {
+    return {
+      size: source.size,
+      replayable: true,
+      stream: (start = 0, end = source.size) => source.slice(start, end).stream(),
+    };
+  }
+  if (source instanceof ArrayBuffer || ArrayBuffer.isView(source)) {
+    const bytes =
+      source instanceof ArrayBuffer
+        ? new Uint8Array(source)
+        : new Uint8Array(source.buffer, source.byteOffset, source.byteLength);
+    return {
+      size: bytes.byteLength,
+      replayable: true,
+      stream: (start = 0, end = bytes.byteLength) => byteStream(bytes.slice(start, end)),
+    };
+  }
+  if (source instanceof ReadableStream) {
+    if (!Number.isSafeInteger(declaredSize) || (declaredSize ?? -1) < 0) {
+      throw new TypeError("A one-shot ReadableStream upload requires an exact non-negative size");
+    }
+    let claimed = false;
+    return {
+      size: declaredSize!,
+      replayable: false,
+      stream() {
+        if (claimed) throw new TypeError("The one-shot upload stream has already been consumed");
+        claimed = true;
+        return source;
+      },
+    };
+  }
+  throw new TypeError("Unsupported upload source");
+}
+
+export function selectUploadMode(
+  source: { size: number; replayable: boolean; text: boolean },
+  capabilities: CapabilitiesResponse,
+  options: Pick<UploadOptions, "representation" | "mode" | "resumable">,
+): Exclude<UploadTransferMode, "auto"> {
+  const requested = options.mode ?? "auto";
+  const eligibleJson =
+    options.representation === "text" &&
+    source.replayable &&
+    source.text &&
+    source.size <= capabilities.limits.jsonInlineMaxBytes;
+  const automatic = eligibleJson
+    ? "json"
+    : !options.resumable && source.size <= capabilities.limits.singleUploadMaxBytes
+      ? "single"
+      : "multipart";
+  const selected = requested === "auto" ? automatic : requested;
+  if (!capabilities.transferModes.includes(selected)) {
+    throw new TypeError(`Upload mode ${selected} is not supported by the server`);
+  }
+  if (selected === "json" && !eligibleJson) {
+    throw new TypeError("JSON upload requires replayable UTF-8 text within jsonInlineMaxBytes");
+  }
+  if (selected === "single" && options.resumable) {
+    throw new TypeError("A resumable upload must use multipart mode");
+  }
+  if (selected === "single" && source.size > capabilities.limits.singleUploadMaxBytes) {
+    throw new TypeError("The source exceeds the server single-upload limit");
+  }
+  if (source.size > capabilities.limits.maxFileBytes) {
+    throw new TypeError("The source exceeds the server maximum file size");
+  }
+  return selected;
+}
+
+function headers(context: BinaryClientContext, extra: HeadersInit = {}): Record<string, string> {
+  const value: Record<string, string> = {};
+  new Headers(extra).forEach((headerValue, name) => {
+    value[name] = headerValue;
+  });
+  if (context.authorizationToken !== undefined)
+    value.authorization = `Bearer ${context.authorizationToken}`;
+  if (context.clientId !== undefined) value["x-stash-client-id"] = context.clientId;
+  return value;
+}
+
+async function jsonResult<T>(response: Response, routeId: RouteId): Promise<ClientResult<T>> {
+  return (await parseClientResponse<T>(response, routeId)) as ClientResult<T>;
+}
+
+async function sendJson<T>(
+  context: BinaryClientContext,
+  routeId: RouteId,
+  method: "POST" | "DELETE",
+  path: string,
+  body: unknown,
+  options: { idempotencyKey?: string; signal?: AbortSignal } = {},
+): Promise<ClientResult<T>> {
+  const key = await context.mintKey(options.idempotencyKey);
+  try {
+    return await jsonResult<T>(
+      await context.send(
+        method,
+        path,
+        undefined,
+        headers(context, { "Content-Type": "application/json", "Idempotency-Key": key }),
+        JSON.stringify(body),
+        options.signal,
+      ),
+      routeId,
+    );
+  } catch (error) {
+    if (error instanceof StashHttpError) throw error;
+    throw new StashHttpError(0, undefined, undefined, error);
+  }
+}
+
+function subkey(root: string, label: string): string {
+  const suffix = `:${label}`;
+  return `${root.slice(0, IDEMPOTENCY_KEY_MAX_CHARS - suffix.length)}${suffix}`;
+}
+
+function sessionPath(stash: string, sessionId?: string): string {
+  return `/v1/stashes/${stash}/uploads${sessionId === undefined ? "" : `/${sessionId}`}`;
+}
+
+function observedStream(
+  stream: ReadableStream<Uint8Array>,
+  total: number,
+  callback: UploadOptions["onProgress"],
+  partNumber?: number,
+): ReadableStream<Uint8Array> {
+  if (callback === undefined) return stream;
+  let observed = 0;
+  return stream.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        observed += chunk.byteLength;
+        callback({ observedBytes: observed, totalBytes: total, partNumber, phase: "source" });
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+}
+
+async function materialize(response: Response, maxBytes: number): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0)
+    throw new TypeError("maxBytes must be non-negative");
+  const body = response.body;
+  if (body === null) return new Uint8Array();
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      size += next.value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel("materialization limit exceeded");
+        throw new RangeError(`Download exceeds the ${maxBytes} byte materialization limit`);
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function downloadValue(response: Response): RawDownload {
+  const version = Number(response.headers.get("X-Stash-Version"));
+  const size = Number(response.headers.get("Content-Length"));
+  const etag = response.headers.get("ETag") ?? "";
+  const contentType = response.headers.get("Content-Type") ?? "application/octet-stream";
+  const cloneFor = () => response.clone();
+  return {
+    response,
+    body: response.body,
+    version,
+    etag,
+    contentType,
+    size,
+    contentRange: response.headers.get("Content-Range"),
+    bytes: (maxBytes) => materialize(cloneFor(), maxBytes),
+    async text(maxBytes, encoding = "utf-8") {
+      return new TextDecoder(encoding, { fatal: true }).decode(
+        await materialize(cloneFor(), maxBytes),
+      );
+    },
+  };
+}
+
+export async function getRaw(
+  context: BinaryClientContext,
+  stash: string,
+  path: string,
+  options: RawDownloadOptions = {},
+  head = false,
+): Promise<RawDownloadResult> {
+  const historical = options.version !== undefined;
+  const requestPath = historical
+    ? `/v1/stashes/${stash}/versions/${options.version}/raw/${path}`
+    : `/v1/stashes/${stash}/raw/${path}`;
+  const routeId: RouteId = historical
+    ? head
+      ? "headRawVersion"
+      : "getRawVersion"
+    : head
+      ? "headRawFile"
+      : "getRawFile";
+  let response: Response;
+  try {
+    response = await context.send(
+      head ? "HEAD" : "GET",
+      requestPath,
+      undefined,
+      headers(context, {
+        ...(options.range === undefined ? {} : { Range: options.range }),
+        ...(options.ifRange === undefined ? {} : { "If-Range": options.ifRange }),
+        ...(options.ifNoneMatch === undefined ? {} : { "If-None-Match": options.ifNoneMatch }),
+      }),
+      undefined,
+      options.signal,
+    );
+  } catch (error) {
+    throw new StashHttpError(0, undefined, undefined, error);
+  }
+  if (response.status === 304) return { ok: true, notModified: true };
+  if (!response.ok) return await jsonResult(response, routeId);
+  return { ok: true, value: downloadValue(response) };
+}
+
+export function createUploadSessionsClient(
+  context: BinaryClientContext,
+  stash: string,
+): StashUploadSessionsClient {
+  const uploadBytes = async <T>(
+    routeId: RouteId,
+    path: string,
+    source: ByteSource,
+    options: UploadPartOptions,
+    query?: Record<string, string>,
+  ): Promise<ClientResult<T>> => {
+    const normalized = normalizeSource(source, options.size);
+    if (normalized.size !== options.size)
+      throw new TypeError("Upload part size does not match its declaration");
+    const key = await context.mintKey(options.idempotencyKey);
+    try {
+      const response = await context.send(
+        "PUT",
+        path,
+        query,
+        headers(context, {
+          "Content-Type": "application/octet-stream",
+          "Content-Length": String(options.size),
+          "Idempotency-Key": key,
+        }),
+        observedStream(normalized.stream(), options.size, options.onProgress),
+        options.signal,
+      );
+      return await jsonResult<T>(response, routeId);
+    } catch (error) {
+      if (error instanceof StashHttpError) throw error;
+      throw new StashHttpError(0, undefined, undefined, error);
+    }
+  };
+
+  return {
+    create(path, input) {
+      const { idempotencyKey, signal, ...body } = input;
+      return sendJson(
+        context,
+        "createUploadSession",
+        "POST",
+        `${sessionPath(stash)}/${path}`,
+        body,
+        {
+          idempotencyKey,
+          signal,
+        },
+      );
+    },
+    async status(sessionId, signal) {
+      const response = await context.send(
+        "GET",
+        sessionPath(stash, sessionId),
+        undefined,
+        headers(context),
+        undefined,
+        signal,
+      );
+      return await jsonResult<GetUploadSessionResult>(response, "getUploadSession");
+    },
+    uploadSingle(sessionId, source, options) {
+      return uploadBytes(
+        "uploadSingleContent",
+        `${sessionPath(stash, sessionId)}/content`,
+        source,
+        options,
+      );
+    },
+    uploadPart(sessionId, partNumber, source, options) {
+      return uploadBytes(
+        "uploadPart",
+        `${sessionPath(stash, sessionId)}/parts/${partNumber}`,
+        source,
+        options,
+        { generation: String(options.generation) },
+      );
+    },
+    complete(sessionId, generation, options) {
+      return sendJson(
+        context,
+        "completeUploadSession",
+        "POST",
+        `${sessionPath(stash, sessionId)}/complete`,
+        { generation },
+        options,
+      );
+    },
+    resume(sessionId, generation, options) {
+      return sendJson(
+        context,
+        "resumeUploadSession",
+        "POST",
+        `${sessionPath(stash, sessionId)}/resume`,
+        { generation },
+        options,
+      );
+    },
+    abort(sessionId, generation, options) {
+      return sendJson(
+        context,
+        "abortUploadSession",
+        "DELETE",
+        sessionPath(stash, sessionId),
+        { generation },
+        options,
+      );
+    },
+  };
+}
+
+async function sourceText(source: NormalizedSource, limit: number): Promise<string | undefined> {
+  if (source.text !== undefined) return source.text;
+  if (!source.replayable || source.size > limit) return undefined;
+  const response = new Response(source.stream());
+  const bytes = await materialize(response, limit);
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+async function attempt<T>(run: () => Promise<T>, retries: number): Promise<T> {
+  let remaining = retries;
+  for (;;) {
+    try {
+      return await run();
+    } catch (error) {
+      if (remaining-- <= 0) throw error;
+    }
+  }
+}
+
+async function* splitOneShot(
+  stream: ReadableStream<Uint8Array>,
+  totalSize: number,
+  partSize: number,
+): AsyncGenerator<Uint8Array> {
+  const reader = stream.getReader();
+  let part = new Uint8Array(Math.min(partSize, totalSize));
+  let partOffset = 0;
+  let observed = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      let chunkOffset = 0;
+      observed += next.value.byteLength;
+      if (observed > totalSize) throw new TypeError("The upload stream exceeds its declared size");
+      while (chunkOffset < next.value.byteLength) {
+        const copied = Math.min(part.byteLength - partOffset, next.value.byteLength - chunkOffset);
+        part.set(next.value.subarray(chunkOffset, chunkOffset + copied), partOffset);
+        partOffset += copied;
+        chunkOffset += copied;
+        if (partOffset === part.byteLength) {
+          yield part;
+          const remaining = totalSize - (observed - (next.value.byteLength - chunkOffset));
+          part = new Uint8Array(Math.min(partSize, Math.max(remaining, 0)));
+          partOffset = 0;
+        }
+      }
+    }
+    if (observed !== totalSize || partOffset !== 0) {
+      throw new TypeError("The upload stream ended before its declared size");
+    }
+  } finally {
+    if (observed < totalSize)
+      await reader.cancel("multipart upload stopped").catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
+export async function upload(
+  context: BinaryClientContext,
+  stash: string,
+  path: string,
+  sourceValue: UploadSource,
+  options: UploadOptions,
+  capabilities: CapabilitiesResponse,
+  putJson: (body: string, idempotencyKey: string) => Promise<ClientResult<CompleteUploadResult>>,
+): Promise<ClientResult<CompleteUploadResult>> {
+  const source = normalizeSource(sourceValue, options.size);
+  const text =
+    options.representation === "text"
+      ? await sourceText(source, capabilities.limits.jsonInlineMaxBytes)
+      : undefined;
+  const mode = selectUploadMode(
+    { size: source.size, replayable: source.replayable, text: text !== undefined },
+    capabilities,
+    options,
+  );
+  const retries = Math.max(0, options.retries ?? 0);
+  const key = await context.mintKey(options.idempotencyKey);
+  if (mode === "json") return putJson(text!, key);
+
+  const sessions = createUploadSessionsClient(context, stash);
+  const created = await attempt(async () => {
+    const value = await sessions.create(path, {
+      expectedVersion: options.expectedVersion,
+      size: source.size,
+      ...(options.sha256 === undefined ? {} : { hash: options.sha256 }),
+      representation: options.representation,
+      contentType: options.contentType,
+      mode,
+      resumable: options.resumable,
+      skipIfUnchanged: options.skipIfUnchanged,
+      idempotencyKey: subkey(key, "create"),
+      signal: options.signal,
+    });
+    if (!value.ok && value.error.status >= 500)
+      throw new StashHttpError(value.error.status, value.error.code, value);
+    return value;
+  }, retries);
+  if (!created.ok) return created;
+  const session = created.value;
+  const generation = session.attemptGeneration;
+  if (mode === "single") {
+    const result = await attempt(
+      async () => {
+        const value = await sessions.uploadSingle(session.id, source.stream(), {
+          generation,
+          size: source.size,
+          idempotencyKey: subkey(key, "content"),
+          signal: options.signal,
+          onProgress: options.onProgress,
+        });
+        if (!value.ok && value.error.status >= 500)
+          throw new StashHttpError(value.error.status, value.error.code, value);
+        return value;
+      },
+      source.replayable ? retries : 0,
+    );
+    if (!result.ok) return result;
+  } else {
+    const partSize = session.partSize;
+    if (partSize === null) throw new TypeError("The server did not return a multipart part size");
+    const totalParts = Math.ceil(source.size / partSize);
+    const oneShotParts = source.replayable
+      ? undefined
+      : splitOneShot(source.stream(), source.size, partSize);
+    try {
+      for (let partNumber = 1; partNumber <= totalParts; partNumber += 1) {
+        const start = (partNumber - 1) * partSize;
+        const end = Math.min(start + partSize, source.size);
+        const oneShotPart =
+          oneShotParts === undefined ? undefined : (await oneShotParts.next()).value;
+        if (!source.replayable && oneShotPart === undefined) {
+          throw new TypeError("The upload stream ended before its declared size");
+        }
+        const part = await attempt(
+          async () => {
+            const partSource = source.replayable ? source.stream(start, end) : oneShotPart!;
+            const value = await sessions.uploadPart(session.id, partNumber, partSource, {
+              generation,
+              size: end - start,
+              idempotencyKey: subkey(key, `p${generation}-${partNumber}`),
+              signal: options.signal,
+              onProgress:
+                options.onProgress === undefined
+                  ? undefined
+                  : (progress) =>
+                      options.onProgress?.({
+                        ...progress,
+                        observedBytes: start + progress.observedBytes,
+                        totalBytes: source.size,
+                        partNumber,
+                      }),
+            });
+            if (!value.ok && value.error.status >= 500)
+              throw new StashHttpError(value.error.status, value.error.code, value);
+            return value;
+          },
+          source.replayable ? retries : 0,
+        );
+        if (!part.ok) return part;
+        options.onProgress?.({
+          observedBytes: end,
+          totalBytes: source.size,
+          partNumber,
+          durableParts: part.value.parts.filter(
+            (entry: UploadPartRecord) => entry.generation === generation,
+          ).length,
+          phase: "part",
+        });
+      }
+    } finally {
+      await oneShotParts?.return(undefined);
+    }
+  }
+  const completed = await attempt(async () => {
+    const value = await sessions.complete(session.id, generation, {
+      idempotencyKey: subkey(key, "complete"),
+      signal: options.signal,
+    });
+    if (!value.ok && value.error.status >= 500)
+      throw new StashHttpError(value.error.status, value.error.code, value);
+    return value;
+  }, retries);
+  if (completed.ok) {
+    options.onProgress?.({
+      observedBytes: source.size,
+      totalBytes: source.size,
+      phase: "complete",
+    });
+  }
+  return completed;
+}

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -695,7 +695,7 @@ export function createStashClient(options: StashClientOptions): StashClient {
               contentType: uploadOptions.contentType,
             },
             idempotencyKey,
-          )) as ClientResult<CompleteUploadResult>,
+          )) as ClientResult<PutResult>,
       );
     },
     uploads: createUploadSessionsClient(binaryContext, stash),

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -12,7 +12,9 @@ import type {
   ApproveProposalBody,
   ApproveProposalResult,
   CandidateDiffResult,
+  CapabilitiesResponse,
   ChangesPage,
+  CompleteUploadResult,
   CreateProposalBody,
   CreateStashBody,
   CreateStashResult,
@@ -61,6 +63,17 @@ import type {
   RouteMethod,
   StashRecord,
 } from "@takazudo/zudo-history-stash-core";
+import {
+  createUploadSessionsClient,
+  getRaw,
+  upload,
+  type BinaryClientContext,
+  type RawDownloadOptions,
+  type RawDownloadResult,
+  type StashUploadSessionsClient,
+  type UploadOptions,
+  type UploadSource,
+} from "./binary.js";
 import type { StashRpcBinding } from "./rpc-types.js";
 import { createStashEventStream, type EventsOptions, type StashEventStream } from "./events.js";
 import { parseClientResponse, StashHttpError } from "./parse.js";
@@ -359,6 +372,16 @@ export interface StashFilesClient {
   diff(path: string, options: DiffOptions): Promise<ClientResult<GetDiffResult>>;
   diffCandidate(path: string, input: DiffCandidateBody): Promise<ClientResult<CandidateDiffResult>>;
   changes(options?: ChangesOptions): Promise<ClientResult<ListChangesResult>>;
+  raw: {
+    get(path: string, options?: RawDownloadOptions): Promise<RawDownloadResult>;
+    head(path: string, options?: RawDownloadOptions): Promise<RawDownloadResult>;
+  };
+  upload(
+    path: string,
+    source: UploadSource,
+    options: UploadOptions,
+  ): Promise<ClientResult<CompleteUploadResult>>;
+  uploads: StashUploadSessionsClient;
 }
 
 /** Proposal operations scoped to one stash. */
@@ -388,6 +411,7 @@ export interface StashAdminClient {
 /** The complete typed client returned by {@link createStashClient}. */
 export interface StashClient {
   health(): Promise<ClientResult<HealthResponse>>;
+  capabilities(): Promise<ClientResult<CapabilitiesResponse>>;
   me(): Promise<ClientResult<MeResponse>>;
   stashes: {
     list(options?: ListStashesOptions): Promise<ClientResult<ListStashesResult>>;
@@ -494,6 +518,13 @@ export function createStashClient(options: StashClientOptions): StashClient {
     const stashResult = stashError<T>(stash);
     if (stashResult !== undefined) return stashResult;
     return validateFilePath<T>(path);
+  };
+
+  const binaryContext: BinaryClientContext = {
+    send,
+    authorizationToken,
+    clientId,
+    mintKey: (supplied) => mintKey(keyFactory, supplied),
   };
 
   const getFileClient = (stash: string): StashFilesClient => ({
@@ -624,6 +655,50 @@ export function createStashClient(options: StashClientOptions): StashClient {
         ]),
       )) as ClientResult<ListChangesResult>;
     },
+    raw: {
+      async get(path, rawOptions = {}) {
+        const invalid = filePath<never>(stash, path);
+        if (invalid !== undefined) return invalid;
+        return getRaw(binaryContext, stash, path, rawOptions);
+      },
+      async head(path, rawOptions = {}) {
+        const invalid = filePath<never>(stash, path);
+        if (invalid !== undefined) return invalid;
+        return getRaw(binaryContext, stash, path, rawOptions, true);
+      },
+    },
+    async upload(path, source, uploadOptions) {
+      const invalid = filePath<never>(stash, path);
+      if (invalid !== undefined) return invalid;
+      const capabilities = (await call<CapabilitiesResponse>(
+        "getCapabilities",
+        "GET",
+        target(route("getCapabilities")),
+      )) as ClientResult<CapabilitiesResponse>;
+      if (!capabilities.ok) return capabilities;
+      return upload(
+        binaryContext,
+        stash,
+        path,
+        source,
+        uploadOptions,
+        capabilities.value,
+        async (body, idempotencyKey) =>
+          (await call(
+            "putFile",
+            "PUT",
+            target(route("putFile", stash, path)),
+            {
+              body,
+              expectedVersion: uploadOptions.expectedVersion,
+              skipIfUnchanged: uploadOptions.skipIfUnchanged,
+              contentType: uploadOptions.contentType,
+            },
+            idempotencyKey,
+          )) as ClientResult<CompleteUploadResult>,
+      );
+    },
+    uploads: createUploadSessionsClient(binaryContext, stash),
   });
 
   const getProposalClient = (stash: string): StashProposalsClient => ({
@@ -843,6 +918,13 @@ export function createStashClient(options: StashClientOptions): StashClient {
         "GET",
         target(route("health")),
       )) as ClientResult<HealthResponse>;
+    },
+    async capabilities() {
+      return (await call<CapabilitiesResponse>(
+        "getCapabilities",
+        "GET",
+        target(route("getCapabilities")),
+      )) as ClientResult<CapabilitiesResponse>;
     },
     async me() {
       return (await call<MeResponse>("me", "GET", target(route("me")))) as ClientResult<MeResponse>;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,7 @@
 export const VERSION = "0.0.0";
 
 export * from "./client.js";
+export * from "./binary.js";
 export type { EventsOptions, StashEventStream, StashLiveStatus } from "./events.js";
 export * from "./parse.js";
 export {

--- a/packages/client/src/rpc-types.ts
+++ b/packages/client/src/rpc-types.ts
@@ -59,6 +59,8 @@ export type ListStashesRpcOptions = ListStashesOptions;
 /** The minimal named RPC binding exposed by the stash Worker. */
 export interface StashRpcBinding {
   request(init: RpcRequest): Promise<Response>;
+  /** Optional flow-controlled bridge used for request/response byte streams. */
+  requestStream?(request: Request, token: string): Promise<Response>;
 }
 
 /**

--- a/packages/client/src/testing/conformance.ts
+++ b/packages/client/src/testing/conformance.ts
@@ -1,6 +1,6 @@
 import { DIFF_MAX_BYTES, canonicalJson } from "@takazudo/zudo-history-stash-core";
 import type { JsonValue, RouteId } from "@takazudo/zudo-history-stash-core";
-import type { StashFetch } from "../client.js";
+import type { StashFetch } from "../transport.js";
 import { parseStashEventStream } from "../sse.js";
 import type { ConformanceOptions, ConformanceRateLimitTarget, ConformanceReport } from "./types.js";
 
@@ -33,6 +33,18 @@ export const CONFORMANCE_SUPPORTED_ROUTE_IDS = [
   "approveProposal",
   "rejectProposal",
   "stashEvents",
+  "getCapabilities",
+  "getRawFile",
+  "headRawFile",
+  "getRawVersion",
+  "headRawVersion",
+  "createUploadSession",
+  "getUploadSession",
+  "uploadSingleContent",
+  "uploadPart",
+  "completeUploadSession",
+  "resumeUploadSession",
+  "abortUploadSession",
 ] as const satisfies readonly RouteId[];
 
 type TraceToken =
@@ -43,6 +55,7 @@ interface TraceRequest {
   path: string;
   token?: TraceToken;
   body?: unknown;
+  rawBody?: Uint8Array;
   headers?: Record<string, string>;
 }
 
@@ -2014,6 +2027,251 @@ const TRACE: readonly TraceStep[] = [
       for (const run of runs) assertSubset(step, run, { jobId: "ledger", kind: "ledger" });
     },
   },
+  {
+    name: "binary capabilities expose configured transfer limits",
+    routeId: "getCapabilities",
+    request: () => ({ method: "GET", path: "/v1/capabilities", token: "none" }),
+    verify(response, body, context) {
+      const step = "binary capabilities expose configured transfer limits";
+      assertStatus(step, response, 200);
+      const value = record(body, step);
+      const limits = record(value.limits, step);
+      if (
+        typeof limits.singleUploadMaxBytes !== "number" ||
+        typeof limits.multipartPartBytes !== "number"
+      ) {
+        traceFailure(step, "capability limits are missing");
+      }
+      remember(context, "multipartPartBytes", limits.multipartPartBytes);
+    },
+  },
+  {
+    name: "single binary session is metadata-only",
+    routeId: "createUploadSession",
+    request: (context) => ({
+      method: "POST",
+      path: `/v1/stashes/${context.stash}/uploads/binary/conformance.bin`,
+      headers: { "Idempotency-Key": "conformance-binary-create" },
+      body: {
+        expectedVersion: null,
+        size: 6,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        mode: "single",
+      },
+    }),
+    verify(response, body, context) {
+      const step = "single binary session is metadata-only";
+      assertStatus(step, response, 201);
+      const value = record(body, step);
+      assertSubset(step, value, {
+        state: "open",
+        declaredSize: 6,
+        representation: "binary",
+        mode: "single",
+      });
+      remember(context, "binarySession", value.id);
+      remember(context, "binaryGeneration", value.attemptGeneration);
+    },
+  },
+  {
+    name: "single upload preserves arbitrary invalid UTF-8 bytes",
+    routeId: "uploadSingleContent",
+    request: (context) => ({
+      method: "PUT",
+      path: `/v1/stashes/${context.stash}/uploads/${String(context.values.get("binarySession"))}/content`,
+      headers: { "Idempotency-Key": "conformance-binary-content" },
+      rawBody: new Uint8Array([0x89, 0x50, 0x00, 0xff, 0x0d, 0x0a]),
+    }),
+    verify(response, body) {
+      assertStatus("single upload preserves arbitrary invalid UTF-8 bytes", response, 202);
+      assertSubset("single upload preserves arbitrary invalid UTF-8 bytes", body, {
+        state: "uploaded",
+        uploadedSize: 6,
+      });
+    },
+  },
+  {
+    name: "single completion commits exactly one binary version",
+    routeId: "completeUploadSession",
+    request: (context) => ({
+      method: "POST",
+      path: `/v1/stashes/${context.stash}/uploads/${String(context.values.get("binarySession"))}/complete`,
+      headers: { "Idempotency-Key": "conformance-binary-complete" },
+      body: { generation: context.values.get("binaryGeneration") },
+    }),
+    verify(response, body, context) {
+      const step = "single completion commits exactly one binary version";
+      assertStatus(step, response, 201);
+      const value = record(body, step);
+      assertSubset(step, value, {
+        size: 6,
+        representation: "binary",
+        contentType: "application/octet-stream",
+      });
+      remember(context, "binaryVersion", value.version);
+    },
+  },
+  {
+    name: "committed upload status remains inspectable",
+    routeId: "getUploadSession",
+    request: (context) => ({
+      method: "GET",
+      path: `/v1/stashes/${context.stash}/uploads/${String(context.values.get("binarySession"))}`,
+    }),
+    verify(response, body) {
+      assertStatus("committed upload status remains inspectable", response, 200);
+      assertSubset("committed upload status remains inspectable", body, {
+        state: "committed",
+        declaredSize: 6,
+      });
+    },
+  },
+  {
+    name: "completion resume is idempotent",
+    routeId: "resumeUploadSession",
+    request: (context) => ({
+      method: "POST",
+      path: `/v1/stashes/${context.stash}/uploads/${String(context.values.get("binarySession"))}/resume`,
+      headers: { "Idempotency-Key": "conformance-binary-complete" },
+      body: { generation: context.values.get("binaryGeneration") },
+    }),
+    verify(response, body) {
+      assertStatus("completion resume is idempotent", response, 200);
+      assertSubset("completion resume is idempotent", body, { state: "committed" });
+    },
+  },
+  {
+    name: "raw current download streams exact bytes",
+    routeId: "getRawFile",
+    request: (context) => ({
+      method: "GET",
+      path: `/v1/stashes/${context.stash}/raw/binary/conformance.bin`,
+    }),
+    streaming: true,
+    async verify(response) {
+      const step = "raw current download streams exact bytes";
+      assertStatus(step, response, 200);
+      assertEqual(
+        step,
+        JSON.stringify([...new Uint8Array(await response.arrayBuffer())]),
+        JSON.stringify([0x89, 0x50, 0x00, 0xff, 0x0d, 0x0a]),
+        "raw bytes",
+      );
+    },
+  },
+  {
+    name: "raw HEAD exposes exact current metadata",
+    routeId: "headRawFile",
+    request: (context) => ({
+      method: "HEAD",
+      path: `/v1/stashes/${context.stash}/raw/binary/conformance.bin`,
+    }),
+    verify(response) {
+      assertStatus("raw HEAD exposes exact current metadata", response, 200);
+      assertEqual(
+        "raw HEAD exposes exact current metadata",
+        response.headers.get("Content-Length"),
+        "6",
+        "content length",
+      );
+    },
+  },
+  {
+    name: "historical raw range is byte exact",
+    routeId: "getRawVersion",
+    request: (context) => ({
+      method: "GET",
+      path: `/v1/stashes/${context.stash}/versions/${String(context.values.get("binaryVersion"))}/raw/binary/conformance.bin`,
+      headers: { Range: "bytes=1-3" },
+    }),
+    streaming: true,
+    async verify(response) {
+      assertStatus("historical raw range is byte exact", response, 206);
+      assertEqual(
+        "historical raw range is byte exact",
+        JSON.stringify([...new Uint8Array(await response.arrayBuffer())]),
+        JSON.stringify([0x50, 0x00, 0xff]),
+        "range bytes",
+      );
+    },
+  },
+  {
+    name: "historical raw HEAD exposes version metadata",
+    routeId: "headRawVersion",
+    request: (context) => ({
+      method: "HEAD",
+      path: `/v1/stashes/${context.stash}/versions/${String(context.values.get("binaryVersion"))}/raw/binary/conformance.bin`,
+    }),
+    verify(response, _body, context) {
+      assertStatus("historical raw HEAD exposes version metadata", response, 200);
+      assertEqual(
+        "historical raw HEAD exposes version metadata",
+        response.headers.get("X-Stash-Version"),
+        String(context.values.get("binaryVersion")),
+        "version header",
+      );
+    },
+  },
+  {
+    name: "multipart session accepts durable replacement parts",
+    routeId: "createUploadSession",
+    request: (context) => ({
+      method: "POST",
+      path: `/v1/stashes/${context.stash}/uploads/binary/aborted.bin`,
+      headers: { "Idempotency-Key": "conformance-multipart-create" },
+      body: {
+        expectedVersion: null,
+        size: 4,
+        representation: "binary",
+        contentType: "application/zip",
+        mode: "multipart",
+        resumable: true,
+      },
+    }),
+    verify(response, body, context) {
+      assertStatus("multipart session accepts durable replacement parts", response, 201);
+      const value = record(body, "multipart session accepts durable replacement parts");
+      remember(context, "multipartSession", value.id);
+      remember(context, "multipartGeneration", value.attemptGeneration);
+    },
+  },
+  {
+    name: "multipart part upload reports durable part state",
+    routeId: "uploadPart",
+    request: (context) => ({
+      method: "PUT",
+      path: `/v1/stashes/${context.stash}/uploads/${String(context.values.get("multipartSession"))}/parts/1?generation=${String(context.values.get("multipartGeneration"))}`,
+      rawBody: new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+    }),
+    verify(response, body) {
+      assertStatus("multipart part upload reports durable part state", response, 202);
+      const parts = array(
+        record(body, "multipart multipart part").parts,
+        "multipart multipart part",
+      );
+      assertEqual(
+        "multipart part upload reports durable part state",
+        parts.length,
+        1,
+        "durable part count",
+      );
+    },
+  },
+  {
+    name: "multipart session can be durably aborted",
+    routeId: "abortUploadSession",
+    request: (context) => ({
+      method: "DELETE",
+      path: `/v1/stashes/${context.stash}/uploads/${String(context.values.get("multipartSession"))}`,
+      headers: { "Idempotency-Key": "conformance-multipart-abort" },
+      body: { generation: context.values.get("multipartGeneration") },
+    }),
+    verify(response, body) {
+      assertStatus("multipart session can be durably aborted", response, 200);
+      assertSubset("multipart session can be durably aborted", body, { state: "aborted" });
+    },
+  },
 ];
 
 /** Stable, serializable trace metadata for coverage and documentation checks. */
@@ -2086,10 +2344,18 @@ async function send(context: TraceContext, request: TraceRequest, step: string):
   const token = tokenFor(context, request.token, step);
   if (token !== undefined) headers.set("Authorization", `Bearer ${token}`);
   if (request.body !== undefined) headers.set("Content-Type", "application/json");
+  if (request.rawBody !== undefined) {
+    headers.set("Content-Type", "application/octet-stream");
+    headers.set("Content-Length", String(request.rawBody.byteLength));
+  }
   return context.fetch(`${context.baseUrl}${request.path}`, {
     method: request.method,
     headers,
-    ...(request.body === undefined ? {} : { body: JSON.stringify(request.body) }),
+    ...(request.rawBody !== undefined
+      ? { body: request.rawBody.slice().buffer }
+      : request.body === undefined
+        ? {}
+        : { body: JSON.stringify(request.body) }),
   });
 }
 

--- a/packages/client/src/testing/fake.ts
+++ b/packages/client/src/testing/fake.ts
@@ -1102,6 +1102,14 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         hash: version.hash,
         rollbackOf: version.rollbackOf,
         identicalToHead: previous.hash === version.hash,
+        ...(version.representation === undefined
+          ? {}
+          : {
+              representation: version.representation,
+              contentType: version.contentType,
+              byteSize: version.size,
+              etag: version.hash,
+            }),
       };
     } else {
       if (version.hash === null) return fail("internal", "The fake put ledger row is invalid.");
@@ -2279,7 +2287,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     id: row.id,
     stash: row.stash,
     path: row.path,
-    principal: { kind: "admin" as const },
+    principal: row.principal,
     state: row.state,
     expectedVersion: row.expectedVersion,
     declaredSize: row.declaredSize,
@@ -2292,15 +2300,20 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     expiresAt: iso(row.expiresAt),
     attemptGeneration: row.attemptGeneration,
     uploadedSize: row.uploadedBytes?.byteLength ?? null,
-    uploadedHash: null,
+    uploadedHash: row.uploadedHash,
     finalizationLeaseOwner: null,
     finalizationLeaseExpiresAt: null,
     result: row.result,
   });
 
-  const requireUpload = (stash: string, id: string): FakeUploadSessionRow => {
+  const requireUpload = (stash: string, id: string, principal: Principal): FakeUploadSessionRow => {
     const row = state.uploadSessions.get(id);
-    if (row === undefined || row.stash !== stash)
+    const owned =
+      row !== undefined &&
+      (row.principal.kind === "admin"
+        ? principal.kind === "admin"
+        : principal.kind === "stash" && row.principal.tokenId === principal.tokenId);
+    if (row === undefined || row.stash !== stash || !owned)
       return fail("not-found", "Upload session not found.");
     if (row.state === "open" && row.expiresAt <= now()) row.state = "expired";
     return row;
@@ -2320,6 +2333,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     request: Request,
     stash: string,
     path: string,
+    principal: Principal,
   ): Promise<Response> => {
     const parsed = CreateUploadSessionBody.safeParse(await requestJson(request));
     if (!parsed.success) return fail("validation", "Invalid upload session input.");
@@ -2333,9 +2347,15 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     const existing = [...state.uploadSessions.values()].find(
       (row) => row.stash === stash && row.createKey === key && key !== null,
     );
+    const samePrincipal =
+      existing === undefined ||
+      (existing.principal.kind === "admin"
+        ? principal.kind === "admin"
+        : principal.kind === "stash" && existing.principal.tokenId === principal.tokenId);
     if (
       existing !== undefined &&
-      (existing.path !== path ||
+      (!samePrincipal ||
+        existing.path !== path ||
         existing.expectedVersion !== parsed.data.expectedVersion ||
         existing.declaredSize !== parsed.data.size ||
         existing.declaredHash !== (parsed.data.hash ?? null) ||
@@ -2370,6 +2390,10 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
       id: `upl_fake_${String(nextUploadSession++).padStart(8, "0")}`,
       stash,
       path,
+      principal:
+        principal.kind === "admin"
+          ? { kind: "admin" }
+          : { kind: "stash", tokenId: principal.tokenId },
       state: "open",
       expectedVersion: parsed.data.expectedVersion,
       declaredSize: parsed.data.size,
@@ -2385,6 +2409,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
       expiresAt: now() + capabilities.limits.uploadSessionTtlSeconds * 1_000,
       attemptGeneration: 0,
       uploadedBytes: null,
+      uploadedHash: null,
       parts: new Map(),
       result: null,
       createKey: key,
@@ -2421,7 +2446,21 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     if (partNumber === undefined) {
       if (row.mode !== "single" || bytes.byteLength !== row.declaredSize)
         return fail("upload-size-mismatch", "Upload size does not match its declaration.");
+      const hash = await sha256Hex(bytes.slice().buffer);
+      if (row.declaredHash !== null && row.declaredHash !== hash) {
+        row.state = "failed";
+        return fail("upload-hash-mismatch", "Upload hash does not match its declaration.");
+      }
+      if (row.representation === "text") {
+        try {
+          new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        } catch {
+          row.state = "failed";
+          return fail("unsupported-representation", "Text uploads must contain valid UTF-8.");
+        }
+      }
       row.uploadedBytes = bytes;
+      row.uploadedHash = hash;
       row.uploadKey = key;
       row.state = "uploaded";
       return json(uploadRecord(row), 202);
@@ -2463,7 +2502,8 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     if (row.state === "committed") {
       if (row.completeKey !== key)
         return fail("idempotency-key-reused", "Idempotency-Key was reused.");
-      return json(resume ? uploadRecord(row) : row.result, resume ? 200 : 201, {
+      const status = row.result !== null && "unchanged" in row.result ? 200 : 201;
+      return json(resume ? uploadRecord(row) : row.result, resume ? 200 : status, {
         "Idempotent-Replayed": "true",
       });
     }
@@ -2540,12 +2580,25 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         message: "",
         meta: {},
       });
+      const r2Key =
+        row.storageTier === "r2"
+          ? `v2/${row.stash}/${hash}/00000000-0000-4000-8000-${String(nextR2ObjectSerial++).padStart(12, "0")}`
+          : null;
+      if (r2Key !== null) {
+        state.r2Objects.set(r2Key, {
+          key: r2Key,
+          stash: row.stash,
+          hash,
+          size: bytes.byteLength,
+          createdAt: version.createdAt,
+        });
+      }
       const blob: FakeBlobRow = {
         stash: row.stash,
         hash,
         body: text,
         bytes: bytes.slice(),
-        r2Key: null,
+        r2Key,
         size: bytes.byteLength,
         createdAt: version.createdAt,
       };
@@ -2562,7 +2615,8 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     }
     row.state = "committed";
     row.completeKey = key;
-    return json(resume ? uploadRecord(row) : row.result, resume ? 200 : 201);
+    const status = row.result !== null && "unchanged" in row.result ? 200 : 201;
+    return json(resume ? uploadRecord(row) : row.result, resume ? 200 : status);
   };
 
   const handleRaw = (
@@ -2805,35 +2859,35 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         case "headRawVersion":
           return handleRaw(request, stash ?? "", path ?? "", match.version);
         case "createUploadSession":
-          return await handleCreateUpload(request, stash ?? "", path ?? "");
+          return await handleCreateUpload(request, stash ?? "", path ?? "", principal);
         case "getUploadSession": {
-          const session = requireUpload(stash ?? "", match.sessionId ?? "");
+          const session = requireUpload(stash ?? "", match.sessionId ?? "", principal);
           return json({ ...uploadRecord(session), parts: sessionParts(session) });
         }
         case "uploadSingleContent":
           return await handleUploadBytes(
             request,
-            requireUpload(stash ?? "", match.sessionId ?? ""),
+            requireUpload(stash ?? "", match.sessionId ?? "", principal),
           );
         case "uploadPart":
           return await handleUploadBytes(
             request,
-            requireUpload(stash ?? "", match.sessionId ?? ""),
+            requireUpload(stash ?? "", match.sessionId ?? "", principal),
             match.partNumber,
           );
         case "completeUploadSession":
           return await handleCompleteUpload(
             request,
-            requireUpload(stash ?? "", match.sessionId ?? ""),
+            requireUpload(stash ?? "", match.sessionId ?? "", principal),
           );
         case "resumeUploadSession":
           return await handleCompleteUpload(
             request,
-            requireUpload(stash ?? "", match.sessionId ?? ""),
+            requireUpload(stash ?? "", match.sessionId ?? "", principal),
             true,
           );
         case "abortUploadSession": {
-          const session = requireUpload(stash ?? "", match.sessionId ?? "");
+          const session = requireUpload(stash ?? "", match.sessionId ?? "", principal);
           const key = idempotencyKey(request) ?? null;
           const parsed = AbortUploadSessionBody.safeParse(await requestJson(request));
           if (!parsed.success || parsed.data.generation !== session.attemptGeneration)

--- a/packages/client/src/testing/fake.ts
+++ b/packages/client/src/testing/fake.ts
@@ -2,6 +2,9 @@ import {
   ApproveProposalBody,
   BODY_LIMIT_BYTES,
   ChangesQuery,
+  CreateUploadSessionBody,
+  CompleteUploadSessionBody,
+  AbortUploadSessionBody,
   CreateProposalBody,
   CreateStashBody,
   CreateTokenBody,
@@ -43,6 +46,7 @@ import {
 } from "@takazudo/zudo-history-stash-core";
 import type {
   Current,
+  CapabilitiesResponse,
   DiffSide,
   ErrorCode,
   GcKind,
@@ -69,6 +73,7 @@ import type {
   FakeStashState,
   FakeTokenRow,
   FakeVersionRow,
+  FakeUploadSessionRow,
 } from "./types.js";
 
 const DEFAULT_CONTENT_TYPE = "text/plain; charset=utf-8";
@@ -83,8 +88,28 @@ const MAX_R2_GC_PAGE_OBJECTS = 24;
 const SHA256_HASH = /^sha256-[0-9a-f]{64}$/;
 const LOWERCASE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const JSON_CONTENT_TYPE = /^application\/([a-z-.]+\+)?json(;\s*[a-zA-Z0-9-]+=([^;]+))*$/i;
+const DEFAULT_CAPABILITIES: CapabilitiesResponse = {
+  representations: ["text", "binary"],
+  contentAccess: ["inline", "raw", "deleted"],
+  transferModes: ["json", "single", "multipart"],
+  storageTiers: ["d1", "r2"],
+  limits: {
+    jsonInlineMaxBytes: MAX_BODY_BYTES,
+    d1InlineMaxBytes: 1_000_000,
+    httpRequestMaxBytes: 100_000_000,
+    singleUploadMaxBytes: 32_000_000,
+    maxFileBytes: 1_073_741_824,
+    diffMaxBytesPerSide: 1_000_000,
+    multipartPartBytes: 8_388_608,
+    maxMultipartParts: 10_000,
+    maxOpenUploadSessionsPerStash: 32,
+    maxReservedUploadBytesPerStash: 2_147_483_648,
+    uploadSessionTtlSeconds: 86_400,
+  },
+};
 
 const SUPPORTED_ROUTE_IDS = new Set<RouteId>([
+  "getCapabilities",
   "me",
   "listStashes",
   "createStash",
@@ -113,6 +138,17 @@ const SUPPORTED_ROUTE_IDS = new Set<RouteId>([
   "approveProposal",
   "rejectProposal",
   "stashEvents",
+  "getRawFile",
+  "headRawFile",
+  "getRawVersion",
+  "headRawVersion",
+  "createUploadSession",
+  "getUploadSession",
+  "uploadSingleContent",
+  "uploadPart",
+  "completeUploadSession",
+  "resumeUploadSession",
+  "abortUploadSession",
 ]);
 
 const LIVE_STASH_ROUTE_IDS = new Set<RouteId>([
@@ -136,6 +172,17 @@ const LIVE_STASH_ROUTE_IDS = new Set<RouteId>([
   "approveProposal",
   "rejectProposal",
   "stashEvents",
+  "getRawFile",
+  "headRawFile",
+  "getRawVersion",
+  "headRawVersion",
+  "createUploadSession",
+  "getUploadSession",
+  "uploadSingleContent",
+  "uploadPart",
+  "completeUploadSession",
+  "resumeUploadSession",
+  "abortUploadSession",
 ]);
 
 const RATE_LIMIT_CAPABILITY_BY_ROUTE = {
@@ -200,6 +247,9 @@ interface MatchedRoute {
   path?: string;
   tokenId?: string;
   proposalId?: string;
+  sessionId?: string;
+  version?: number;
+  partNumber?: number;
 }
 
 class FakeHttpError extends Error {
@@ -266,6 +316,7 @@ function decode(value: string): string {
 function routeMatch(request: Request): MatchedRoute | undefined {
   const { pathname } = new URL(request.url);
   const method = request.method.toUpperCase();
+  if (method === "GET" && pathname === "/v1/capabilities") return { routeId: "getCapabilities" };
   if (method === "GET" && pathname === "/v1/me") return { routeId: "me" };
   if (method === "GET" && pathname === "/v1/stashes") return { routeId: "listStashes" };
   if (method === "POST" && pathname === "/v1/stashes") return { routeId: "createStash" };
@@ -355,6 +406,59 @@ function routeMatch(request: Request): MatchedRoute | undefined {
   match = /^\/v1\/stashes\/([^/]+)\/files$/.exec(pathname);
   if (method === "GET" && match?.[1] !== undefined) {
     return { routeId: "listFiles", stash: decode(match[1]) };
+  }
+
+  match = /^\/v1\/stashes\/([^/]+)\/versions\/(\d+)\/raw\/(.+)$/.exec(pathname);
+  if ((method === "GET" || method === "HEAD") && match?.[1] && match[2] && match[3]) {
+    return {
+      routeId: method === "HEAD" ? "headRawVersion" : "getRawVersion",
+      stash: decode(match[1]),
+      version: Number(match[2]),
+      path: decode(match[3]),
+    };
+  }
+
+  match = /^\/v1\/stashes\/([^/]+)\/raw\/(.+)$/.exec(pathname);
+  if ((method === "GET" || method === "HEAD") && match?.[1] && match[2]) {
+    return {
+      routeId: method === "HEAD" ? "headRawFile" : "getRawFile",
+      stash: decode(match[1]),
+      path: decode(match[2]),
+    };
+  }
+
+  match = /^\/v1\/stashes\/([^/]+)\/uploads\/([^/]+)\/parts\/(\d+)$/.exec(pathname);
+  if (method === "PUT" && match?.[1] && match[2] && match[3]) {
+    return {
+      routeId: "uploadPart",
+      stash: decode(match[1]),
+      sessionId: decode(match[2]),
+      partNumber: Number(match[3]),
+    };
+  }
+  match = /^\/v1\/stashes\/([^/]+)\/uploads\/([^/]+)\/(content|complete|resume)$/.exec(pathname);
+  if (match?.[1] && match[2] && match[3]) {
+    const routeId =
+      match[3] === "content"
+        ? "uploadSingleContent"
+        : match[3] === "complete"
+          ? "completeUploadSession"
+          : "resumeUploadSession";
+    if (routeId === "uploadSingleContent" ? method === "PUT" : method === "POST") {
+      return { routeId, stash: decode(match[1]), sessionId: decode(match[2]) };
+    }
+  }
+  match = /^\/v1\/stashes\/([^/]+)\/uploads\/([^/]+)$/.exec(pathname);
+  if ((method === "GET" || method === "DELETE") && match?.[1] && match[2]) {
+    return {
+      routeId: method === "GET" ? "getUploadSession" : "abortUploadSession",
+      stash: decode(match[1]),
+      sessionId: decode(match[2]),
+    };
+  }
+  match = /^\/v1\/stashes\/([^/]+)\/uploads\/(.+)$/.exec(pathname);
+  if (method === "POST" && match?.[1] && match[2]) {
+    return { routeId: "createUploadSession", stash: decode(match[1]), path: decode(match[2]) };
   }
 
   match = /^\/v1\/stashes\/([^/]+)\/files\/(.+)$/.exec(pathname);
@@ -509,6 +613,10 @@ function changesPage(rows: FakeVersionRow[], since: number | undefined, limit: n
     author: row.author,
     message: row.message,
     size: row.size,
+    representation: row.representation ?? "text",
+    contentAccess: row.kind === "delete" ? "deleted" : (row.contentAccess ?? "inline"),
+    contentType: row.contentType,
+    byteSize: row.size,
     createdAt: iso(row.createdAt),
   }));
   if (since !== undefined) {
@@ -536,6 +644,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
   const deleteGraceDays = options.deleteGraceDays ?? DEFAULT_DELETE_GRACE_DAYS;
   const gcOrphanMinAgeMs = options.gcOrphanMinAgeMs ?? DEFAULT_GC_ORPHAN_MIN_AGE_MS;
   const proposalTtlDays = options.proposalTtlDays ?? DEFAULT_PROPOSAL_TTL_DAYS;
+  const capabilities = options.capabilities ?? DEFAULT_CAPABILITIES;
   if (!Number.isSafeInteger(deleteGraceDays) || deleteGraceDays < 1) {
     throw new TypeError("deleteGraceDays must be a positive safe integer");
   }
@@ -579,6 +688,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
       ],
     ]),
     gcRuns: [],
+    uploadSessions: new Map(),
   };
   let nextToken = 1;
   let nextChangeId = 1;
@@ -586,6 +696,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
   let nextProposalSerial = 1;
   let nextGcRun = 1;
   let nextGcCursorSerial = 1;
+  let nextUploadSession = 1;
   const gcCursorPositions = new Map<string, { kind: GcKind; afterKey: string }>();
 
   interface EventSubscriber {
@@ -715,8 +826,15 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
   const bodyFor = (version: FakeVersionRow): string => {
     if (version.hash === null) return "";
     const body = state.blobs.get(version.stash)?.get(version.hash)?.body;
-    if (body === undefined) return fail("internal", "The fake version points at a missing blob.");
+    if (body === undefined || body === null)
+      return fail("unsupported-representation", "Binary content has no JSON body.");
     return body;
+  };
+  const bytesFor = (version: FakeVersionRow): Uint8Array => {
+    if (version.hash === null) return new Uint8Array();
+    const bytes = state.blobs.get(version.stash)?.get(version.hash)?.bytes;
+    if (bytes === undefined) return fail("internal", "The fake version points at a missing blob.");
+    return bytes;
   };
   const storeBlob = (stash: string, hash: string, body: string, createdAt: number): FakeBlobRow => {
     const rows = nested(state.blobs, stash);
@@ -730,7 +848,15 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
       nextR2ObjectSerial += 1;
       state.r2Objects.set(r2Key, { key: r2Key, stash, hash, size, createdAt });
     }
-    const row: FakeBlobRow = { stash, hash, body, r2Key, size, createdAt };
+    const row: FakeBlobRow = {
+      stash,
+      hash,
+      body,
+      bytes: new TextEncoder().encode(body),
+      r2Key,
+      size,
+      createdAt,
+    };
     rows.set(hash, row);
     return row;
   };
@@ -1518,7 +1644,8 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
 
   const proposalBody = (row: FakeProposalRow): string => {
     const body = state.blobs.get(row.stash)?.get(row.blobHash)?.body;
-    if (body === undefined) return fail("internal", "The fake proposal points at a missing blob.");
+    if (body === undefined || body === null)
+      return fail("internal", "The fake proposal points at a missing blob.");
     return body;
   };
 
@@ -1838,6 +1965,10 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
           headVersion: file.headVersion,
           hash: file.headHash,
           size: head.size,
+          representation: head.representation ?? "text",
+          contentAccess: file.deleted ? "deleted" : (head.contentAccess ?? "inline"),
+          contentType: head.contentType,
+          byteSize: head.size,
           deleted: file.deleted,
           updatedAt: iso(file.updatedAt),
         };
@@ -1890,7 +2021,11 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         meta: cloneMeta(version.meta),
         createdAt: iso(version.createdAt),
         deleted,
-        body: deleted ? null : bodyFor(version),
+        representation: version.representation ?? "text",
+        contentAccess: deleted ? "deleted" : (version.contentAccess ?? "inline"),
+        contentType: version.contentType,
+        byteSize: version.size,
+        body: deleted || version.contentAccess === "raw" ? null : bodyFor(version),
       },
       200,
       headers,
@@ -2012,7 +2147,9 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         kind: "delete",
         hash: null,
         size: 0,
-        contentType: DEFAULT_CONTENT_TYPE,
+        contentType: head.contentType,
+        representation: head.representation,
+        contentAccess: "deleted",
         rollbackOf: null,
         author: parsed.data.author ?? "",
         message: parsed.data.message ?? "",
@@ -2069,6 +2206,8 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         hash: target.hash,
         size: target.size,
         contentType: target.contentType,
+        representation: target.representation,
+        contentAccess: target.contentAccess,
         rollbackOf: target.version,
         author: parsed.data.author ?? "",
         message:
@@ -2088,6 +2227,14 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         identicalToHead: target.hash === head.hash,
         changeId: version.changeId,
         createdAt: iso(version.createdAt),
+        ...(target.representation === undefined
+          ? {}
+          : {
+              representation: target.representation,
+              contentType: target.contentType,
+              byteSize: target.size,
+              etag: target.hash,
+            }),
       },
       201,
     );
@@ -2119,8 +2266,385 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         message: version.message,
         meta: cloneMeta(version.meta),
         createdAt: iso(version.createdAt),
+        representation: version.representation ?? "text",
+        contentAccess: version.kind === "delete" ? "deleted" : (version.contentAccess ?? "inline"),
+        contentType: version.contentType,
+        byteSize: version.size,
       })),
       nextBefore: hasMore ? (page.at(-1)?.version ?? null) : null,
+    });
+  };
+
+  const uploadRecord = (row: FakeUploadSessionRow) => ({
+    id: row.id,
+    stash: row.stash,
+    path: row.path,
+    principal: { kind: "admin" as const },
+    state: row.state,
+    expectedVersion: row.expectedVersion,
+    declaredSize: row.declaredSize,
+    declaredHash: row.declaredHash,
+    representation: row.representation,
+    contentType: row.contentType,
+    mode: row.mode,
+    storageTier: row.storageTier,
+    partSize: row.partSize,
+    expiresAt: iso(row.expiresAt),
+    attemptGeneration: row.attemptGeneration,
+    uploadedSize: row.uploadedBytes?.byteLength ?? null,
+    uploadedHash: null,
+    finalizationLeaseOwner: null,
+    finalizationLeaseExpiresAt: null,
+    result: row.result,
+  });
+
+  const requireUpload = (stash: string, id: string): FakeUploadSessionRow => {
+    const row = state.uploadSessions.get(id);
+    if (row === undefined || row.stash !== stash)
+      return fail("not-found", "Upload session not found.");
+    if (row.state === "open" && row.expiresAt <= now()) row.state = "expired";
+    return row;
+  };
+
+  const sessionParts = (row: FakeUploadSessionRow) =>
+    [...row.parts.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([partNumber, bytes]) => ({
+        partNumber,
+        size: bytes.byteLength,
+        generation: row.attemptGeneration,
+        etag: `fake-part-${row.attemptGeneration}-${partNumber}-${bytes.byteLength}`,
+      }));
+
+  const handleCreateUpload = async (
+    request: Request,
+    stash: string,
+    path: string,
+  ): Promise<Response> => {
+    const parsed = CreateUploadSessionBody.safeParse(await requestJson(request));
+    if (!parsed.success) return fail("validation", "Invalid upload session input.");
+    const key = idempotencyKey(request) ?? null;
+    const mode =
+      parsed.data.mode === "auto"
+        ? !parsed.data.resumable && parsed.data.size <= capabilities.limits.singleUploadMaxBytes
+          ? "single"
+          : "multipart"
+        : parsed.data.mode;
+    const existing = [...state.uploadSessions.values()].find(
+      (row) => row.stash === stash && row.createKey === key && key !== null,
+    );
+    if (
+      existing !== undefined &&
+      (existing.path !== path ||
+        existing.expectedVersion !== parsed.data.expectedVersion ||
+        existing.declaredSize !== parsed.data.size ||
+        existing.declaredHash !== (parsed.data.hash ?? null) ||
+        existing.representation !== parsed.data.representation ||
+        existing.contentType !== parsed.data.contentType ||
+        existing.mode !== mode)
+    )
+      return fail("idempotency-key-reused", "Idempotency-Key was reused.");
+    if (existing !== undefined)
+      return json(uploadRecord(existing), 201, { "Idempotent-Replayed": "true" });
+    const file = getFile(stash, path);
+    if (parsed.data.expectedVersion === null && file !== undefined)
+      return fail("exists", "File already exists.");
+    if (parsed.data.expectedVersion !== null && file === undefined)
+      return fail("not-found", "File not found.");
+    if (file !== undefined && parsed.data.expectedVersion !== file.headVersion)
+      return fail("stale", "Expected version is stale.", current(file, getHeadVersion(file)));
+    if (parsed.data.size > capabilities.limits.maxFileBytes)
+      return fail("payload-too-large", "The declared file size is too large.");
+    if (
+      mode === "single" &&
+      (parsed.data.resumable || parsed.data.size > capabilities.limits.singleUploadMaxBytes)
+    ) {
+      return fail(
+        parsed.data.resumable ? "validation" : "payload-too-large",
+        "Invalid single upload mode.",
+      );
+    }
+    if (mode === "multipart" && parsed.data.size === 0)
+      return fail("validation", "An empty file must use single upload mode.");
+    const row: FakeUploadSessionRow = {
+      id: `upl_fake_${String(nextUploadSession++).padStart(8, "0")}`,
+      stash,
+      path,
+      state: "open",
+      expectedVersion: parsed.data.expectedVersion,
+      declaredSize: parsed.data.size,
+      declaredHash: parsed.data.hash ?? null,
+      representation: parsed.data.representation,
+      contentType: parsed.data.contentType,
+      mode,
+      storageTier:
+        mode === "multipart" || parsed.data.size > capabilities.limits.d1InlineMaxBytes
+          ? "r2"
+          : "d1",
+      partSize: mode === "multipart" ? capabilities.limits.multipartPartBytes : null,
+      expiresAt: now() + capabilities.limits.uploadSessionTtlSeconds * 1_000,
+      attemptGeneration: 0,
+      uploadedBytes: null,
+      parts: new Map(),
+      result: null,
+      createKey: key,
+      completeKey: null,
+      uploadKey: null,
+      abortKey: null,
+      terminalCurrent: null,
+      skipIfUnchanged: parsed.data.skipIfUnchanged,
+    };
+    state.uploadSessions.set(row.id, row);
+    return json(uploadRecord(row), 201);
+  };
+
+  const handleUploadBytes = async (
+    request: Request,
+    row: FakeUploadSessionRow,
+    partNumber?: number,
+  ): Promise<Response> => {
+    const key = idempotencyKey(request) ?? null;
+    if (partNumber === undefined && row.state === "uploaded" && row.uploadKey === key) {
+      return json(uploadRecord(row), 202, { "Idempotent-Replayed": "true" });
+    }
+    if (row.state !== "open")
+      return fail(
+        row.state === "expired" ? "upload-session-expired" : "upload-session-not-open",
+        "Upload session does not accept bytes.",
+      );
+    const generation = Number(
+      new URL(request.url).searchParams.get("generation") ?? row.attemptGeneration,
+    );
+    if (generation !== row.attemptGeneration)
+      return fail("upload-session-not-open", "Upload generation is stale.");
+    const bytes = new Uint8Array(await request.arrayBuffer());
+    if (partNumber === undefined) {
+      if (row.mode !== "single" || bytes.byteLength !== row.declaredSize)
+        return fail("upload-size-mismatch", "Upload size does not match its declaration.");
+      row.uploadedBytes = bytes;
+      row.uploadKey = key;
+      row.state = "uploaded";
+      return json(uploadRecord(row), 202);
+    }
+    if (row.mode !== "multipart" || row.partSize === null)
+      return fail("upload-session-not-open", "Upload session does not accept parts.");
+    const expectedParts = Math.ceil(row.declaredSize / row.partSize);
+    const expectedSize =
+      partNumber === expectedParts
+        ? row.declaredSize - row.partSize * (expectedParts - 1)
+        : row.partSize;
+    if (partNumber < 1 || partNumber > expectedParts || bytes.byteLength !== expectedSize)
+      return fail("upload-size-mismatch", "Upload part size is incorrect.");
+    row.parts.set(partNumber, bytes);
+    return json({ ...uploadRecord(row), parts: sessionParts(row) }, 202);
+  };
+
+  const handleCompleteUpload = async (
+    request: Request,
+    row: FakeUploadSessionRow,
+    resume = false,
+  ): Promise<Response> => {
+    const parsed = CompleteUploadSessionBody.safeParse(await requestJson(request));
+    if (!parsed.success || parsed.data.generation !== row.attemptGeneration)
+      return fail("validation", "Invalid upload completion input.");
+    const key = idempotencyKey(request) ?? null;
+    if (row.state === "stale") {
+      if (row.completeKey !== key)
+        return fail("idempotency-key-reused", "Idempotency-Key was reused.");
+      return json(
+        {
+          error: { code: "stale", message: "Expected version is stale." },
+          ...(row.terminalCurrent === null ? {} : { current: row.terminalCurrent }),
+        },
+        409,
+        { "Idempotent-Replayed": "true" },
+      );
+    }
+    if (row.state === "committed") {
+      if (row.completeKey !== key)
+        return fail("idempotency-key-reused", "Idempotency-Key was reused.");
+      return json(resume ? uploadRecord(row) : row.result, resume ? 200 : 201, {
+        "Idempotent-Replayed": "true",
+      });
+    }
+    if (resume && row.state === "open") return json(uploadRecord(row));
+    if (row.state !== "open" && row.state !== "uploaded")
+      return fail(
+        row.state === "expired" ? "upload-session-expired" : "upload-session-not-open",
+        "Upload session is not ready to complete.",
+      );
+    let bytes: Uint8Array;
+    if (row.mode === "single") {
+      if (row.uploadedBytes === null)
+        return fail("upload-session-not-open", "Upload session is not ready to complete.");
+      bytes = row.uploadedBytes;
+    } else {
+      const parts = sessionParts(row);
+      const expected = Math.ceil(row.declaredSize / (row.partSize ?? 1));
+      if (parts.length !== expected)
+        return fail("upload-size-mismatch", "Multipart upload is incomplete.");
+      bytes = new Uint8Array(row.declaredSize);
+      let offset = 0;
+      for (let part = 1; part <= expected; part += 1) {
+        const value = row.parts.get(part);
+        if (value === undefined)
+          return fail("upload-size-mismatch", "Multipart upload is incomplete.");
+        bytes.set(value, offset);
+        offset += value.byteLength;
+      }
+    }
+    const hash = await sha256Hex(bytes.slice().buffer);
+    if (row.declaredHash !== null && row.declaredHash !== hash) {
+      row.state = "failed";
+      return fail("upload-hash-mismatch", "Upload hash does not match its declaration.");
+    }
+    let text: string | null = null;
+    if (row.representation === "text") {
+      try {
+        text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+      } catch {
+        row.state = "failed";
+        return fail("unsupported-representation", "Text uploads must contain valid UTF-8.");
+      }
+    }
+    const file = getFile(row.stash, row.path);
+    if (file !== undefined && file.headVersion !== row.expectedVersion) {
+      row.state = "stale";
+      row.completeKey = key;
+      row.terminalCurrent = current(file, getHeadVersion(file));
+      return fail("stale", "Expected version is stale.", row.terminalCurrent);
+    }
+    if (row.skipIfUnchanged && file !== undefined && !file.deleted && file.headHash === hash) {
+      row.result = {
+        unchanged: true,
+        version: file.headVersion,
+        hash,
+        size: bytes.byteLength,
+        representation: row.representation,
+        contentType: row.contentType,
+      };
+    } else {
+      const version = append(row.stash, row.path, {
+        kind: "put",
+        hash,
+        size: bytes.byteLength,
+        contentType: row.contentType,
+        representation: row.representation,
+        contentAccess:
+          row.representation === "text" &&
+          bytes.byteLength <= capabilities.limits.jsonInlineMaxBytes
+            ? "inline"
+            : "raw",
+        rollbackOf: null,
+        author: "",
+        message: "",
+        meta: {},
+      });
+      const blob: FakeBlobRow = {
+        stash: row.stash,
+        hash,
+        body: text,
+        bytes: bytes.slice(),
+        r2Key: null,
+        size: bytes.byteLength,
+        createdAt: version.createdAt,
+      };
+      nested(state.blobs, row.stash).set(hash, blob);
+      row.result = {
+        version: version.version,
+        hash,
+        size: bytes.byteLength,
+        representation: row.representation,
+        contentType: row.contentType,
+        changeId: version.changeId,
+        createdAt: iso(version.createdAt),
+      };
+    }
+    row.state = "committed";
+    row.completeKey = key;
+    return json(resume ? uploadRecord(row) : row.result, resume ? 200 : 201);
+  };
+
+  const handleRaw = (
+    request: Request,
+    stash: string,
+    path: string,
+    requestedVersion?: number,
+  ): Response => {
+    const file = getFile(stash, path);
+    if (file === undefined)
+      return fail(
+        requestedVersion === undefined ? "not-found" : "version-not-found",
+        "File not found.",
+      );
+    const version =
+      requestedVersion === undefined
+        ? getHeadVersion(file)
+        : getVersion(stash, path, requestedVersion);
+    if (version === undefined) return fail("version-not-found", "Version not found.");
+    if (version.kind === "delete") return fail("file-deleted", "The file version is deleted.");
+    const all = bytesFor(version);
+    const etag = `"${version.hash ?? ""}"`;
+    if (ifNoneMatchMatches(request.headers.get("If-None-Match"), etag))
+      return new Response(null, {
+        status: 304,
+        headers: { ETag: etag, "X-Stash-Version": String(version.version) },
+      });
+    let start = 0;
+    let end = all.byteLength - 1;
+    let partial = false;
+    const range = request.headers.get("Range");
+    const ifRange = request.headers.get("If-Range");
+    if (range !== null && (ifRange === null || ifRange === etag)) {
+      const matched = /^bytes=(\d*)-(\d*)$/.exec(range);
+      if (matched === null || (matched[1] === "" && matched[2] === ""))
+        return json(
+          {
+            error: { code: "range-not-satisfiable", message: "The byte range is not satisfiable." },
+          },
+          416,
+          { "Content-Range": `bytes */${all.byteLength}` },
+        );
+      if (matched[1] === "") {
+        const suffix = BigInt(matched[2] ?? "0");
+        if (suffix < 1n)
+          return json(
+            {
+              error: {
+                code: "range-not-satisfiable",
+                message: "The byte range is not satisfiable.",
+              },
+            },
+            416,
+            { "Content-Range": `bytes */${all.byteLength}` },
+          );
+        start = suffix >= BigInt(all.byteLength) ? 0 : all.byteLength - Number(suffix);
+      } else {
+        start = Number(matched[1]);
+        end = matched[2] === "" ? end : Math.min(Number(matched[2]), end);
+      }
+      if (start > end || start >= all.byteLength)
+        return json(
+          {
+            error: { code: "range-not-satisfiable", message: "The byte range is not satisfiable." },
+          },
+          416,
+          { "Content-Range": `bytes */${all.byteLength}` },
+        );
+      partial = true;
+    }
+    const bytes = all.slice(start, end + 1);
+    const responseHeaders: Record<string, string> = {
+      ETag: etag,
+      "X-Stash-Version": String(version.version),
+      "Content-Type": version.contentType,
+      "Content-Length": String(bytes.byteLength),
+      "Accept-Ranges": "bytes",
+    };
+    if (partial) responseHeaders["Content-Range"] = `bytes ${start}-${end}/${all.byteLength}`;
+    return new Response(request.method === "HEAD" ? null : bytes, {
+      status: partial ? 206 : 200,
+      headers: responseHeaders,
     });
   };
 
@@ -2228,7 +2752,8 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
     try {
       const match = routeMatch(request);
       if (match === undefined || !SUPPORTED_ROUTE_IDS.has(match.routeId)) return unsupported();
-      const principal = await authenticate(request);
+      const principal: Principal =
+        match.routeId === "getCapabilities" ? { kind: "admin" } : await authenticate(request);
       authorize(principal, match);
       const rateLimited = await applyRateLimit(principal, match.routeId);
       if (rateLimited !== undefined) return rateLimited;
@@ -2239,6 +2764,8 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
         requireLiveStash(stash);
       }
       switch (match.routeId) {
+        case "getCapabilities":
+          return json(capabilities);
         case "me":
           return json(
             principal.kind === "admin"
@@ -2271,6 +2798,56 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
           return handleRevokeToken(stash ?? "", match.tokenId ?? "");
         case "stashEvents":
           return handleEvents(request, stash ?? "", url);
+        case "getRawFile":
+        case "headRawFile":
+          return handleRaw(request, stash ?? "", path ?? "");
+        case "getRawVersion":
+        case "headRawVersion":
+          return handleRaw(request, stash ?? "", path ?? "", match.version);
+        case "createUploadSession":
+          return await handleCreateUpload(request, stash ?? "", path ?? "");
+        case "getUploadSession": {
+          const session = requireUpload(stash ?? "", match.sessionId ?? "");
+          return json({ ...uploadRecord(session), parts: sessionParts(session) });
+        }
+        case "uploadSingleContent":
+          return await handleUploadBytes(
+            request,
+            requireUpload(stash ?? "", match.sessionId ?? ""),
+          );
+        case "uploadPart":
+          return await handleUploadBytes(
+            request,
+            requireUpload(stash ?? "", match.sessionId ?? ""),
+            match.partNumber,
+          );
+        case "completeUploadSession":
+          return await handleCompleteUpload(
+            request,
+            requireUpload(stash ?? "", match.sessionId ?? ""),
+          );
+        case "resumeUploadSession":
+          return await handleCompleteUpload(
+            request,
+            requireUpload(stash ?? "", match.sessionId ?? ""),
+            true,
+          );
+        case "abortUploadSession": {
+          const session = requireUpload(stash ?? "", match.sessionId ?? "");
+          const key = idempotencyKey(request) ?? null;
+          const parsed = AbortUploadSessionBody.safeParse(await requestJson(request));
+          if (!parsed.success || parsed.data.generation !== session.attemptGeneration)
+            return fail("validation", "Invalid upload abort input.");
+          if (session.state === "aborted" && session.abortKey === key)
+            return json({ id: session.id, state: "aborted" }, 200, {
+              "Idempotent-Replayed": "true",
+            });
+          if (session.state === "committed" || session.state === "aborted")
+            return fail("upload-session-not-open", "Upload session cannot be aborted.");
+          session.state = "aborted";
+          session.abortKey = key;
+          return json({ id: session.id, state: "aborted" });
+        }
         case "listFiles":
           return handleListFiles(stash ?? "", url);
         case "getFile":
@@ -2347,6 +2924,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
       state.versions.length = 0;
       state.idempotency.clear();
       state.gcRuns.length = 0;
+      state.uploadSessions.clear();
       for (const job of state.gcJobs.values()) {
         job.nextCursor = null;
         job.leaseOwner = null;
@@ -2361,6 +2939,7 @@ export function createFakeStash(options: FakeStashOptions = {}): FakeStash {
       nextProposalSerial = 1;
       nextGcRun = 1;
       nextGcCursorSerial = 1;
+      nextUploadSession = 1;
     },
   };
 }

--- a/packages/client/src/testing/types.ts
+++ b/packages/client/src/testing/types.ts
@@ -135,6 +135,7 @@ export interface FakeUploadSessionRow {
   id: string;
   stash: string;
   path: string;
+  principal: { kind: "admin" } | { kind: "stash"; tokenId: string };
   state: UploadSessionState;
   expectedVersion: number | null;
   declaredSize: number;
@@ -147,6 +148,7 @@ export interface FakeUploadSessionRow {
   expiresAt: number;
   attemptGeneration: number;
   uploadedBytes: Uint8Array | null;
+  uploadedHash: string | null;
   parts: Map<number, Uint8Array>;
   result: UploadCompletionResult | null;
   createKey: string | null;

--- a/packages/client/src/testing/types.ts
+++ b/packages/client/src/testing/types.ts
@@ -1,6 +1,9 @@
 import type {
   GcKind,
   GcRunResult,
+  CapabilitiesResponse,
+  ContentAccess,
+  Current,
   JsonValue,
   ProposalStatus,
   ReconnectReason,
@@ -10,8 +13,13 @@ import type {
   StashProposalEvent,
   TokenScope,
   VersionKind,
+  Representation,
+  StorageTier,
+  UploadMode,
+  UploadCompletionResult,
+  UploadSessionState,
 } from "@takazudo/zudo-history-stash-core";
-import type { StashFetch } from "../client.js";
+import type { StashFetch } from "../transport.js";
 
 export type RateLimitCapability = "read" | "write" | "diff";
 
@@ -41,6 +49,8 @@ export interface FakeStashOptions {
   gcOrphanMinAgeMs?: number;
   /** Number of days before a proposal expires. Defaults to the Worker value of fourteen. */
   proposalTtlDays?: number;
+  /** Binary settings advertised by the fake; useful for deterministic mode-selection tests. */
+  capabilities?: CapabilitiesResponse;
 }
 
 export interface FakeMintTokenOptions {
@@ -75,7 +85,9 @@ export interface FakeTokenRow {
 export interface FakeBlobRow {
   stash: string;
   hash: string;
-  body: string;
+  body: string | null;
+  /** Exact immutable content bytes, including invalid UTF-8. */
+  bytes: Uint8Array;
   /** Exact immutable R2 generation referenced by the logical blob row, or null for inline data. */
   r2Key: string | null;
   size: number;
@@ -110,11 +122,39 @@ export interface FakeVersionRow {
   hash: string | null;
   size: number;
   contentType: string;
+  representation?: Representation;
+  contentAccess?: ContentAccess;
   rollbackOf: number | null;
   author: string;
   message: string;
   meta: Record<string, JsonValue>;
   createdAt: number;
+}
+
+export interface FakeUploadSessionRow {
+  id: string;
+  stash: string;
+  path: string;
+  state: UploadSessionState;
+  expectedVersion: number | null;
+  declaredSize: number;
+  declaredHash: string | null;
+  representation: Representation;
+  contentType: string;
+  mode: UploadMode;
+  storageTier: StorageTier;
+  partSize: number | null;
+  expiresAt: number;
+  attemptGeneration: number;
+  uploadedBytes: Uint8Array | null;
+  parts: Map<number, Uint8Array>;
+  result: UploadCompletionResult | null;
+  createKey: string | null;
+  completeKey: string | null;
+  uploadKey: string | null;
+  abortKey: string | null;
+  terminalCurrent: Current | null;
+  skipIfUnchanged: boolean;
 }
 
 /** Stored proposal state. Expiry is projected at read time and is never persisted as a status. */
@@ -171,6 +211,7 @@ export interface FakeStashState {
   idempotency: Map<string, Map<string, FakeIdempotencyRow>>;
   gcJobs: Map<GcKind, FakeGcJobRow>;
   gcRuns: GcRunResult[];
+  uploadSessions: Map<string, FakeUploadSessionRow>;
 }
 
 /** Controllable in-memory source backing the fake's authenticated SSE route. */

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -13,7 +13,8 @@ export type Send = (
   path: string,
   query: TransportQuery | undefined,
   headers: Record<string, string>,
-  body: string | undefined,
+  body: BodyInit | null | undefined,
+  signal?: AbortSignal,
 ) => Promise<Response>;
 
 function joinBaseUrl(baseUrl: string, path: string): string {
@@ -28,11 +29,13 @@ function appendQuery(url: string, query: TransportQuery | undefined): string {
 
 /** Creates the existing HTTP/fetch request path without changing its request bytes. */
 export function createFetchSend(fetcher: StashFetch, baseUrl: string): Send {
-  return (method, path, query, headers, body) =>
+  return (method, path, query, headers, body, signal) =>
     fetcher(appendQuery(joinBaseUrl(baseUrl, path), query), {
       method,
       headers,
       ...(body === undefined ? {} : { body }),
+      ...(signal === undefined ? {} : { signal }),
+      ...(body instanceof ReadableStream ? ({ duplex: "half" } as RequestInit) : {}),
     });
 }
 
@@ -44,15 +47,37 @@ function withoutAuthorization(headers: Record<string, string>): Record<string, s
 
 /** Creates an in-process RPC request path. The dedicated token always wins over headers. */
 export function createRpcSend(binding: StashRpcBinding, token: string): Send {
-  return (method, path, query, headers, body) => {
+  return (method, path, query, headers, body, signal) => {
     const rpcHeaders = withoutAuthorization(headers);
-    return binding.request({
+    const needsStreamBridge =
+      body instanceof ReadableStream ||
+      body instanceof Blob ||
+      body instanceof ArrayBuffer ||
+      path === "/v1/capabilities" ||
+      path.includes("/raw/") ||
+      path.includes("/uploads/");
+    if (!needsStreamBridge || binding.requestStream === undefined) {
+      if (needsStreamBridge && body instanceof ReadableStream) {
+        throw new TypeError("The RPC binding does not expose the byte-stream request bridge");
+      }
+      return binding.request({
+        method,
+        path,
+        ...(query === undefined ? {} : { query }),
+        ...(Object.keys(rpcHeaders).length === 0 ? {} : { headers: rpcHeaders }),
+        ...(body === undefined || body === null ? {} : { body: String(body) }),
+        token,
+      });
+    }
+    const serializedQuery = query === undefined ? "" : new URLSearchParams(query).toString();
+    const url = `https://stash.internal${path}${serializedQuery === "" ? "" : `?${serializedQuery}`}`;
+    const request = new Request(url, {
       method,
-      path,
-      ...(query === undefined ? {} : { query }),
-      ...(Object.keys(rpcHeaders).length === 0 ? {} : { headers: rpcHeaders }),
+      headers: rpcHeaders,
       ...(body === undefined ? {} : { body }),
-      token,
+      ...(signal === undefined ? {} : { signal }),
+      ...(body instanceof ReadableStream ? ({ duplex: "half" } as RequestInit) : {}),
     });
+    return binding.requestStream(request, token);
   };
 }

--- a/packages/client/test/testing/fixtures/golden-responses.ts
+++ b/packages/client/test/testing/fixtures/golden-responses.ts
@@ -342,6 +342,10 @@ export const GOLDEN_RESPONSES = {
     createdAt: GOLDEN_CREATED_AT,
     deleted: false,
     body: "hello",
+    representation: "text",
+    contentAccess: "inline",
+    contentType: "text/plain; charset=utf-8",
+    byteSize: 5,
     etag: `"v1-${GOLDEN_HELLO_HASH}"`,
   },
   stale: {
@@ -373,6 +377,10 @@ export const GOLDEN_RESPONSES = {
     createdAt: GOLDEN_CREATED_AT,
     deleted: true,
     body: null,
+    representation: "text",
+    contentAccess: "deleted",
+    contentType: "text/plain; charset=utf-8",
+    byteSize: 0,
     etag: '"v2-deleted"',
   },
 } as const;

--- a/packages/client/test/testing/golden.test.ts
+++ b/packages/client/test/testing/golden.test.ts
@@ -80,6 +80,10 @@ const goldenFileBody = {
   createdAt: GOLDEN_RESPONSES.file.createdAt,
   deleted: GOLDEN_RESPONSES.file.deleted,
   body: GOLDEN_RESPONSES.file.body,
+  representation: GOLDEN_RESPONSES.file.representation,
+  contentAccess: GOLDEN_RESPONSES.file.contentAccess,
+  contentType: GOLDEN_RESPONSES.file.contentType,
+  byteSize: GOLDEN_RESPONSES.file.byteSize,
 };
 
 const rollbackResult = {

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -1,6 +1,6 @@
 import type { RouteMethod } from "./routes.js";
 
-/** A structured-clone-friendly request sent through the stash RPC entrypoint. */
+/** Legacy structured request accepted by the stash RPC entrypoint. */
 export interface RpcRequest {
   method: RouteMethod;
   /** A `/v1/...` path with route parameters substituted and left unencoded. */

--- a/workers/example-rpc-consumer/README.md
+++ b/workers/example-rpc-consumer/README.md
@@ -5,6 +5,9 @@ This private Worker demonstrates a consumer of the History Stash named `StashRpc
 rolls back through the typed RPC transport. It is intended as a deployment and integration
 example, not a public API.
 
+`GET /binary-demo` uploads arbitrary bytes and streams them back through the flow-controlled
+`Request`/`Response` RPC bridge. The bytes never become a serialized/base64 RPC value.
+
 `STASH_TOKEN` is deliberately an empty placeholder in `wrangler.toml` so the binding shape is
 visible. In a real deployment, replace it with a Worker secret:
 

--- a/workers/example-rpc-consumer/src/index.ts
+++ b/workers/example-rpc-consumer/src/index.ts
@@ -12,6 +12,7 @@ export interface Env {
 
 export const DEMO_STASH = "example-rpc-demo";
 export const DEMO_PATH = "demo.txt";
+export const BINARY_DEMO_PATH = "demo.bin";
 const DEMO_BODY = "Written by the example RPC consumer.\n";
 
 function versionForPut(get: FileGetResult): number | null | undefined {
@@ -31,7 +32,8 @@ function rollbackTarget(get: FileGetResult, putVersion: number): number {
  */
 export async function handleRequest(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
-  if (url.pathname !== "/demo") return new Response("Not found", { status: 404 });
+  if (url.pathname !== "/demo" && url.pathname !== "/binary-demo")
+    return new Response("Not found", { status: 404 });
   if (request.method !== "GET") {
     return new Response("Method not allowed", { status: 405, headers: { Allow: "GET" } });
   }
@@ -39,6 +41,28 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
   const client = createStashClient({
     transport: { kind: "rpc", binding: env.STASH_RPC, token: env.STASH_TOKEN },
   });
+  if (url.pathname === "/binary-demo") {
+    const files = client.files(DEMO_STASH);
+    const current = await files.get(BINARY_DEMO_PATH);
+    const expectedVersion = versionForPut(current);
+    if (expectedVersion === undefined) return Response.json({ current }, { status: 500 });
+    const uploaded = await files.upload(
+      BINARY_DEMO_PATH,
+      new Uint8Array([0x89, 0x50, 0x00, 0xff, 0x0d, 0x0a]),
+      {
+        expectedVersion,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        idempotencyKey: `example-rpc-binary-${expectedVersion ?? "new"}`,
+      },
+    );
+    if (!uploaded.ok) return Response.json({ uploaded }, { status: uploaded.error.status });
+    const downloaded = await files.raw.get(BINARY_DEMO_PATH);
+    if (!downloaded.ok || "notModified" in downloaded)
+      return Response.json({ downloaded }, { status: 500 });
+    const bytes = await downloaded.value.bytes(64);
+    return Response.json({ uploaded, bytes: [...bytes] });
+  }
   const files = client.files(DEMO_STASH);
   const get = await files.get(DEMO_PATH);
   const expectedVersion = versionForPut(get);

--- a/workers/stash/src/rpc.ts
+++ b/workers/stash/src/rpc.ts
@@ -78,6 +78,16 @@ function optionalQuery(
 }
 
 export class StashRpc extends WorkerEntrypoint<Env> implements StashRpcMethods {
+  /**
+   * Flow-controlled RPC bridge for raw upload/download bodies. Request and Response are RPC-aware
+   * types, so their streams are not serialized into the RPC value payload.
+   */
+  async requestStream(request: Request, token: string): Promise<Response> {
+    request.headers.delete("authorization");
+    request.headers.set("Authorization", `Bearer ${token}`);
+    return app.fetch(request, this.env, this.ctx);
+  }
+
   async request(init: RpcRequest): Promise<Response> {
     const headers = new Headers(init.headers);
     headers.delete("authorization");

--- a/workers/stash/test/example-consumer.test.ts
+++ b/workers/stash/test/example-consumer.test.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   DEMO_STASH,
+  BINARY_DEMO_PATH,
   handleRequest,
   type Env as ExampleEnv,
 } from "../../example-rpc-consumer/src/index.js";
@@ -76,5 +77,20 @@ describe("example RPC consumer", () => {
     );
     expect(response.status).toBe(405);
     expect(response.headers.get("allow")).toBe("GET");
+  });
+
+  it("streams arbitrary bytes through the named RPC consumer bridge", async () => {
+    await seedStash(DEMO_STASH);
+    const token = await mintToken(DEMO_STASH, "write");
+    const response = await handleRequest(
+      new Request("https://example-consumer.test/binary-demo"),
+      exampleEnv(token.token),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      uploaded: { ok: true, value: { version: 1, representation: "binary", size: 6 } },
+      bytes: [0x89, 0x50, 0x00, 0xff, 0x0d, 0x0a],
+    });
+    expect(BINARY_DEMO_PATH).toBe("demo.bin");
   });
 });

--- a/workers/stash/test/rpc.test.ts
+++ b/workers/stash/test/rpc.test.ts
@@ -483,6 +483,31 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("StashRpc request construction", () => {
+  it("passes Request and Response streams through the flow-controlled bridge", async () => {
+    const upstream = new Response(new Uint8Array([0x00, 0xff, 0x50, 0x4b]), {
+      headers: { "Content-Type": "application/octet-stream" },
+    });
+    const fetchSpy = vi.spyOn(app, "fetch").mockResolvedValueOnce(upstream);
+    const rpc = new StashRpc(createExecutionContext(), createTestEnv().env);
+    const request = new Request("https://stash.internal/v1/stashes/demo/uploads/upl_1/content", {
+      method: "PUT",
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0x89, 0x50, 0x00, 0xff]));
+          controller.close();
+        },
+      }),
+      duplex: "half",
+    } as RequestInit);
+
+    const response = await rpc.requestStream(request, "winner");
+    const [forwarded] = fetchSpy.mock.calls[0]!;
+    expect(forwarded.headers.get("authorization")).toBe("Bearer winner");
+    expect([...new Uint8Array(await forwarded.arrayBuffer())]).toEqual([0x89, 0x50, 0x00, 0xff]);
+    expect(response).toBe(upstream);
+    expect([...new Uint8Array(await response.arrayBuffer())]).toEqual([0x00, 0xff, 0x50, 0x4b]);
+  });
+
   it("dispatches the exact Request, Env, and context to the singleton app and returns its Response", async () => {
     const expected = new Response("same response", {
       status: 202,

--- a/workers/stash/test/rpc.test.ts
+++ b/workers/stash/test/rpc.test.ts
@@ -491,14 +491,8 @@ describe("StashRpc request construction", () => {
     const rpc = new StashRpc(createExecutionContext(), createTestEnv().env);
     const request = new Request("https://stash.internal/v1/stashes/demo/uploads/upl_1/content", {
       method: "PUT",
-      body: new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(new Uint8Array([0x89, 0x50, 0x00, 0xff]));
-          controller.close();
-        },
-      }),
-      duplex: "half",
-    } as RequestInit);
+      body: new Uint8Array([0x89, 0x50, 0x00, 0xff]),
+    });
 
     const response = await rpc.requestStream(request, "winner");
     const [forwarded] = fetchSpy.mock.calls[0]!;

--- a/workers/viewer/src/worker.test.ts
+++ b/workers/viewer/src/worker.test.ts
@@ -22,7 +22,10 @@ describe("viewer proxy", () => {
       headers: {
         authorization: "Bearer secret",
         "content-type": "application/json",
+        "content-length": "11",
         "if-none-match": `"v1-hash"`,
+        "if-range": `"v1-hash"`,
+        range: "bytes=0-10",
         "idempotency-key": "request-1",
         "x-stash-client-id": "tab-viewer-1",
         cookie: "must-not-forward=1",
@@ -38,9 +41,12 @@ describe("viewer proxy", () => {
     const headers = new Headers(forwardedInit?.headers);
     expect([...headers.keys()]).toEqual([
       "authorization",
+      "content-length",
       "content-type",
       "idempotency-key",
       "if-none-match",
+      "if-range",
+      "range",
       "x-stash-client-id",
     ]);
     expect(headers.get("x-stash-client-id")).toBe("tab-viewer-1");

--- a/workers/viewer/src/worker.ts
+++ b/workers/viewer/src/worker.ts
@@ -12,7 +12,10 @@ const FORWARDED_HEADERS = [
   "authorization",
   "content-type",
   "if-none-match",
+  "if-range",
   "idempotency-key",
+  "range",
+  "content-length",
   "x-stash-client-id",
 ] as const;
 


### PR DESCRIPTION
Closes #193
Part of #188

## Summary

- add capability-selected JSON, single-stream, and multipart uploads to the isomorphic SDK
- add streamed current/historical downloads with bounded materializers and cancellation
- carry raw request/response bodies through the named RPC `requestStream()` bridge
- extend the fake backend and HTTP/fetch/RPC conformance with binary/history/replay behavior

## Validation

- 144 Client tests plus Core, Worker RPC, fake, and example-consumer coverage
- package typecheck/lint/build and final integrated `pnpm b4push`
