### PR TITLE
Fix Node-only preview cleanup jobs

### DIFF
--- a/.github/workflows/preview-reaper.yml
+++ b/.github/workflows/preview-reaper.yml
@@ -114,6 +114,7 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22.13.0
+          package-manager-cache: false
 
       - name: Recheck pull request after acquiring the preview lock
         id: pull

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22.13.0
+          package-manager-cache: false
 
       - name: Require an exact closed pull request
         id: pull

--- a/scripts/preview-reaper.test.mjs
+++ b/scripts/preview-reaper.test.mjs
@@ -791,6 +791,10 @@ describe("workflow contracts", () => {
       /workflow_dispatch:[\s\S]*?pr:[\s\S]*?required: true[\s\S]*?type: number/u,
     );
     assert.match(teardown, /contents: read\n\s+pull-requests: write/u);
+    assert.match(
+      teardown,
+      /- name: Setup Node\.js\n\s+uses: actions\/setup-node@[a-f0-9]{40}[^\n]*\n\s+with:\n\s+node-version: 22\.13\.0\n\s+package-manager-cache: false\n\n\s+- name: Require an exact closed pull request/u,
+    );
     assert.equal((teardown.match(/persist-credentials: false/gu) ?? []).length, 2);
     assert.equal(
       (
@@ -824,6 +828,10 @@ describe("workflow contracts", () => {
     assert.match(reaper, /schedule:\n\s+- cron: "17 3 \* \* 0"/u);
     assert.match(reaper, /workflow_dispatch:/u);
     assert.match(reaper, /contents: read\n\s+pull-requests: read/u);
+    assert.match(
+      reaper,
+      /- name: Setup Node\.js\n\s+uses: actions\/setup-node@[a-f0-9]{40}[^\n]*\n\s+with:\n\s+node-version: 22\.13\.0\n\s+package-manager-cache: false\n\n\s+- name: Recheck pull request after acquiring the preview lock/u,
+    );
     assert.equal(reaper.includes("preview-comment.mjs"), false);
     assert.equal((reaper.match(/persist-credentials: false/gu) ?? []).length, 3);
     assert.equal(


### PR DESCRIPTION
## Summary

- disable `setup-node` automatic package-manager caching in the Node-only PR teardown gate
- apply the same guard to the scheduled preview reaper's Node-only cleanup path
- lock both placements with workflow-contract regression assertions

## Why

PR #203's close-triggered teardown failed during `actions/setup-node` before the eligibility gate ran. The action detected the repository's pnpm package-manager declaration and attempted to cache pnpm even though those lightweight jobs intentionally install no package manager.

## Verification

- `node --test scripts/preview-reaper.test.mjs` (21/21)
- `pnpm b4push` (all 10 checks)
- focused workflow/security review: no findings

Follow-up to #203.
