### PR TITLE
Fix non-fork preview teardown validation

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -56,7 +56,8 @@ jobs:
           pull_json="$(node scripts/preview-reaper.mjs check-pr --pr "$PREVIEW_PR_NUMBER")"
           pr="$(jq -er '.pr | select(type == "number" and floor == . and . >= 1)' <<<"$pull_json")"
           state="$(jq -er '.state | select(. == "open" or . == "closed")' <<<"$pull_json")"
-          fork="$(jq -er '.fork | select(type == "boolean")' <<<"$pull_json")"
+          jq -e '.fork | type == "boolean"' <<<"$pull_json" >/dev/null
+          fork="$(jq -r '.fork' <<<"$pull_json")"
           [[ "$pr" == "$PREVIEW_PR_NUMBER" ]]
           [[ "$state" == "closed" ]]
           {

--- a/scripts/preview-reaper.test.mjs
+++ b/scripts/preview-reaper.test.mjs
@@ -795,6 +795,11 @@ describe("workflow contracts", () => {
       teardown,
       /- name: Setup Node\.js\n\s+uses: actions\/setup-node@[a-f0-9]{40}[^\n]*\n\s+with:\n\s+node-version: 22\.13\.0\n\s+package-manager-cache: false\n\n\s+- name: Require an exact closed pull request/u,
     );
+    assert.match(
+      teardown,
+      /jq -e '\.fork \| type == "boolean"' <<<"\$pull_json" >\/dev\/null\n\s+fork="\$\(jq -r '\.fork' <<<"\$pull_json"\)"/u,
+    );
+    assert.equal(teardown.includes('.fork | select(type == "boolean")'), false);
     assert.equal((teardown.match(/persist-credentials: false/gu) ?? []).length, 2);
     assert.equal(
       (


### PR DESCRIPTION
## Summary

- accept valid same-repository pull-request evidence where `fork` is `false`
- keep malformed, missing, and non-boolean fork evidence fail-closed
- lock the corrected validation/extraction sequence into the workflow contract tests

## Cause

`jq -e` treats the valid JSON value `false` as an unsuccessful result. The teardown gate combined boolean type validation with extraction, so every same-repository PR aborted before credential gating.

The workflow now validates the JSON type separately, then extracts the exact boolean value.

## Verification

- `node --test scripts/preview-reaper.test.mjs` (21/21)
- exact closed-PR gate reproduction for PR #203 (`state=closed`, `fork=false`)
- malformed/missing/null/string/number fork matrix fails closed
- independent focused review: no findings
- `pnpm b4push` (all 10 steps passed)

Follow-up to #203 and #204.
