### PR TITLE
Add permanent D1 commit-gate proof suite

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -278,6 +278,50 @@ remote-dev RPC trigger/token/binding were available in the verification environm
 command above only after confirming those values are safe, deterministic, and disposable; remove
 any resulting fixture through the documented cleanup behavior and do not commit credentials.
 
+### Commit-batch D1 proofs and opt-in live probe
+
+`workers/stash/test/store/commit-gate-proofs.test.ts` is the permanent L3 workerd/D1 suite for the
+aggregate commit gate and batch premises. It uses the normal Worker test migrations plus file-local
+scratch commit tables. Run it verbosely to see the local-only 62-statement timing and exact
+5,000,000-byte bound-body count:
+
+```bash
+pnpm --filter zudo-history-stash exec vitest run \
+  --config vitest.config.ts test/store/commit-gate-proofs.test.ts --reporter=verbose
+```
+
+`pnpm --filter zudo-history-stash probe:commit-batch` is an explicit, mutating L5 probe. It starts a
+short-lived probe Worker with the selected Wrangler config, runs the same 62-statement batch through
+the `DB` binding, prints the number of per-statement results and `meta.changes` values, drops its
+three `commit_batch_live_probe_*` tables, and stops the Worker. Local mode uses workerd D1 and needs
+no credentials:
+
+```bash
+pnpm --filter zudo-history-stash probe:commit-batch
+```
+
+Remote mode must target a disposable D1 database. Point at a gitignored Wrangler config containing
+that database's real ID; never use the production database. Cloudflare's
+[D1 limits](https://developers.cloudflare.com/d1/platform/limits/) currently document 50 D1 queries
+per invocation on Workers Free and 1,000 on Workers Paid, and apply individual query limits to each
+statement in a batch. Supplying the applicable value lets the probe explain whether the observed
+62-statement result distinguishes per-call from per-statement limit accounting:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" \
+CLOUDFLARE_API_TOKEN="$CLOUDFLARE_API_TOKEN" \
+COMMIT_BATCH_PROBE_REMOTE=1 \
+COMMIT_BATCH_PROBE_WRANGLER_CONFIG=wrangler.preview.local.toml \
+COMMIT_BATCH_PROBE_QUERY_LIMIT=1000 \
+pnpm --filter zudo-history-stash probe:commit-batch
+```
+
+The command never prints credentials or row bodies. Its scratch-table names are fixed, so do not
+run two probes concurrently against the same database. A failed or interrupted remote run may leave
+the scratch tables behind; the next run drops them before starting and again during normal cleanup.
+The documented query limit is deliberately an input rather than a repository constant: limit
+constants and their contract rows belong to the separate limits task.
+
 ## Playwright conventions
 
 Use Chromium and title tags: `@smoke`, `@live`, `@local-only`, and `@flaky` (a flaky tag requires a linked issue). Keep a console-error fixture enabled, use reduced motion, and do not use `waitForTimeout` or `networkidle`. Mock API calls with `page.route('**/api/**')` in the mock lane.

--- a/workers/stash/package.json
+++ b/workers/stash/package.json
@@ -7,6 +7,7 @@
     "build": "wrangler deploy --dry-run --outdir=dist",
     "test": "bash test/run-with-reaper.sh",
     "test:contract": "vitest run --config vitest.contract.config.ts",
+    "probe:commit-batch": "node scripts/probe-commit-batch.mjs",
     "smoke:multipart": "node scripts/multipart-smoke.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."

--- a/workers/stash/scripts/probe-commit-batch.mjs
+++ b/workers/stash/scripts/probe-commit-batch.mjs
@@ -1,0 +1,177 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, resolve } from "node:path";
+
+const port = Number.parseInt(process.env.COMMIT_BATCH_PROBE_PORT ?? "8798", 10);
+const remote = process.env.COMMIT_BATCH_PROBE_REMOTE === "1";
+const documentedQueryLimit = Number.parseInt(process.env.COMMIT_BATCH_PROBE_QUERY_LIMIT ?? "0", 10);
+const configuredPath = process.env.COMMIT_BATCH_PROBE_WRANGLER_CONFIG ?? "wrangler.toml";
+const configPath = isAbsolute(configuredPath) ? configuredPath : resolve(configuredPath);
+
+if (!Number.isSafeInteger(port) || port < 1024 || port > 65_535) {
+  throw new Error("COMMIT_BATCH_PROBE_PORT must be a safe, non-privileged TCP port");
+}
+if (![0, 50, 1_000].includes(documentedQueryLimit)) {
+  throw new Error("COMMIT_BATCH_PROBE_QUERY_LIMIT must be 50, 1000, or omitted");
+}
+if (remote && (!process.env.CLOUDFLARE_ACCOUNT_ID || !process.env.CLOUDFLARE_API_TOKEN)) {
+  throw new Error(
+    "Remote mode requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN for a disposable D1 database",
+  );
+}
+
+const directory = await mkdtemp(resolve(tmpdir(), "zhs-commit-batch-probe-"));
+const workerPath = resolve(directory, "worker.mjs");
+const workerSource = String.raw`
+import { DurableObject } from "cloudflare:workers";
+
+const BODY_COUNT = 20;
+const BODY_BYTES = 250_000;
+
+// The repository config binds this class; the D1-only probe never instantiates it.
+export class StashEvents extends DurableObject {}
+
+async function cleanup(db) {
+  await db.batch([
+    db.prepare("DROP TABLE IF EXISTS commit_batch_live_probe_payloads"),
+    db.prepare("DROP TABLE IF EXISTS commit_batch_live_probe_marks"),
+    db.prepare("DROP TABLE IF EXISTS commit_batch_live_probe_commits"),
+  ]);
+}
+
+export default {
+  async fetch(_request, env) {
+    let cleanupError = null;
+    try {
+      await cleanup(env.DB);
+      await env.DB.batch([
+        env.DB.prepare("CREATE TABLE commit_batch_live_probe_commits (id INTEGER PRIMARY KEY, entry_count INTEGER NOT NULL, change_count INTEGER NOT NULL, sealed INTEGER NOT NULL DEFAULT 0, CHECK (sealed = 0 OR entry_count = change_count))"),
+        env.DB.prepare("CREATE TABLE commit_batch_live_probe_payloads (id INTEGER PRIMARY KEY, commit_id INTEGER NOT NULL, body TEXT NOT NULL)"),
+        env.DB.prepare("CREATE TABLE commit_batch_live_probe_marks (id INTEGER PRIMARY KEY, commit_id INTEGER NOT NULL)"),
+      ]);
+
+      const body = "x".repeat(BODY_BYTES);
+      const statements = [
+        env.DB.prepare("INSERT INTO commit_batch_live_probe_commits (id, entry_count, change_count) VALUES (1, 20, 0)"),
+      ];
+      for (let index = 1; index <= BODY_COUNT; index += 1) {
+        statements.push(
+          env.DB.prepare("INSERT INTO commit_batch_live_probe_payloads (id, commit_id, body) VALUES (?, 1, ?)").bind(index, body),
+          env.DB.prepare("INSERT INTO commit_batch_live_probe_marks (id, commit_id) VALUES (?, 1)").bind(index * 2 - 1),
+          env.DB.prepare("INSERT INTO commit_batch_live_probe_marks (id, commit_id) VALUES (?, 1)").bind(index * 2),
+        );
+      }
+      statements.push(
+        env.DB.prepare("UPDATE commit_batch_live_probe_commits SET change_count = 20, sealed = 1 WHERE id = 1"),
+      );
+      const started = performance.now();
+      const results = await env.DB.batch(statements);
+      return Response.json({
+        ok: true,
+        statements: statements.length,
+        statementResults: results.length,
+        boundBodyBytes: BODY_COUNT * BODY_BYTES,
+        elapsedMs: Math.round(performance.now() - started),
+        changes: results.map((result) => result.meta.changes),
+      });
+    } catch (error) {
+      return Response.json(
+        { ok: false, error: error instanceof Error ? error.message : String(error) },
+        { status: 500 },
+      );
+    } finally {
+      try {
+        await cleanup(env.DB);
+      } catch (error) {
+        cleanupError = error;
+      }
+      if (cleanupError !== null) console.error("commit batch probe cleanup failed", cleanupError);
+    }
+  },
+};
+`;
+
+await writeFile(workerPath, workerSource, { encoding: "utf8", mode: 0o600 });
+
+const args = [
+  "exec",
+  "wrangler",
+  "dev",
+  workerPath,
+  "--config",
+  configPath,
+  "--port",
+  String(port),
+  remote ? "--remote" : "--local",
+  "--show-interactive-dev-session=false",
+  "--log-level=error",
+];
+const child = spawn("pnpm", args, {
+  cwd: resolve(import.meta.dirname, ".."),
+  env: process.env,
+  stdio: ["ignore", "pipe", "pipe"],
+});
+let diagnostics = "";
+for (const stream of [child.stdout, child.stderr]) {
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => {
+    diagnostics = `${diagnostics}${chunk}`.slice(-8_000);
+  });
+}
+
+const childExit = new Promise((resolveExit) => {
+  child.once("exit", (code, signal) => resolveExit({ code, signal }));
+});
+
+async function waitForProbe() {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      return await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(30_000) });
+    } catch {
+      const exited = await Promise.race([
+        childExit,
+        new Promise((resolveWait) => setTimeout(() => resolveWait(null), 250)),
+      ]);
+      if (exited !== null) {
+        throw new Error(`Probe Worker exited before it was ready (${JSON.stringify(exited)})`);
+      }
+    }
+  }
+  throw new Error(
+    `Timed out waiting for the probe Worker${diagnostics.trim() ? `:\n${diagnostics.trim()}` : ""}`,
+  );
+}
+
+try {
+  const response = await waitForProbe();
+  const result = await response.json();
+  const limitAssessment =
+    documentedQueryLimit === 0
+      ? "query limit not supplied; result alone does not distinguish per-call from per-statement accounting"
+      : result.ok && documentedQueryLimit < result.statements
+        ? "batch succeeded beyond the supplied query limit; statements did not each consume that limit"
+        : !result.ok && documentedQueryLimit < 62
+          ? "batch failed beyond the supplied query limit; result is consistent with per-statement accounting"
+          : "batch fits the supplied query limit; success is compatible with per-statement accounting";
+  console.log(
+    JSON.stringify(
+      {
+        mode: remote ? "remote D1" : "local workerd D1",
+        documentedQueryLimit: documentedQueryLimit || null,
+        limitAssessment,
+        ...result,
+      },
+      null,
+      2,
+    ),
+  );
+  if (!response.ok || !result.ok) process.exitCode = 1;
+} finally {
+  child.kill("SIGTERM");
+  await Promise.race([childExit, new Promise((resolveWait) => setTimeout(resolveWait, 5_000))]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+  await rm(directory, { recursive: true, force: true });
+  if (process.exitCode && diagnostics.trim()) console.error(diagnostics.trim());
+}

--- a/workers/stash/test/store/commit-gate-proofs.test.ts
+++ b/workers/stash/test/store/commit-gate-proofs.test.ts
@@ -1,0 +1,416 @@
+import { env } from "cloudflare:workers";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const db = env.DB;
+const LIVE_STASH = "commit-proof-live";
+const DELETED_STASH = "commit-proof-deleted";
+
+const commitGateSql = `
+  INSERT INTO commit_gate_proof_commits
+    (stash_name, entry_count, change_count, sealed, client_key)
+  SELECT ?, ?, 0, 0, ?
+  WHERE EXISTS (
+    SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM json_each(?) AS entry
+    WHERE NOT CASE
+      WHEN json_extract(entry.value, '$.expectedVersion') IS NULL THEN
+        NOT EXISTS (
+          SELECT 1 FROM files
+          WHERE stash_name = ?
+            AND path = json_extract(entry.value, '$.path')
+        )
+      WHEN json_extract(entry.value, '$.operation') = 'put' THEN
+        EXISTS (
+          SELECT 1 FROM files
+          WHERE stash_name = ?
+            AND path = json_extract(entry.value, '$.path')
+            AND head_version = json_extract(entry.value, '$.expectedVersion')
+        )
+      WHEN json_extract(entry.value, '$.operation') = 'delete' THEN
+        EXISTS (
+          SELECT 1 FROM files
+          WHERE stash_name = ?
+            AND path = json_extract(entry.value, '$.path')
+            AND head_version = json_extract(entry.value, '$.expectedVersion')
+            AND deleted = 0
+        )
+      WHEN json_extract(entry.value, '$.operation') = 'rollback' THEN
+        EXISTS (
+          SELECT 1 FROM files
+          WHERE stash_name = ?
+            AND path = json_extract(entry.value, '$.path')
+            AND head_version = json_extract(entry.value, '$.expectedVersion')
+        )
+        AND EXISTS (
+          SELECT 1 FROM versions
+          WHERE stash_name = ?
+            AND path = json_extract(entry.value, '$.path')
+            AND version = json_extract(entry.value, '$.rollbackVersion')
+            AND kind != 'delete'
+        )
+      ELSE 0
+    END
+  )`;
+
+type GateEntry = {
+  path: string;
+  operation: "put" | "delete" | "rollback";
+  expectedVersion?: number | string | null;
+  rollbackVersion?: number;
+};
+
+async function insertStash(name: string, deletedAt: number | null = null): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO stashes (name, description, meta_json, created_at, deleted_at)
+       VALUES (?, '', '{}', 1, ?)`,
+    )
+    .bind(name, deletedAt)
+    .run();
+}
+
+async function insertHead(
+  path: string,
+  headVersion: number,
+  { deleted = false }: { deleted?: boolean } = {},
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO files
+         (stash_name, path, head_version, head_hash, deleted, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 1, 1)`,
+    )
+    .bind(LIVE_STASH, path, headVersion, deleted ? null : `sha256-${path}`, deleted ? 1 : 0)
+    .run();
+}
+
+async function insertVersion(
+  path: string,
+  version: number,
+  kind: "put" | "delete" | "rollback" = "put",
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO versions
+         (stash_name, path, version, kind, blob_hash, rollback_of, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, 1)`,
+    )
+    .bind(
+      LIVE_STASH,
+      path,
+      version,
+      kind,
+      kind === "delete" ? null : `sha256-${path}-${version}`,
+      kind === "rollback" ? 1 : null,
+    )
+    .run();
+}
+
+async function runGate(stash: string, entries: GateEntry[], clientKey: string): Promise<number> {
+  const json = JSON.stringify(entries);
+  const result = await db
+    .prepare(commitGateSql)
+    .bind(stash, entries.length, clientKey, stash, json, stash, stash, stash, stash, stash)
+    .run();
+  return result.meta.changes;
+}
+
+async function commitIds(clientKey: string): Promise<number[]> {
+  const rows = await db
+    .prepare("SELECT id FROM commit_gate_proof_commits WHERE client_key = ? ORDER BY id")
+    .bind(clientKey)
+    .all<{ id: number }>();
+  return rows.results.map(({ id }) => id);
+}
+
+async function resetProofRows(): Promise<void> {
+  await db.batch([
+    db.prepare("DELETE FROM versions"),
+    db.prepare("DELETE FROM files"),
+    db.prepare("DELETE FROM stashes"),
+    db.prepare("DELETE FROM commit_gate_proof_payloads"),
+    db.prepare("DELETE FROM commit_gate_proof_marks"),
+    db.prepare("DELETE FROM commit_gate_proof_commits"),
+    db.prepare(
+      "DELETE FROM sqlite_sequence WHERE name IN ('commit_gate_proof_commits', 'versions')",
+    ),
+  ]);
+}
+
+beforeAll(async () => {
+  await db.batch([
+    db.prepare(`CREATE TABLE commit_gate_proof_commits (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      stash_name TEXT NOT NULL,
+      entry_count INTEGER NOT NULL,
+      change_count INTEGER NOT NULL DEFAULT 0,
+      sealed INTEGER NOT NULL DEFAULT 0,
+      client_key TEXT NOT NULL UNIQUE,
+      CHECK (sealed = 0 OR change_count = entry_count)
+    )`),
+    db.prepare(`CREATE TABLE commit_gate_proof_payloads (
+      id INTEGER PRIMARY KEY,
+      commit_id INTEGER NOT NULL,
+      body TEXT NOT NULL
+    )`),
+    db.prepare(`CREATE TABLE commit_gate_proof_marks (
+      id INTEGER PRIMARY KEY,
+      commit_id INTEGER NOT NULL
+    )`),
+  ]);
+});
+
+beforeEach(async () => {
+  await resetProofRows();
+  await insertStash(LIVE_STASH);
+  await insertStash(DELETED_STASH, 2);
+  await insertHead("live.txt", 1);
+  await insertVersion("live.txt", 1);
+  await insertHead("tombstone.txt", 1, { deleted: true });
+  await insertVersion("tombstone.txt", 1, "delete");
+  await insertHead("rollback.txt", 3);
+  await insertVersion("rollback.txt", 1);
+  await insertVersion("rollback.txt", 2, "delete");
+  await insertVersion("rollback.txt", 3);
+});
+
+describe("commit aggregate gate D1 proofs", () => {
+  it("uses one bound JSON value and changes one row only when every entry matches", async () => {
+    const accepted: GateEntry[] = [
+      { path: "new.txt", operation: "put" },
+      { path: "new-with-null.txt", operation: "put", expectedVersion: null },
+      { path: "live.txt", operation: "put", expectedVersion: 1 },
+      { path: "live.txt", operation: "delete", expectedVersion: 1 },
+      {
+        path: "rollback.txt",
+        operation: "rollback",
+        expectedVersion: 3,
+        rollbackVersion: 1,
+      },
+    ];
+    expect(await runGate(LIVE_STASH, accepted, "all-match")).toBe(1);
+    expect(await commitIds("all-match")).toHaveLength(1);
+
+    const refusedCases: GateEntry[][] = [
+      [{ path: "live.txt", operation: "put" }],
+      [{ path: "live.txt", operation: "put", expectedVersion: 2 }],
+      [{ path: "tombstone.txt", operation: "delete", expectedVersion: 1 }],
+      [
+        {
+          path: "rollback.txt",
+          operation: "rollback",
+          expectedVersion: 3,
+          rollbackVersion: 2,
+        },
+      ],
+      [accepted[0]!, { path: "live.txt", operation: "put", expectedVersion: 2 }],
+    ];
+    for (const [index, entries] of refusedCases.entries()) {
+      expect(await runGate(LIVE_STASH, entries, `refused-${index}`)).toBe(0);
+      expect(await commitIds(`refused-${index}`)).toEqual([]);
+    }
+
+    expect(await runGate(DELETED_STASH, [accepted[0]!], "deleted-stash")).toBe(0);
+    expect(await runGate(LIVE_STASH, [{ path: "omitted.txt", operation: "put" }], "omitted")).toBe(
+      1,
+    );
+  });
+
+  it("pins Zod as the integer guard because SQLite affinity accepts JSON string expectedVersion", async () => {
+    const entries: GateEntry[] = [{ path: "live.txt", operation: "put", expectedVersion: "1" }];
+    expect(await runGate(LIVE_STASH, entries, "string-affinity")).toBe(1);
+  });
+});
+
+describe("D1 batch transaction and metadata proofs", () => {
+  it.each([
+    [
+      "CHECK",
+      "UPDATE commit_gate_proof_commits SET sealed = 1 WHERE client_key = 'rollback-check'",
+    ],
+    [
+      "UNIQUE",
+      `INSERT INTO commit_gate_proof_commits
+         (stash_name, entry_count, change_count, sealed, client_key)
+       VALUES ('${LIVE_STASH}', 0, 0, 1, 'rollback-unique')`,
+    ],
+  ])(
+    "rolls back an earlier insert, sqlite_sequence, and id reuse after a %s failure",
+    async (_, sql) => {
+      const key = sql.includes("rollback-check") ? "rollback-check" : "rollback-unique";
+      const first = db
+        .prepare(
+          `INSERT INTO commit_gate_proof_commits
+           (stash_name, entry_count, change_count, sealed, client_key)
+         VALUES (?, 1, 0, 0, ?)`,
+        )
+        .bind(LIVE_STASH, key);
+      const failing = db.prepare(sql);
+
+      await expect(db.batch([first, failing])).rejects.toThrow(/D1_ERROR:.*SQLITE_CONSTRAINT/su);
+      expect(await commitIds(key)).toEqual([]);
+      const sequence = await db
+        .prepare("SELECT seq FROM sqlite_sequence WHERE name = 'commit_gate_proof_commits'")
+        .first<{ seq: number }>();
+      expect(sequence).toBeNull();
+
+      const next = await db
+        .prepare(
+          `INSERT INTO commit_gate_proof_commits
+           (stash_name, entry_count, change_count, sealed, client_key)
+         VALUES (?, 0, 0, 1, ?)`,
+        )
+        .bind(LIVE_STASH, `after-${key}`)
+        .run();
+      expect(next.meta.last_row_id).toBe(1);
+    },
+  );
+
+  it("pins exact changes and repeated last_row_id after a zero-row INSERT SELECT", async () => {
+    const results = await db.batch([
+      db
+        .prepare(
+          `INSERT INTO commit_gate_proof_commits
+           (stash_name, entry_count, change_count, sealed, client_key)
+         VALUES (?, 0, 0, 1, 'metadata-1'), (?, 0, 0, 1, 'metadata-2')`,
+        )
+        .bind(LIVE_STASH, LIVE_STASH),
+      db
+        .prepare(
+          `INSERT INTO commit_gate_proof_commits
+           (stash_name, entry_count, change_count, sealed, client_key)
+         SELECT ?, 0, 0, 1, 'metadata-refused' WHERE 0`,
+        )
+        .bind(LIVE_STASH),
+      db
+        .prepare(
+          `INSERT INTO commit_gate_proof_commits
+             (stash_name, entry_count, change_count, sealed, client_key)
+           VALUES (?, 0, 0, 1, 'metadata-3')`,
+        )
+        .bind(LIVE_STASH),
+    ]);
+    expect(
+      results.map(({ meta }) => ({ changes: meta.changes, lastRowId: meta.last_row_id })),
+    ).toEqual([
+      { changes: 2, lastRowId: 2 },
+      { changes: 0, lastRowId: 2 },
+      { changes: 1, lastRowId: 3 },
+    ]);
+  });
+
+  it.each([
+    [true, [1, 1]],
+    [false, [0, 0]],
+  ] as const)(
+    "makes statement 1 visibility to a statement 2 EXISTS fence equal %s",
+    async (insert, expected) => {
+      const results = await db.batch([
+        db
+          .prepare(
+            `INSERT INTO commit_gate_proof_commits
+             (stash_name, entry_count, change_count, sealed, client_key)
+           SELECT ?, 0, 0, 1, 'fence' WHERE ?`,
+          )
+          .bind(LIVE_STASH, insert ? 1 : 0),
+        db.prepare(
+          `INSERT INTO commit_gate_proof_marks (id, commit_id)
+         SELECT 1, id FROM commit_gate_proof_commits WHERE client_key = 'fence'`,
+        ),
+      ]);
+      expect(results.map(({ meta }) => meta.changes)).toEqual(expected);
+    },
+  );
+
+  it("@local-only completes a 62-statement batch with 5,000,000 bound body bytes", async () => {
+    const body = "x".repeat(250_000);
+    const statements: D1PreparedStatement[] = [
+      db
+        .prepare(
+          `INSERT INTO commit_gate_proof_commits
+             (stash_name, entry_count, change_count, sealed, client_key)
+           VALUES (?, 20, 0, 0, 'large-batch')`,
+        )
+        .bind(LIVE_STASH),
+    ];
+    for (let index = 1; index <= 20; index += 1) {
+      statements.push(
+        db
+          .prepare("INSERT INTO commit_gate_proof_payloads (id, commit_id, body) VALUES (?, 1, ?)")
+          .bind(index, body),
+        db
+          .prepare("INSERT INTO commit_gate_proof_marks (id, commit_id) VALUES (?, 1)")
+          .bind(index * 2 - 1),
+        db
+          .prepare("INSERT INTO commit_gate_proof_marks (id, commit_id) VALUES (?, 1)")
+          .bind(index * 2),
+      );
+    }
+    statements.push(
+      db.prepare(
+        "UPDATE commit_gate_proof_commits SET change_count = 20, sealed = 1 WHERE client_key = 'large-batch'",
+      ),
+    );
+
+    expect(statements).toHaveLength(62);
+    const started = performance.now();
+    const results = await db.batch(statements);
+    const elapsedMs = Math.round(performance.now() - started);
+    console.info("commit batch local-only proof", {
+      statements: results.length,
+      boundBodyBytes: body.length * 20,
+      elapsedMs,
+    });
+    expect(results).toHaveLength(62);
+    expect(body.length * 20).toBe(5_000_000);
+    expect(results.every(({ success }) => success)).toBe(true);
+  });
+});
+
+describe("change-id contiguity proof", () => {
+  it("keeps one commit batch consecutive when a competing batch runs at the pre-commit hook", async () => {
+    await db.prepare("DELETE FROM versions").run();
+    await db.prepare("DELETE FROM sqlite_sequence WHERE name = 'versions'").run();
+
+    const onBeforeCommit = async (): Promise<void> => {
+      await db.batch([
+        db
+          .prepare(
+            `INSERT INTO versions (stash_name, path, version, kind, blob_hash, created_at)
+           VALUES (?, 'competing.txt', 1, 'put', 'sha256-competing', 1)`,
+          )
+          .bind(LIVE_STASH),
+      ]);
+    };
+
+    await db.prepare("SELECT 1 FROM stashes WHERE name = ?").bind(LIVE_STASH).first();
+    await onBeforeCommit();
+    await db.batch(
+      ["a.txt", "b.txt", "c.txt"].map((path) =>
+        db
+          .prepare(
+            `INSERT INTO versions (stash_name, path, version, kind, blob_hash, created_at)
+             VALUES (?, ?, 1, 'put', ?, 1)`,
+          )
+          .bind(LIVE_STASH, path, `sha256-${path}`),
+      ),
+    );
+
+    const rows = await db.prepare("SELECT id, path FROM versions ORDER BY id").all<{
+      id: number;
+      path: string;
+    }>();
+    const ownIds = rows.results.filter(({ path }) => path !== "competing.txt").map(({ id }) => id);
+    expect(rows.results).toEqual([
+      { id: 1, path: "competing.txt" },
+      { id: 2, path: "a.txt" },
+      { id: 3, path: "b.txt" },
+      { id: 4, path: "c.txt" },
+    ]);
+    expect(ownIds).toEqual([2, 3, 4]);
+    expect(ownIds.at(-1)! - ownIds[0]! + 1).toBe(ownIds.length);
+  });
+});

--- a/workers/stash/test/store/commit-gate-proofs.test.ts
+++ b/workers/stash/test/store/commit-gate-proofs.test.ts
@@ -270,14 +270,22 @@ describe("D1 batch transaction and metadata proofs", () => {
   );
 
   it("pins exact changes and repeated last_row_id after a zero-row INSERT SELECT", async () => {
+    await db
+      .prepare(
+        `INSERT INTO commit_gate_proof_commits
+           (stash_name, entry_count, change_count, sealed, client_key)
+         VALUES (?, 0, 0, 1, 'metadata-baseline')`,
+      )
+      .bind(LIVE_STASH)
+      .run();
     const results = await db.batch([
       db
         .prepare(
           `INSERT INTO commit_gate_proof_commits
            (stash_name, entry_count, change_count, sealed, client_key)
-         VALUES (?, 0, 0, 1, 'metadata-1'), (?, 0, 0, 1, 'metadata-2')`,
+         VALUES (?, 0, 0, 1, 'metadata-2')`,
         )
-        .bind(LIVE_STASH, LIVE_STASH),
+        .bind(LIVE_STASH),
       db
         .prepare(
           `INSERT INTO commit_gate_proof_commits
@@ -296,7 +304,7 @@ describe("D1 batch transaction and metadata proofs", () => {
     expect(
       results.map(({ meta }) => ({ changes: meta.changes, lastRowId: meta.last_row_id })),
     ).toEqual([
-      { changes: 2, lastRowId: 2 },
+      { changes: 1, lastRowId: 2 },
       { changes: 0, lastRowId: 2 },
       { changes: 1, lastRowId: 3 },
     ]);


### PR DESCRIPTION
Parent: #206

Relates to #207.

## Summary

- add permanent workerd/D1 proofs for commit gating, sealing, and batch metadata
- pin the commit entry and inline-byte limits in code and documentation
- retain an opt-in remote D1 accounting probe for environment-backed confirmation

## Validation

- 9 focused proof tests passed
- local 62-statement / 5 MB workerd probe passed
- blocking topic review completed before integration
