### PR TITLE
Persist uniform commit records for every write

### DIFF
--- a/workers/stash/migrations/0009_commits.sql
+++ b/workers/stash/migrations/0009_commits.sql
@@ -1,0 +1,78 @@
+CREATE TABLE commits (
+  id                TEXT PRIMARY KEY,
+  stash_name        TEXT NOT NULL REFERENCES stashes(name),
+  source            TEXT NOT NULL CHECK (source IN ('put','delete','rollback','import','upload','change-set','revert','commit')),
+  source_id         TEXT,
+  author            TEXT NOT NULL DEFAULT '',
+  message           TEXT NOT NULL DEFAULT '',
+  meta_json         TEXT NOT NULL DEFAULT '{}',
+  entry_count       INTEGER NOT NULL CHECK (entry_count > 0),
+  change_count      INTEGER NOT NULL DEFAULT 0,
+  sealed            INTEGER NOT NULL DEFAULT 0 CHECK (sealed IN (0,1)),
+  first_change_id   INTEGER,
+  last_change_id    INTEGER,
+  reverts_commit_id TEXT,
+  idempotency_key   TEXT,
+  request_hash      TEXT,
+  created_by        TEXT NOT NULL,
+  created_at        INTEGER NOT NULL,
+  CHECK (sealed = 0 OR (
+    change_count = entry_count
+    AND first_change_id IS NOT NULL
+    AND last_change_id IS NOT NULL
+  ))
+);
+
+CREATE INDEX commits_stash_created ON commits (stash_name, created_at, id);
+CREATE UNIQUE INDEX commits_stash_idempotency
+  ON commits (stash_name, idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX commits_stash_last_change ON commits (stash_name, last_change_id);
+
+INSERT INTO commits (
+  id, stash_name, source, source_id, author, message, meta_json,
+  entry_count, change_count, sealed, first_change_id, last_change_id,
+  reverts_commit_id, idempotency_key, request_hash, created_by, created_at
+)
+SELECT
+  'cmt_legacy_' || id, stash_name, kind, NULL, author, message, meta_json,
+  1, 1, 1, id, id, NULL, NULL, NULL, 'legacy', created_at
+FROM versions;
+
+CREATE TABLE versions_new (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  stash_name        TEXT NOT NULL REFERENCES stashes(name),
+  path              TEXT NOT NULL,
+  version           INTEGER NOT NULL,
+  kind              TEXT NOT NULL CHECK (kind IN ('put','delete','rollback')),
+  blob_hash         TEXT,
+  size_bytes        INTEGER NOT NULL DEFAULT 0,
+  content_type      TEXT NOT NULL DEFAULT 'text/plain; charset=utf-8',
+  rollback_of       INTEGER,
+  author            TEXT NOT NULL DEFAULT '',
+  message           TEXT NOT NULL DEFAULT '',
+  meta_json         TEXT NOT NULL DEFAULT '{}',
+  created_at        INTEGER NOT NULL,
+  representation    TEXT NOT NULL DEFAULT 'text' CHECK (representation IN ('text','binary')),
+  application_etag  TEXT,
+  content_storage   TEXT NOT NULL DEFAULT 'legacy' CHECK (content_storage IN ('legacy','bytes')),
+  commit_id         TEXT NOT NULL REFERENCES commits(id),
+  UNIQUE (stash_name, path, version),
+  CHECK ((kind = 'delete') = (blob_hash IS NULL)),
+  CHECK ((kind = 'rollback') = (rollback_of IS NOT NULL))
+);
+
+INSERT INTO versions_new (
+  id, stash_name, path, version, kind, blob_hash, size_bytes, content_type,
+  rollback_of, author, message, meta_json, created_at, representation,
+  application_etag, content_storage, commit_id
+)
+SELECT
+  id, stash_name, path, version, kind, blob_hash, size_bytes, content_type,
+  rollback_of, author, message, meta_json, created_at, representation,
+  application_etag, content_storage, 'cmt_legacy_' || id
+FROM versions;
+
+DROP TABLE versions;
+ALTER TABLE versions_new RENAME TO versions;
+CREATE INDEX versions_stash_id ON versions (stash_name, id);
+CREATE INDEX versions_stash_commit ON versions (stash_name, commit_id);

--- a/workers/stash/migrations/0009_commits.sql
+++ b/workers/stash/migrations/0009_commits.sql
@@ -1,5 +1,5 @@
 CREATE TABLE commits (
-  id                TEXT PRIMARY KEY,
+  id                TEXT PRIMARY KEY, /* 'cmt_' + 13-digit epoch ms + 8 hex; legacy: 'cmt_legacy_' || versions.id */
   stash_name        TEXT NOT NULL REFERENCES stashes(name),
   source            TEXT NOT NULL CHECK (source IN ('put','delete','rollback','import','upload','change-set','revert','commit')),
   source_id         TEXT,

--- a/workers/stash/src/d1/admin-store.ts
+++ b/workers/stash/src/d1/admin-store.ts
@@ -162,6 +162,7 @@ const UPDATE_ROTATION_PREDECESSOR = `
 const CHANGES_ASC = `
   SELECT
     v.id AS change_id,
+    v.commit_id AS commit_id,
     v.stash_name AS stash,
     v.path,
     v.version,
@@ -184,6 +185,7 @@ const CHANGES_ASC = `
 const CHANGES_BEFORE = `
   SELECT
     v.id AS change_id,
+    v.commit_id AS commit_id,
     v.stash_name AS stash,
     v.path,
     v.version,
@@ -206,6 +208,7 @@ const CHANGES_BEFORE = `
 const CHANGES_NEWEST = `
   SELECT
     v.id AS change_id,
+    v.commit_id AS commit_id,
     v.stash_name AS stash,
     v.path,
     v.version,
@@ -258,6 +261,7 @@ interface TokenListRow {
 
 interface ChangeRow {
   change_id: number;
+  commit_id: string;
   stash: string;
   path: string;
   version: number;
@@ -448,7 +452,7 @@ function mapChange(row: ChangeRow, jsonInlineMaxBytes: number): ChangeItem {
   }
   return {
     changeId: row.change_id,
-    commitId: `legacy:${row.change_id}`,
+    commitId: row.commit_id,
     stash: row.stash,
     path: row.path,
     version: row.version,

--- a/workers/stash/src/d1/import.ts
+++ b/workers/stash/src/d1/import.ts
@@ -14,6 +14,7 @@ import { prepareBlob, type BlobGenerationFactory, type PreparedBlob } from "./bl
 import { importBatch, type PreparedImportVersion } from "./sql/import.js";
 import { selectHeadForWrite } from "./sql/writes.js";
 import type { StoreDependencies } from "./store.js";
+import { mintCommitId, SELECT_COMMIT_VERSIONS } from "./sql/commits.js";
 
 interface HeadForImportRow {
   head_version: number;
@@ -86,6 +87,7 @@ export interface StashImport {
 }
 
 export interface ImportDependencies extends StoreDependencies {
+  createdBy?: string;
   onBeforeCommit?: () => void | Promise<void>;
   createBlobGeneration?: BlobGenerationFactory;
 }
@@ -285,7 +287,12 @@ export function createImport(env: Env, deps: ImportDependencies): StashImport {
     });
 
     await deps.onBeforeCommit?.();
+    const commitCreatedAt = deps.now();
+    const commitId = mintCommitId(commitCreatedAt, deps.createId);
     const batch = importBatch(db, {
+      commitId,
+      createdBy: deps.createdBy ?? "system",
+      createdAt: commitCreatedAt,
       stash,
       path: value.path,
       expectedVersion: value.expectedVersion,
@@ -294,13 +301,20 @@ export function createImport(env: Env, deps: ImportDependencies): StashImport {
     try {
       const results = await db.batch(batch.statements);
       if (results.at(-1)?.meta.changes === 1) {
+        const committedRows = await db
+          .prepare(SELECT_COMMIT_VERSIONS)
+          .bind(stash, commitId)
+          .all<{ id: number; path: string; version: number; kind: "put" | "delete" | "rollback" }>();
         const createdVersions = logical.map((entry, index): ImportedVersionFact | null => {
-          const statementIndex = batch.versionStatementIndexes[index];
-          const changeId =
-            statementIndex === undefined ? undefined : results[statementIndex]?.meta.last_row_id;
-          if (typeof changeId !== "number" || changeId < 1) return null;
+          const committed = committedRows.results[index];
+          if (
+            committed === undefined ||
+            committed.path !== value.path ||
+            committed.version !== entry.version ||
+            committed.kind !== entry.kind
+          ) return null;
           return {
-            changeId,
+            changeId: committed.id,
             version: entry.version,
             kind: entry.kind,
             author: entry.author,
@@ -323,7 +337,7 @@ export function createImport(env: Env, deps: ImportDependencies): StashImport {
           statusCode: 201,
           createdVersions: exactCreatedVersions,
           value: {
-            commitId: `legacy:${firstChangeId}`,
+            commitId,
             path: value.path,
             headVersion: prepared.at(-1)?.version ?? baseVersion,
             firstChangeId,

--- a/workers/stash/src/d1/import.ts
+++ b/workers/stash/src/d1/import.ts
@@ -301,10 +301,12 @@ export function createImport(env: Env, deps: ImportDependencies): StashImport {
     try {
       const results = await db.batch(batch.statements);
       if (results.at(-1)?.meta.changes === 1) {
-        const committedRows = await db
-          .prepare(SELECT_COMMIT_VERSIONS)
-          .bind(stash, commitId)
-          .all<{ id: number; path: string; version: number; kind: "put" | "delete" | "rollback" }>();
+        const committedRows = await db.prepare(SELECT_COMMIT_VERSIONS).bind(stash, commitId).all<{
+          id: number;
+          path: string;
+          version: number;
+          kind: "put" | "delete" | "rollback";
+        }>();
         const createdVersions = logical.map((entry, index): ImportedVersionFact | null => {
           const committed = committedRows.results[index];
           if (
@@ -312,7 +314,8 @@ export function createImport(env: Env, deps: ImportDependencies): StashImport {
             committed.path !== value.path ||
             committed.version !== entry.version ||
             committed.kind !== entry.kind
-          ) return null;
+          )
+            return null;
           return {
             changeId: committed.id,
             version: entry.version,

--- a/workers/stash/src/d1/reads.ts
+++ b/workers/stash/src/d1/reads.ts
@@ -109,6 +109,7 @@ export interface ReadHistoryPage {
 
 export interface ReadChangeItem {
   changeId: number;
+  commitId: string;
   stash: string;
   path: string;
   version: number;
@@ -339,7 +340,7 @@ function mapFileSource(
 
 function mapVersion(row: HistoryVersionRow, jsonInlineMaxBytes: number): ReadVersionRecord {
   return {
-    commitId: `legacy:${row.change_id}`,
+    commitId: row.commit_id,
     version: row.version,
     kind: row.kind,
     hash: row.hash,
@@ -368,6 +369,7 @@ function mapFileSummary(row: FileSummaryRow, jsonInlineMaxBytes: number): ReadFi
 function mapChange(row: ChangeRow, jsonInlineMaxBytes: number): ReadChangeItem {
   return {
     changeId: row.change_id,
+    commitId: row.commit_id,
     stash: row.stash,
     path: row.path,
     version: row.version,

--- a/workers/stash/src/d1/schema.ts
+++ b/workers/stash/src/d1/schema.ts
@@ -66,6 +66,27 @@ export interface VersionRow {
   representation: "text" | "binary";
   application_etag: string | null;
   content_storage: "legacy" | "bytes";
+  commit_id: string;
+}
+
+export interface CommitRow {
+  id: string;
+  stash_name: string;
+  source: "put" | "delete" | "rollback" | "import" | "upload" | "change-set" | "revert" | "commit";
+  source_id: string | null;
+  author: string;
+  message: string;
+  meta_json: string;
+  entry_count: number;
+  change_count: number;
+  sealed: 0 | 1;
+  first_change_id: number | null;
+  last_change_id: number | null;
+  reverts_commit_id: string | null;
+  idempotency_key: string | null;
+  request_hash: string | null;
+  created_by: string;
+  created_at: number;
 }
 
 export type UploadSessionState =
@@ -189,6 +210,7 @@ export const TABLE_NAMES = [
   "blobs",
   "files",
   "versions",
+  "commits",
   "idempotency",
   "gc_jobs",
   "gc_runs",
@@ -234,6 +256,26 @@ export const TABLE_COLUMNS = {
     "representation",
     "application_etag",
     "content_storage",
+    "commit_id",
+  ],
+  commits: [
+    "id",
+    "stash_name",
+    "source",
+    "source_id",
+    "author",
+    "message",
+    "meta_json",
+    "entry_count",
+    "change_count",
+    "sealed",
+    "first_change_id",
+    "last_change_id",
+    "reverts_commit_id",
+    "idempotency_key",
+    "request_hash",
+    "created_by",
+    "created_at",
   ],
   idempotency: [
     "stash_name",

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -1,0 +1,71 @@
+import type { CommitRow } from "../schema.js";
+import type { SqlFragment } from "./writes.js";
+
+type Preparer = Pick<D1DatabaseSession, "prepare">;
+
+export type CommitInsertRow = Omit<
+  CommitRow,
+  "change_count" | "sealed" | "first_change_id" | "last_change_id"
+>;
+
+export function mintCommitId(now: number, createId: () => string): string {
+  const timestamp = String(now).padStart(13, "0");
+  const randomHex = createId().replace(/[^0-9a-f]/gi, "").slice(0, 8).padEnd(8, "0");
+  return `cmt_${timestamp}${randomHex}`;
+}
+
+export function commitInsertStatement(
+  db: Preparer,
+  row: CommitInsertRow,
+  fence: SqlFragment,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO commits
+        (id, stash_name, source, source_id, author, message, meta_json, entry_count,
+         reverts_commit_id, idempotency_key, request_hash, created_by, created_at)
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? WHERE ${fence.sql}`,
+    )
+    .bind(
+      row.id,
+      row.stash_name,
+      row.source,
+      row.source_id,
+      row.author,
+      row.message,
+      row.meta_json,
+      row.entry_count,
+      row.reverts_commit_id,
+      row.idempotency_key,
+      row.request_hash,
+      row.created_by,
+      row.created_at,
+      ...fence.params,
+    );
+}
+
+export function sealStatement(
+  db: Preparer,
+  input: { stash: string; id: string; extraPredicate?: SqlFragment },
+): D1PreparedStatement {
+  const extra = input.extraPredicate;
+  return db
+    .prepare(
+      `UPDATE commits
+       SET change_count = (SELECT COUNT(*) FROM versions WHERE commit_id = commits.id),
+           first_change_id = (SELECT MIN(id) FROM versions WHERE commit_id = commits.id),
+           last_change_id = (SELECT MAX(id) FROM versions WHERE commit_id = commits.id),
+           sealed = 1
+       WHERE stash_name = ? AND id = ? AND sealed = 0
+         AND entry_count = (SELECT COUNT(*) FROM versions WHERE commit_id = commits.id)
+         ${extra ? `AND (${extra.sql})` : ""}`,
+    )
+    .bind(input.stash, input.id, ...(extra?.params ?? []));
+}
+
+export const SELECT_COMMIT_VERSIONS = `
+  SELECT id, path, version, kind
+  FROM versions
+  WHERE stash_name = ? AND commit_id = ?
+  ORDER BY id
+`;

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -10,7 +10,12 @@ export type CommitInsertRow = Omit<
 
 export function mintCommitId(now: number, createId: () => string): string {
   const timestamp = String(now).padStart(13, "0");
-  const randomHex = createId().replace(/[^0-9a-f]/gi, "").slice(0, 8).padEnd(8, "0");
+  let hash = 0x811c9dc5;
+  for (const character of createId()) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  const randomHex = (hash >>> 0).toString(16).padStart(8, "0");
   return `cmt_${timestamp}${randomHex}`;
 }
 

--- a/workers/stash/src/d1/sql/import.ts
+++ b/workers/stash/src/d1/sql/import.ts
@@ -1,5 +1,6 @@
 import type { PreparedBlob } from "../blobs.js";
 import { fence, type SqlFragment } from "./writes.js";
+import { commitInsertStatement, sealStatement } from "./commits.js";
 
 const DEFAULT_CONTENT_TYPE = "text/plain; charset=utf-8";
 
@@ -37,6 +38,9 @@ export type PreparedImportVersion =
     });
 
 export interface ImportBatchInput {
+  commitId: string;
+  createdBy: string;
+  createdAt: number;
   stash: string;
   path: string;
   expectedVersion: number | null;
@@ -45,7 +49,6 @@ export interface ImportBatchInput {
 
 export interface ImportBatch {
   statements: D1PreparedStatement[];
-  versionStatementIndexes: number[];
 }
 
 function operationFence(input: ImportBatchInput): SqlFragment {
@@ -80,8 +83,8 @@ function putStatements(
       .prepare(
         `INSERT INTO versions
           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-           rollback_of, author, message, meta_json, created_at)
-         SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ? WHERE ${importFence.sql}`,
+           rollback_of, author, message, meta_json, created_at, commit_id)
+         SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ?, ? WHERE ${importFence.sql}`,
       )
       .bind(
         input.stash,
@@ -94,6 +97,7 @@ function putStatements(
         entry.message,
         entry.metaJson,
         entry.createdAt,
+        input.commitId,
         ...importFence.params,
       ),
   ];
@@ -109,8 +113,8 @@ function deleteStatement(
     .prepare(
       `INSERT INTO versions
         (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-         rollback_of, author, message, meta_json, created_at)
-       SELECT ?, ?, ?, 'delete', NULL, 0, ?, NULL, ?, ?, ?, ? WHERE ${importFence.sql}`,
+         rollback_of, author, message, meta_json, created_at, commit_id)
+       SELECT ?, ?, ?, 'delete', NULL, 0, ?, NULL, ?, ?, ?, ?, ? WHERE ${importFence.sql}`,
     )
     .bind(
       input.stash,
@@ -121,6 +125,7 @@ function deleteStatement(
       entry.message,
       entry.metaJson,
       entry.createdAt,
+      input.commitId,
       ...importFence.params,
     );
 }
@@ -136,9 +141,9 @@ function rollbackStatement(
     .prepare(
       `INSERT INTO versions
         (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-         rollback_of, author, message, meta_json, created_at)
+         rollback_of, author, message, meta_json, created_at, commit_id)
        SELECT ?, ?, ?, 'rollback', target.blob_hash, target.size_bytes, target.content_type,
-         target.version, ?, ?, ?, ?
+         target.version, ?, ?, ?, ?, ?
        FROM versions target
        WHERE target.stash_name = ? AND target.path = ? AND target.version = ?
          AND target.blob_hash IS NOT NULL AND ${importFence.sql}`,
@@ -151,6 +156,7 @@ function rollbackStatement(
       entry.message,
       entry.metaJson,
       entry.createdAt,
+      input.commitId,
       input.stash,
       input.path,
       entry.rollbackOf,
@@ -161,20 +167,35 @@ function rollbackStatement(
 export function importBatch(db: Preparer, input: ImportBatchInput): ImportBatch {
   if (input.versions.length === 0) throw new Error("Import batch requires versions");
   const importFence = operationFence(input);
-  const statements: D1PreparedStatement[] = [];
-  const versionStatementIndexes: number[] = [];
+  const statements: D1PreparedStatement[] = [
+    commitInsertStatement(
+      db,
+      {
+        id: input.commitId,
+        stash_name: input.stash,
+        source: "import",
+        source_id: null,
+        author: "",
+        message: "",
+        meta_json: "{}",
+        entry_count: input.versions.length,
+        reverts_commit_id: null,
+        idempotency_key: null,
+        request_hash: null,
+        created_by: input.createdBy,
+        created_at: input.createdAt,
+      },
+      importFence,
+    ),
+  ];
 
   for (const entry of input.versions) {
-    const before = statements.length;
     if (entry.kind === "put") {
       statements.push(...putStatements(db, input, entry, importFence));
-      versionStatementIndexes.push(before + 1);
     } else if (entry.kind === "delete") {
       statements.push(deleteStatement(db, input, entry, importFence));
-      versionStatementIndexes.push(before);
     } else {
       statements.push(rollbackStatement(db, input, entry, importFence));
-      versionStatementIndexes.push(before);
     }
   }
 
@@ -234,5 +255,6 @@ export function importBatch(db: Preparer, input: ImportBatchInput): ImportBatch 
     );
   }
 
-  return { statements, versionStatementIndexes };
+  statements.push(sealStatement(db, { stash: input.stash, id: input.commitId }));
+  return { statements };
 }

--- a/workers/stash/src/d1/sql/reads.ts
+++ b/workers/stash/src/d1/sql/reads.ts
@@ -121,6 +121,7 @@ export const SELECT_HISTORY_HEAD = `
 export const SELECT_HISTORY_VERSIONS = `
   SELECT
     v.id AS change_id,
+    v.commit_id AS commit_id,
     v.version AS version,
     v.kind AS kind,
     v.blob_hash AS hash,
@@ -144,6 +145,7 @@ export const SELECT_HISTORY_VERSIONS = `
 export const SELECT_CHANGES_ASC = `
   SELECT
     v.id AS change_id,
+    v.commit_id AS commit_id,
     v.stash_name AS stash,
     v.path AS path,
     v.version AS version,
@@ -166,6 +168,7 @@ export const SELECT_CHANGES_ASC = `
 export const SELECT_CHANGES_BEFORE = `
   SELECT
     v.id AS change_id,
+    v.commit_id AS commit_id,
     v.stash_name AS stash,
     v.path AS path,
     v.version AS version,
@@ -188,6 +191,7 @@ export const SELECT_CHANGES_BEFORE = `
 export const SELECT_CHANGES_NEWEST = `
   SELECT
     v.id AS change_id,
+    v.commit_id AS commit_id,
     v.stash_name AS stash,
     v.path AS path,
     v.version AS version,
@@ -247,6 +251,7 @@ export interface HistoryHeadRow {
 
 export interface HistoryVersionRow {
   change_id: number;
+  commit_id: string;
   version: number;
   kind: "put" | "delete" | "rollback";
   hash: string | null;
@@ -263,6 +268,7 @@ export interface HistoryVersionRow {
 
 export interface ChangeRow {
   change_id: number;
+  commit_id: string;
   stash: string;
   path: string;
   version: number;

--- a/workers/stash/src/d1/sql/writes.ts
+++ b/workers/stash/src/d1/sql/writes.ts
@@ -1,4 +1,5 @@
 import type { PreparedBlob } from "../blobs.js";
+import { commitInsertStatement, sealStatement } from "./commits.js";
 
 /**
  * Every mutation has one operation predicate F, and that exact predicate is applied to every
@@ -18,6 +19,8 @@ export interface LedgerInsert {
 }
 
 export type PutBatchInput = {
+  commitId: string;
+  createdBy: string;
   stash: string;
   path: string;
   expectedVersion: number | null;
@@ -32,6 +35,8 @@ export type PutBatchInput = {
 } & PreparedBlob;
 
 export interface DeleteBatchInput {
+  commitId: string;
+  createdBy: string;
   stash: string;
   path: string;
   expectedVersion: number;
@@ -42,6 +47,8 @@ export interface DeleteBatchInput {
 }
 
 export interface RollbackBatchInput {
+  commitId: string;
+  createdBy: string;
   stash: string;
   path: string;
   expectedVersion: number;
@@ -56,6 +63,7 @@ export interface RollbackBatchInput {
 type Preparer = Pick<D1DatabaseSession, "prepare">;
 
 export interface VersionInsertInput {
+  commitId: string;
   stash: string;
   path: string;
   version: number;
@@ -185,8 +193,8 @@ export function versionInsert(
     .prepare(
       `INSERT INTO versions
         (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-         rollback_of, author, message, meta_json, created_at)
-       SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ? WHERE ${operationFence.sql}`,
+         rollback_of, author, message, meta_json, created_at, commit_id)
+       SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ?, ? WHERE ${operationFence.sql}`,
     )
     .bind(
       input.stash,
@@ -199,6 +207,7 @@ export function versionInsert(
       input.message,
       input.metaJson,
       input.createdAt,
+      input.commitId,
       ...operationFence.params,
     );
 }
@@ -298,13 +307,42 @@ function putStatements(
   ];
 }
 
+function commitStatement(
+  db: Preparer,
+  input: PutBatchInput | DeleteBatchInput | RollbackBatchInput,
+  source: "put" | "delete" | "rollback",
+  operationFence: SqlFragment,
+): D1PreparedStatement {
+  return commitInsertStatement(
+    db,
+    {
+      id: input.commitId,
+      stash_name: input.stash,
+      source,
+      source_id: null,
+      author: input.author,
+      message: input.message,
+      meta_json: "metaJson" in input ? input.metaJson : "{}",
+      entry_count: 1,
+      reverts_commit_id: null,
+      idempotency_key: input.ledger?.key ?? null,
+      request_hash: input.ledger?.requestHash ?? null,
+      created_by: input.createdBy,
+      created_at: input.createdAt,
+    },
+    operationFence,
+  );
+}
+
 export function putUpdateBatch(db: Preparer, input: PutBatchInput): D1PreparedStatement[] {
   if (input.expectedVersion === null) throw new Error("putUpdateBatch requires expectedVersion");
   const operationFence = fence.put(input.stash, input.path, input.expectedVersion);
   const version = input.expectedVersion + 1;
   return [
+    commitStatement(db, input, "put", operationFence),
     ...putStatements(db, input, operationFence, version),
     headWrite(db, { ...input, version }, operationFence),
+    sealStatement(db, { stash: input.stash, id: input.commitId }),
   ];
 }
 
@@ -313,8 +351,10 @@ export function putCreateBatch(db: Preparer, input: PutBatchInput): D1PreparedSt
     throw new Error("putCreateBatch requires null expectedVersion");
   const operationFence = fence.create(input.stash, input.path);
   return [
+    commitStatement(db, input, "put", operationFence),
     ...putStatements(db, input, operationFence, 1),
     headWrite(db, { ...input, version: 1 }, operationFence),
+    sealStatement(db, { stash: input.stash, id: input.commitId }),
   ];
 }
 
@@ -322,14 +362,15 @@ export function deleteBatch(db: Preparer, input: DeleteBatchInput): D1PreparedSt
   const operationFence = fence.delete(input.stash, input.path, input.expectedVersion);
   const version = input.expectedVersion + 1;
   return [
+    commitStatement(db, input, "delete", operationFence),
     db
       .prepare(
         `INSERT INTO versions
           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
            rollback_of, author, message, meta_json, created_at,
-           representation, application_etag, content_storage)
+           representation, application_etag, content_storage, commit_id)
          SELECT ?, ?, ?, 'delete', NULL, 0, current.content_type,
-           NULL, ?, ?, '{}', ?, current.representation, NULL, current.content_storage
+           NULL, ?, ?, '{}', ?, current.representation, NULL, current.content_storage, ?
          FROM versions AS current
          WHERE current.stash_name = ? AND current.path = ? AND current.version = ?
            AND ${operationFence.sql}`,
@@ -341,6 +382,7 @@ export function deleteBatch(db: Preparer, input: DeleteBatchInput): D1PreparedSt
         input.author,
         input.message,
         input.createdAt,
+        input.commitId,
         input.stash,
         input.path,
         input.expectedVersion,
@@ -366,6 +408,7 @@ export function deleteBatch(db: Preparer, input: DeleteBatchInput): D1PreparedSt
         input.path,
         version,
       ),
+    sealStatement(db, { stash: input.stash, id: input.commitId }),
   ];
 }
 
@@ -378,15 +421,16 @@ export function rollbackBatch(db: Preparer, input: RollbackBatchInput): D1Prepar
   );
   const version = input.expectedVersion + 1;
   return [
+    commitStatement(db, input, "rollback", operationFence),
     db
       .prepare(
         `INSERT INTO versions
           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
            rollback_of, author, message, meta_json, created_at,
-           representation, application_etag, content_storage)
+           representation, application_etag, content_storage, commit_id)
          SELECT ?, ?, ?, 'rollback', target.blob_hash, target.size_bytes, target.content_type,
            target.version, ?, COALESCE(NULLIF(?, ''), 'Rollback to v' || target.version), ?, ?,
-           target.representation, target.application_etag, target.content_storage
+           target.representation, target.application_etag, target.content_storage, ?
          FROM versions target
          WHERE target.stash_name = ? AND target.path = ? AND target.version = ?
            AND ${operationFence.sql}`,
@@ -399,6 +443,7 @@ export function rollbackBatch(db: Preparer, input: RollbackBatchInput): D1Prepar
         input.message,
         input.metaJson,
         input.createdAt,
+        input.commitId,
         input.stash,
         input.path,
         input.toVersion,
@@ -427,5 +472,6 @@ export function rollbackBatch(db: Preparer, input: RollbackBatchInput): D1Prepar
         input.path,
         version,
       ),
+    sealStatement(db, { stash: input.stash, id: input.commitId }),
   ];
 }

--- a/workers/stash/src/d1/sql/writes.ts
+++ b/workers/stash/src/d1/sql/writes.ts
@@ -3,9 +3,9 @@ import { commitInsertStatement, sealStatement } from "./commits.js";
 
 /**
  * Every mutation has one operation predicate F, and that exact predicate is applied to every
- * statement in its batch. The files/head statement is always last and also requires the newly
- * inserted version row to exist. Only `results.at(-1)?.meta.changes === 1` decides success. If F
- * refuses a mutation, every statement changes zero rows, leaving all four write tables untouched.
+ * statement in its batch. The commit insert is first, the files/head statement is immediately
+ * before the seal, and the seal is the final verdict. Only `results.at(-1)?.meta.changes === 1`
+ * decides success. If F refuses a mutation, every statement changes zero rows.
  */
 export interface SqlFragment {
   sql: string;

--- a/workers/stash/src/d1/sql/writes.ts
+++ b/workers/stash/src/d1/sql/writes.ts
@@ -140,7 +140,7 @@ export const selectHeadForWrite = `
 export const selectVersionMeta = `
   SELECT v.id, v.version, v.kind, v.blob_hash, v.size_bytes, v.content_type,
     v.rollback_of, v.author, v.message, v.meta_json, v.created_at,
-    v.representation, v.application_etag, v.content_storage,
+    v.representation, v.application_etag, v.content_storage, v.commit_id,
     previous.blob_hash AS previous_blob_hash,
     previous.representation AS previous_representation,
     previous.content_type AS previous_content_type

--- a/workers/stash/src/d1/upload-finalize.ts
+++ b/workers/stash/src/d1/upload-finalize.ts
@@ -1,10 +1,13 @@
 import type { UploadCommitResult, UploadUnchangedResult } from "@takazudo/zudo-history-stash-core";
 import type { FinalizationLease } from "./upload-sessions.js";
 import type { UploadSessionRow } from "./schema.js";
+import { commitInsertStatement, sealStatement } from "./sql/commits.js";
 
 type Preparer = Pick<D1DatabaseSession, "prepare">;
 
 export interface UploadFinalizeInput {
+  commitId?: string;
+  createdBy?: string;
   session: UploadSessionRow;
   lease: FinalizationLease;
   createdAt: number;
@@ -63,6 +66,9 @@ export function uploadFinalizeBatch(
   db: Preparer,
   input: UploadFinalizeInput,
 ): D1PreparedStatement[] {
+  if (input.commitId === undefined || input.createdBy === undefined) {
+    throw new Error("Committed upload finalization requires commit attribution");
+  }
   const fence = casFence(input);
   const version = (input.session.expected_version ?? 0) + 1;
   const stagedSource =
@@ -85,6 +91,25 @@ export function uploadFinalizeBatch(
     ...fence.params,
   ];
   const statements: D1PreparedStatement[] = [
+    commitInsertStatement(
+      db,
+      {
+        id: input.commitId,
+        stash_name: input.session.stash_name,
+        source: "upload",
+        source_id: input.session.id,
+        author: input.session.principal_id ?? "",
+        message: "",
+        meta_json: "{}",
+        entry_count: 1,
+        reverts_commit_id: null,
+        idempotency_key: null,
+        request_hash: null,
+        created_by: input.createdBy,
+        created_at: input.createdAt,
+      },
+      fence,
+    ),
     db
       .prepare(
         `INSERT INTO byte_blobs
@@ -108,8 +133,8 @@ export function uploadFinalizeBatch(
         `INSERT INTO versions
            (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
             rollback_of, author, message, meta_json, created_at, representation,
-            application_etag, content_storage)
-         SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, '', '{}', ?, ?, ?, 'bytes'
+            application_etag, content_storage, commit_id)
+         SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, '', '{}', ?, ?, ?, 'bytes', ?
          WHERE ${versionFence}`,
       )
       .bind(
@@ -123,6 +148,7 @@ export function uploadFinalizeBatch(
         input.createdAt,
         input.session.representation,
         input.session.uploaded_hash,
+        input.commitId,
         ...versionFenceParams,
       ),
   ];
@@ -210,8 +236,7 @@ export function uploadFinalizeBatch(
       .prepare(
         `UPDATE upload_sessions SET state = 'committed', result_status = 201,
            result_json = json_object(
-             'commitId', 'legacy:' || (SELECT id FROM versions
-               WHERE stash_name = ? AND path = ? AND version = ?),
+             'commitId', ?,
              'version', ?, 'hash', uploaded_hash, 'size', uploaded_size,
              'representation', representation, 'contentType', content_type,
              'changeId', (SELECT id FROM versions
@@ -224,9 +249,7 @@ export function uploadFinalizeBatch(
            AND finalization_lease_until > ? AND ${insertedVersion}`,
       )
       .bind(
-        input.session.stash_name,
-        input.session.path,
-        version,
+        input.commitId,
         version,
         input.session.stash_name,
         input.session.path,
@@ -242,6 +265,18 @@ export function uploadFinalizeBatch(
         input.createdAt,
         ...insertedParams,
       ),
+  );
+  statements.push(
+    sealStatement(db, {
+      stash: input.session.stash_name,
+      id: input.commitId,
+      extraPredicate: {
+        sql: `EXISTS (SELECT 1 FROM upload_sessions
+          WHERE id = ? AND state = 'committed' AND result_status = 201
+            AND json_extract(result_json, '$.commitId') = ?)`,
+        params: [input.session.id, input.commitId],
+      },
+    }),
   );
   return statements;
 }

--- a/workers/stash/src/d1/writes.ts
+++ b/workers/stash/src/d1/writes.ts
@@ -233,10 +233,7 @@ async function committedChangeId(
   stash: string,
   commitId: string,
 ): Promise<number | null> {
-  const rows = await db
-    .prepare(SELECT_COMMIT_VERSIONS)
-    .bind(stash, commitId)
-    .all<{ id: number }>();
+  const rows = await db.prepare(SELECT_COMMIT_VERSIONS).bind(stash, commitId).all<{ id: number }>();
   const id = rows.results.length === 1 ? rows.results[0]?.id : undefined;
   return typeof id === "number" && id > 0 ? id : null;
 }

--- a/workers/stash/src/d1/writes.ts
+++ b/workers/stash/src/d1/writes.ts
@@ -32,6 +32,7 @@ import {
   type LedgerInsert,
 } from "./sql/writes.js";
 import type { StoreDependencies } from "./store.js";
+import { mintCommitId, SELECT_COMMIT_VERSIONS } from "./sql/commits.js";
 
 const DEFAULT_CONTENT_TYPE = "text/plain; charset=utf-8";
 
@@ -54,6 +55,7 @@ interface VersionMetaRow extends VersionRow {
 
 export interface WriteOptions {
   idempotencyKey?: string;
+  createdBy?: string;
 }
 
 export type StoreWriteResult<T> =
@@ -174,7 +176,7 @@ async function replay<T>(
   const row = await readVersion(db, ledger.stash_name, ledger.path, ledger.version);
   if (!row) return failure("internal", 500, "Idempotency result is missing");
   const base = {
-    commitId: `legacy:${row.id}`,
+    commitId: row.commit_id,
     version: row.version,
     changeId: row.id,
     createdAt: new Date(row.created_at).toISOString(),
@@ -226,8 +228,16 @@ function batchWon(results: D1Result[]): boolean {
   return results.at(-1)?.meta.changes === 1;
 }
 
-function changeId(results: D1Result[], versionStatementIndex: number): number | null {
-  const id = results[versionStatementIndex]?.meta.last_row_id;
+async function committedChangeId(
+  db: D1DatabaseSession,
+  stash: string,
+  commitId: string,
+): Promise<number | null> {
+  const rows = await db
+    .prepare(SELECT_COMMIT_VERSIONS)
+    .bind(stash, commitId)
+    .all<{ id: number }>();
+  const id = rows.results.length === 1 ? rows.results[0]?.id : undefined;
   return typeof id === "number" && id > 0 ? id : null;
 }
 
@@ -300,11 +310,14 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
     const prepared = await prepareBlob(env, stash, hash, input.body, deps.createBlobGeneration);
     await deps.onBeforeCommit?.();
     const createdAt = deps.now();
+    const commitId = mintCommitId(createdAt, deps.createId);
     const ledger: LedgerInsert | undefined = options.idempotencyKey
       ? { key: options.idempotencyKey, requestHash, statusCode: 201 }
       : undefined;
     const batchInput = {
       stash,
+      commitId,
+      createdBy: options.createdBy ?? "system",
       path,
       expectedVersion: input.expectedVersion,
       hash,
@@ -324,11 +337,11 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
           : putUpdateBatch(db, batchInput),
       );
       if (batchWon(results)) {
-        const id = changeId(results, 1);
+        const id = await committedChangeId(db, stash, commitId);
         if (id === null) return failure("internal", 500, "Missing put change id");
         return created(
           {
-            commitId: `legacy:${id}`,
+            commitId,
             version: (input.expectedVersion ?? 0) + 1,
             hash,
             size,
@@ -400,6 +413,7 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
 
     await deps.onBeforeCommit?.();
     const createdAt = deps.now();
+    const commitId = mintCommitId(createdAt, deps.createId);
     const ledger: LedgerInsert | undefined = options.idempotencyKey
       ? { key: options.idempotencyKey, requestHash, statusCode: 200 }
       : undefined;
@@ -407,6 +421,8 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
       const results = await db.batch(
         deleteBatch(db, {
           stash,
+          commitId,
+          createdBy: options.createdBy ?? "system",
           path,
           expectedVersion: input.expectedVersion,
           author: input.author ?? "",
@@ -416,11 +432,11 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
         }),
       );
       if (batchWon(results)) {
-        const id = changeId(results, 0);
+        const id = await committedChangeId(db, stash, commitId);
         if (id === null) return failure("internal", 500, "Missing delete change id");
         return created(
           {
-            commitId: `legacy:${id}`,
+            commitId,
             version: input.expectedVersion + 1,
             changeId: id,
             createdAt: new Date(createdAt).toISOString(),
@@ -503,6 +519,7 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
 
     await deps.onBeforeCommit?.();
     const createdAt = deps.now();
+    const commitId = mintCommitId(createdAt, deps.createId);
     const ledger: LedgerInsert | undefined = options.idempotencyKey
       ? { key: options.idempotencyKey, requestHash, statusCode: 201 }
       : undefined;
@@ -510,6 +527,8 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
       const results = await db.batch(
         rollbackBatch(db, {
           stash,
+          commitId,
+          createdBy: options.createdBy ?? "system",
           path,
           expectedVersion: input.expectedVersion,
           toVersion: input.toVersion,
@@ -521,11 +540,11 @@ export function createWrites(env: Env, deps: WriteDependencies): StashWrites {
         }),
       );
       if (batchWon(results)) {
-        const id = changeId(results, 0);
+        const id = await committedChangeId(db, stash, commitId);
         if (id === null) return failure("internal", 500, "Missing rollback change id");
         return created(
           {
-            commitId: `legacy:${id}`,
+            commitId,
             version: input.expectedVersion + 1,
             hash: target.blob_hash,
             rollbackOf: input.toVersion,

--- a/workers/stash/src/events/subscribe.ts
+++ b/workers/stash/src/events/subscribe.ts
@@ -20,6 +20,7 @@ function encodeEvent(event: StashEvent): Uint8Array {
 
 function replayEvent(change: {
   changeId: number;
+  commitId: string;
   stash: string;
   path: string;
   version: number;
@@ -29,7 +30,7 @@ function replayEvent(change: {
   return {
     type: "change",
     changeId: change.changeId,
-    commitId: `legacy:${change.changeId}`,
+    commitId: change.commitId,
     stash: change.stash,
     path: change.path,
     version: change.version,

--- a/workers/stash/src/routes/files.ts
+++ b/workers/stash/src/routes/files.ts
@@ -198,10 +198,12 @@ files.put("/v1/stashes/:stash/files/:path{.+}", async (c) => {
   const path = filePath(c);
   const stash = c.get("routeStash").name;
   const key = idempotencyKey(c);
-  const store = createStashStore(c.env);
+  const store = createStashStore(c.env, c.get("deps"));
+  const principal = c.get("principal");
   const result = unwrapWrite(
     await store.writes.put(stash, path, await putBody(c), {
       idempotencyKey: key,
+      createdBy: principal.kind === "admin" ? "admin" : principal.tokenId,
     }),
   );
   if (result.replayed) c.header("Idempotent-Replayed", "true");
@@ -227,10 +229,12 @@ files.post("/v1/stashes/:stash/delete/:path{.+}", async (c) => {
   const path = filePath(c);
   const stash = c.get("routeStash").name;
   const key = idempotencyKey(c);
-  const store = createStashStore(c.env);
+  const store = createStashStore(c.env, c.get("deps"));
+  const principal = c.get("principal");
   const result = unwrapWrite(
     await store.writes.delete(stash, path, await deleteBody(c), {
       idempotencyKey: key,
+      createdBy: principal.kind === "admin" ? "admin" : principal.tokenId,
     }),
   );
   if (result.replayed) c.header("Idempotent-Replayed", "true");
@@ -256,10 +260,12 @@ files.post("/v1/stashes/:stash/rollback/:path{.+}", async (c) => {
   const path = filePath(c);
   const stash = c.get("routeStash").name;
   const key = idempotencyKey(c);
-  const store = createStashStore(c.env);
+  const store = createStashStore(c.env, c.get("deps"));
+  const principal = c.get("principal");
   const result = unwrapWrite(
     await store.writes.rollback(stash, path, await rollbackBody(c), {
       idempotencyKey: key,
+      createdBy: principal.kind === "admin" ? "admin" : principal.tokenId,
     }),
   );
   if (result.replayed) c.header("Idempotent-Replayed", "true");

--- a/workers/stash/src/routes/import.ts
+++ b/workers/stash/src/routes/import.ts
@@ -13,9 +13,11 @@ importRoutes.post(
     if (!result.success) throw new StashError("validation", "Invalid import input.");
   }),
   async (c) => {
+    const principal = c.get("principal");
     const importer = createImport(c.env, {
-      now: Date.now,
-      createId: () => crypto.randomUUID(),
+      now: c.get("deps").now,
+      createId: c.get("deps").createId,
+      createdBy: principal.kind === "admin" ? "admin" : principal.tokenId,
     });
     const stash = c.get("routeStash").name;
     const input = c.req.valid("json");

--- a/workers/stash/src/routes/uploads.ts
+++ b/workers/stash/src/routes/uploads.ts
@@ -22,6 +22,7 @@ import {
 } from "../byte-writes.js";
 import type { AppEnv, Principal } from "../context.js";
 import { finalizeUnchanged, finalizeUpload } from "../d1/upload-finalize.js";
+import { mintCommitId } from "../d1/sql/commits.js";
 import { D1UploadSessionStore, type FinalizationLease } from "../d1/upload-sessions.js";
 import type { UploadSessionRow } from "../d1/schema.js";
 import { deliverEvents, eventOrigin } from "../events/publish.js";
@@ -970,6 +971,9 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
     });
   }
   const committed = await finalizeUpload(c.env.DB, {
+    commitId: mintCommitId(finalizationNow, c.get("deps").createId),
+    createdBy:
+      row.principal_kind === "admin" ? "admin" : (row.principal_id ?? "unknown-principal"),
     session: row,
     lease: leaseState.current,
     createdAt: finalizationNow,

--- a/workers/stash/src/routes/uploads.ts
+++ b/workers/stash/src/routes/uploads.ts
@@ -972,8 +972,7 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
   }
   const committed = await finalizeUpload(c.env.DB, {
     commitId: mintCommitId(finalizationNow, c.get("deps").createId),
-    createdBy:
-      row.principal_kind === "admin" ? "admin" : (row.principal_id ?? "unknown-principal"),
+    createdBy: row.principal_kind === "admin" ? "admin" : (row.principal_id ?? "unknown-principal"),
     session: row,
     lease: leaseState.current,
     createdAt: finalizationNow,

--- a/workers/stash/test/concealment.test.ts
+++ b/workers/stash/test/concealment.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../src/app.js";
 import type { Env } from "../src/env.js";
 import { bearer, mintToken, request, resetDatabase, seedStash } from "./helpers/app.js";
+import { seedCommit } from "./helpers/seed-rows.js";
 
 const NOW = Date.parse("2026-08-27T00:00:00.000Z");
 const DAY_MS = 86_400_000;
@@ -43,12 +44,13 @@ async function markDeleted(stash: string, deletedAt: number): Promise<void> {
 }
 
 async function seedVersion(stash: string, path: string, createdAt: number): Promise<number> {
+  const commitId = await seedCommit(stash, `cmt_conceal_${stash}_${path}`, createdAt);
   const result = await env.DB.prepare(
     `INSERT INTO versions
-       (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at)
-     VALUES (?, ?, 1, 'put', ?, 1, 'tester', '', ?)`,
+       (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at, commit_id)
+     VALUES (?, ?, 1, 'put', ?, 1, 'tester', '', ?, ?)`,
   )
-    .bind(stash, path, `hash-${stash}-${path}`, createdAt)
+    .bind(stash, path, `hash-${stash}-${path}`, createdAt, commitId)
     .run();
   return result.meta.last_row_id;
 }

--- a/workers/stash/test/events/do.test.ts
+++ b/workers/stash/test/events/do.test.ts
@@ -84,7 +84,7 @@ describe("StashEvents Durable Object", () => {
       const event: StashEvent = {
         type: "change",
         changeId: 41,
-        commitId: "legacy:41",
+        commitId: "cmt_test_41",
         stash: "docs",
         path: "guide.json",
         version: 3,
@@ -117,7 +117,7 @@ describe("StashEvents Durable Object", () => {
       const event: StashEvent = {
         type: "change",
         changeId: 42,
-        commitId: "legacy:42",
+        commitId: "cmt_test_42",
         stash: "docs",
         path: "x".repeat(70_000),
         version: 1,
@@ -229,7 +229,7 @@ describe("StashEvents Durable Object", () => {
       const baseEvent: StashEvent = {
         type: "change",
         changeId: 42,
-        commitId: "legacy:42",
+        commitId: "cmt_test_42",
         stash: "docs",
         path: "",
         version: 1,

--- a/workers/stash/test/events/publish.test.ts
+++ b/workers/stash/test/events/publish.test.ts
@@ -261,7 +261,9 @@ describe("event publication", () => {
     );
     const firstCommit = await bindings.DB.prepare(
       "SELECT commit_id FROM versions WHERE stash_name = ? AND id = ?",
-    ).bind(STASH, rows.results[0]?.id).first<{ commit_id: string }>();
+    )
+      .bind(STASH, rows.results[0]?.id)
+      .first<{ commit_id: string }>();
     await expect(response.json()).resolves.toEqual({
       commitId: firstCommit?.commit_id,
       path: "history.txt",

--- a/workers/stash/test/events/publish.test.ts
+++ b/workers/stash/test/events/publish.test.ts
@@ -70,10 +70,10 @@ function recordingEnv(
                   }
                   return async (statements: D1PreparedStatement[]) => {
                     const results = await session.batch(statements);
-                    if (statements.length !== 5 || results.at(-1)?.meta.changes !== 1)
+                    if (statements.length !== 7 || results.at(-1)?.meta.changes !== 1)
                       return results;
                     const ids = options.importVersionIds ?? [];
-                    const versionIndexes = [1, 2, 3];
+                    const versionIndexes = [2, 3, 4];
                     return results.map((result, index) => {
                       const versionOffset = versionIndexes.indexOf(index);
                       if (versionOffset < 0 || ids[versionOffset] === undefined) return result;
@@ -223,9 +223,9 @@ describe("event publication", () => {
     expect(events).toHaveLength(3);
   });
 
-  it("publishes import events in statement order with each exact inserted id", async () => {
-    const exactIds = [101, 303, 707];
-    const { bindings, events } = recordingEnv({ importVersionIds: exactIds });
+  it("publishes import events from commit-scoped rows despite poisoned last_row_id metadata", async () => {
+    const poisonedIds = [101, 303, 707];
+    const { bindings, events } = recordingEnv({ importVersionIds: poisonedIds });
     const response = await mutation(
       bindings,
       "/import",
@@ -247,9 +247,9 @@ describe("event publication", () => {
       .bind(STASH)
       .all<{ id: number; version: number; kind: string }>();
     expect(rows.results).toHaveLength(3);
-    expect(rows.results.map(({ id }) => id).every((id) => !exactIds.includes(id))).toBe(true);
+    expect(rows.results.map(({ id }) => id).every((id) => !poisonedIds.includes(id))).toBe(true);
     expect(events.map((event) => (event.type === "change" ? event.changeId : -1))).toEqual(
-      exactIds,
+      rows.results.map(({ id }) => id),
     );
     expect(events.map((event) => (event.type === "change" ? event.kind : ""))).toEqual([
       "put",
@@ -259,11 +259,14 @@ describe("event publication", () => {
     expect(events.every((event) => event.type === "change" && event.origin === "importer")).toBe(
       true,
     );
+    const firstCommit = await bindings.DB.prepare(
+      "SELECT commit_id FROM versions WHERE stash_name = ? AND id = ?",
+    ).bind(STASH, rows.results[0]?.id).first<{ commit_id: string }>();
     await expect(response.json()).resolves.toEqual({
-      commitId: `legacy:${exactIds[0]}`,
+      commitId: firstCommit?.commit_id,
       path: "history.txt",
       headVersion: 3,
-      firstChangeId: exactIds[0],
+      firstChangeId: rows.results[0]?.id,
     });
     const refused = await mutation(bindings, "/import", {
       path: "history.txt",
@@ -285,18 +288,18 @@ describe("event publication", () => {
     );
     expect(continued.status).toBe(201);
     const rollbackRow = await bindings.DB.prepare(
-      `SELECT id, size_bytes, created_at FROM versions
+      `SELECT id, commit_id, size_bytes, created_at FROM versions
        WHERE stash_name = ? AND path = ? AND version = 4`,
     )
       .bind(STASH, "history.txt")
-      .first<{ id: number; size_bytes: number; created_at: number }>();
+      .first<{ id: number; commit_id: string; size_bytes: number; created_at: number }>();
     if (rollbackRow === null) throw new Error("Expected committed continuation rollback");
     expect(rollbackRow.size_bytes).toBe(3);
     expect(events).toHaveLength(4);
     expect(events.at(-1)).toEqual({
       type: "change",
       changeId: rollbackRow.id,
-      commitId: `legacy:${rollbackRow.id}`,
+      commitId: rollbackRow.commit_id,
       stash: STASH,
       path: "history.txt",
       version: 4,
@@ -305,7 +308,7 @@ describe("event publication", () => {
       createdAt: new Date(rollbackRow.created_at).toISOString(),
     });
     await expect(continued.json()).resolves.toEqual({
-      commitId: `legacy:${rollbackRow.id}`,
+      commitId: rollbackRow.commit_id,
       path: "history.txt",
       headVersion: 4,
       firstChangeId: rollbackRow.id,

--- a/workers/stash/test/helpers/app.ts
+++ b/workers/stash/test/helpers/app.ts
@@ -36,6 +36,7 @@ export async function resetDatabase(): Promise<void> {
     "gc_runs",
     "idempotency",
     "versions",
+    "commits",
     "files",
     "blobs",
     "byte_blobs",

--- a/workers/stash/test/helpers/seed-rows.ts
+++ b/workers/stash/test/helpers/seed-rows.ts
@@ -2,6 +2,23 @@ import { createTestEnv } from "./env.js";
 
 export const READ_FIXTURE_STASH = "reads-fixture";
 
+export async function seedCommit(
+  stash: string,
+  id: string,
+  createdAt = 1,
+  source: "put" | "delete" | "rollback" | "import" | "upload" = "put",
+): Promise<string> {
+  await createTestEnv()
+    .env.DB.prepare(
+      `INSERT INTO commits
+         (id, stash_name, source, entry_count, created_by, created_at)
+       VALUES (?, ?, ?, 1, 'test-fixture', ?)`,
+    )
+    .bind(id, stash, source, createdAt)
+    .run();
+  return id;
+}
+
 const HASH_ALPHA_ONE = "sha256-alpha-one";
 const HASH_ALPHA_TWO = "sha256-alpha-two";
 const HASH_BETA_ONE = "sha256-beta-one";
@@ -144,14 +161,20 @@ export async function seedReadRows(): Promise<void> {
     ],
   ] as const;
   for (const version of versions) {
+    const commitId = await seedCommit(
+      READ_FIXTURE_STASH,
+      `cmt_fixture_${version[0]}`,
+      version[12],
+      version[4],
+    );
     await db
       .prepare(
         `INSERT INTO versions (
           id, stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-          rollback_of, author, message, meta_json, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          rollback_of, author, message, meta_json, created_at, commit_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .bind(...version)
+      .bind(...version, commitId)
       .run();
   }
 

--- a/workers/stash/test/lifecycle.test.ts
+++ b/workers/stash/test/lifecycle.test.ts
@@ -5,6 +5,7 @@ import { createAdminStore } from "../src/d1/admin-store.js";
 import type { Env } from "../src/env.js";
 import { resetDatabase } from "./helpers/app.js";
 import { createTestEnv } from "./helpers/env.js";
+import { seedCommit } from "./helpers/seed-rows.js";
 
 const STASH = "lifecycle-store";
 const DELETED_AT = 1_900_000_000_000;
@@ -57,12 +58,13 @@ async function seedHistoryAndTokens(): Promise<void> {
   )
     .bind(STASH, DELETED_AT - 900)
     .run();
+  const commitId = await seedCommit(STASH, "cmt_lifecycle_1", DELETED_AT - 800);
   await env.DB.prepare(
     `INSERT INTO versions
-       (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at)
-     VALUES (?, 'file.txt', 1, 'put', 'hash-one', 4, 'author', 'message', ?)`,
+       (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at, commit_id)
+     VALUES (?, 'file.txt', 1, 'put', 'hash-one', 4, 'author', 'message', ?, ?)`,
   )
-    .bind(STASH, DELETED_AT - 800)
+    .bind(STASH, DELETED_AT - 800, commitId)
     .run();
   await env.DB.prepare(
     `INSERT INTO files

--- a/workers/stash/test/migrations.test.ts
+++ b/workers/stash/test/migrations.test.ts
@@ -85,6 +85,11 @@ describe("D1 migrations", () => {
       name: string;
     }>();
     expect(versionIndexes.results.map(({ name }) => name)).toContain("versions_stash_commit");
+    const versionColumns = await env.DB.prepare("PRAGMA table_info(versions)").all<{
+      name: string;
+      notnull: number;
+    }>();
+    expect(versionColumns.results.find(({ name }) => name === "commit_id")?.notnull).toBe(1);
 
     await expect(env.DB.prepare("SELECT 1 FROM proposals").first()).rejects.toThrow();
 

--- a/workers/stash/test/migrations.test.ts
+++ b/workers/stash/test/migrations.test.ts
@@ -70,6 +70,22 @@ describe("D1 migrations", () => {
       { name: "id", desc: 1 },
     ]);
 
+    const commitIndexes = await env.DB.prepare("PRAGMA index_list(commits)").all<{
+      name: string;
+      partial: number;
+    }>();
+    expect(commitIndexes.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "commits_stash_created", partial: 0 }),
+        expect.objectContaining({ name: "commits_stash_idempotency", partial: 1 }),
+        expect.objectContaining({ name: "commits_stash_last_change", partial: 0 }),
+      ]),
+    );
+    const versionIndexes = await env.DB.prepare("PRAGMA index_list(versions)").all<{
+      name: string;
+    }>();
+    expect(versionIndexes.results.map(({ name }) => name)).toContain("versions_stash_commit");
+
     await expect(env.DB.prepare("SELECT 1 FROM proposals").first()).rejects.toThrow();
 
     const jobs = await env.DB.prepare(
@@ -176,6 +192,25 @@ describe("D1 migrations", () => {
       "SELECT deleted_at FROM stashes WHERE name = 'upgrade'",
     ).first<{ deleted_at: number | null }>();
     expect(upgradedStash).toEqual({ deleted_at: null });
+    const legacyCommit = await env.UPGRADE_DB.prepare(
+      `SELECT id, stash_name, source, entry_count, change_count, sealed,
+         first_change_id, last_change_id, created_by
+       FROM commits WHERE id = 'cmt_legacy_1'`,
+    ).first();
+    expect(legacyCommit).toEqual({
+      id: "cmt_legacy_1",
+      stash_name: "upgrade",
+      source: "put",
+      entry_count: 1,
+      change_count: 1,
+      sealed: 1,
+      first_change_id: 1,
+      last_change_id: 1,
+      created_by: "legacy",
+    });
+    await expect(
+      env.UPGRADE_DB.prepare("SELECT commit_id FROM versions WHERE id = 1").first(),
+    ).resolves.toEqual({ commit_id: "cmt_legacy_1" });
     await expect(
       env.UPGRADE_DB.prepare(
         `SELECT b.body, b.size_bytes, v.representation, v.application_etag, v.content_storage, f.head_hash
@@ -213,10 +248,14 @@ describe("D1 migrations", () => {
       0, 255, 1, 2,
     ]);
     await env.UPGRADE_DB.prepare(
+      `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+       VALUES ('cmt_upgrade_bytes', 'upgrade', 'put', 1, 'test', 2)`,
+    ).run();
+    await env.UPGRADE_DB.prepare(
       `INSERT INTO versions
          (stash_name, path, version, kind, blob_hash, size_bytes, representation,
-          application_etag, content_storage, created_at)
-       VALUES ('upgrade', 'raw.bin', 1, 'put', ?, 4, 'binary', ?, 'bytes', 2)`,
+          application_etag, content_storage, created_at, commit_id)
+       VALUES ('upgrade', 'raw.bin', 1, 'put', ?, 4, 'binary', ?, 'bytes', 2, 'cmt_upgrade_bytes')`,
     )
       .bind(byteHash, byteHash)
       .run();
@@ -309,14 +348,19 @@ describe("D1 migrations", () => {
     await env.DB.prepare(
       "INSERT INTO stashes (name, description, meta_json, created_at) VALUES ('alpha', '', '{}', 1)",
     ).run();
+    await env.DB.prepare(
+      `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+       VALUES ('cmt_constraint_a', 'alpha', 'delete', 1, 'test', 1),
+              ('cmt_constraint_b', 'alpha', 'rollback', 1, 'test', 1)`,
+    ).run();
     await expect(
       env.DB.prepare(
-        "INSERT INTO versions (stash_name,path,version,kind,blob_hash,created_at) VALUES ('alpha','a',1,'delete','sha256-x',1)",
+        "INSERT INTO versions (stash_name,path,version,kind,blob_hash,created_at,commit_id) VALUES ('alpha','a',1,'delete','sha256-x',1,'cmt_constraint_a')",
       ).run(),
     ).rejects.toThrow();
     await expect(
       env.DB.prepare(
-        "INSERT INTO versions (stash_name,path,version,kind,blob_hash,created_at) VALUES ('alpha','b',1,'rollback','sha256-x',1)",
+        "INSERT INTO versions (stash_name,path,version,kind,blob_hash,created_at,commit_id) VALUES ('alpha','b',1,'rollback','sha256-x',1,'cmt_constraint_b')",
       ).run(),
     ).rejects.toThrow();
     await expect(

--- a/workers/stash/test/routes/admin.test.ts
+++ b/workers/stash/test/routes/admin.test.ts
@@ -4,6 +4,7 @@ import { app, createApp } from "../../src/app.js";
 import type { Env } from "../../src/env.js";
 import { bearer, mintToken, request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv } from "../helpers/env.js";
+import { seedCommit } from "../helpers/seed-rows.js";
 
 const BASE_URL = "http://example.test";
 
@@ -113,13 +114,14 @@ async function insertChange(
   createdAt: number,
   { author = "author", message = "message", size = 10 } = {},
 ): Promise<number> {
+  const commitId = await seedCommit(stash, `cmt_admin_${path}`, createdAt);
   const result = await createTestEnv()
     .env.DB.prepare(
       `INSERT INTO versions
-         (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at)
-       VALUES (?, ?, 1, 'put', ?, ?, ?, ?, ?)`,
+         (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at, commit_id)
+       VALUES (?, ?, 1, 'put', ?, ?, ?, ?, ?, ?)`,
     )
-    .bind(stash, path, `sha256-${path}`, size, author, message, createdAt)
+    .bind(stash, path, `sha256-${path}`, size, author, message, createdAt, commitId)
     .run();
   return result.meta.last_row_id;
 }

--- a/workers/stash/test/routes/diff.test.ts
+++ b/workers/stash/test/routes/diff.test.ts
@@ -47,11 +47,7 @@ async function seedLiveFile(path: string, bodies: readonly string[]): Promise<st
       )
       .bind(READ_FIXTURE_STASH, hash, body, encoder.encode(body).byteLength, createdAt)
       .run();
-    const commitId = await seedCommit(
-      READ_FIXTURE_STASH,
-      `cmt_diff_${path}_${version}`,
-      createdAt,
-    );
+    const commitId = await seedCommit(READ_FIXTURE_STASH, `cmt_diff_${path}_${version}`, createdAt);
     await db
       .prepare(
         `INSERT INTO versions (
@@ -59,7 +55,15 @@ async function seedLiveFile(path: string, bodies: readonly string[]): Promise<st
           rollback_of, author, message, meta_json, created_at, commit_id
         ) VALUES (?, ?, ?, 'put', ?, ?, 'text/plain; charset=utf-8', NULL, '', '', '{}', ?, ?)`,
       )
-      .bind(READ_FIXTURE_STASH, path, version, hash, encoder.encode(body).byteLength, createdAt, commitId)
+      .bind(
+        READ_FIXTURE_STASH,
+        path,
+        version,
+        hash,
+        encoder.encode(body).byteLength,
+        createdAt,
+        commitId,
+      )
       .run();
   }
   const headVersion = bodies.length;

--- a/workers/stash/test/routes/diff.test.ts
+++ b/workers/stash/test/routes/diff.test.ts
@@ -12,7 +12,7 @@ import type { ReadVersionRecord, StashReads } from "../../src/d1/reads.js";
 import { createDiffRoutes } from "../../src/routes/diff.js";
 import { bearer, mintToken, request, resetDatabase } from "../helpers/app.js";
 import { createTestEnv } from "../helpers/env.js";
-import { READ_FIXTURE_STASH, seedReadRows } from "../helpers/seed-rows.js";
+import { READ_FIXTURE_STASH, seedCommit, seedReadRows } from "../helpers/seed-rows.js";
 
 const encoder = new TextEncoder();
 const baseUrl = `http://example.test/v1/stashes/${READ_FIXTURE_STASH}/diff`;
@@ -47,14 +47,19 @@ async function seedLiveFile(path: string, bodies: readonly string[]): Promise<st
       )
       .bind(READ_FIXTURE_STASH, hash, body, encoder.encode(body).byteLength, createdAt)
       .run();
+    const commitId = await seedCommit(
+      READ_FIXTURE_STASH,
+      `cmt_diff_${path}_${version}`,
+      createdAt,
+    );
     await db
       .prepare(
         `INSERT INTO versions (
           stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-          rollback_of, author, message, meta_json, created_at
-        ) VALUES (?, ?, ?, 'put', ?, ?, 'text/plain; charset=utf-8', NULL, '', '', '{}', ?)`,
+          rollback_of, author, message, meta_json, created_at, commit_id
+        ) VALUES (?, ?, ?, 'put', ?, ?, 'text/plain; charset=utf-8', NULL, '', '', '{}', ?, ?)`,
       )
-      .bind(READ_FIXTURE_STASH, path, version, hash, encoder.encode(body).byteLength, createdAt)
+      .bind(READ_FIXTURE_STASH, path, version, hash, encoder.encode(body).byteLength, createdAt, commitId)
       .run();
   }
   const headVersion = bodies.length;
@@ -78,7 +83,7 @@ async function seedLiveFile(path: string, bodies: readonly string[]): Promise<st
 
 function version(versionNumber: number, hash: string): ReadVersionRecord {
   return {
-    commitId: "legacy:1",
+    commitId: "cmt_fixture_1",
     version: versionNumber,
     kind: "put",
     hash,

--- a/workers/stash/test/routes/events.test.ts
+++ b/workers/stash/test/routes/events.test.ts
@@ -13,7 +13,6 @@ import type { Env } from "../../src/env.js";
 import { effectiveStashEventsLifetimeMs } from "../../src/routes/events.js";
 import { bearer, mintToken, request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv } from "../helpers/env.js";
-import { seedCommit } from "../helpers/seed-rows.js";
 
 const decoder = new TextDecoder();
 
@@ -468,16 +467,22 @@ function delayedAscendingSnapshot(db: D1Database): {
 }
 
 async function seedChanges(bindings: Env, stash: string, count: number): Promise<void> {
-  for (let offset = 0; offset < count; offset += 100) {
+  for (let offset = 0; offset < count; offset += 50) {
     const statements: D1PreparedStatement[] = [];
-    for (const index of Array.from({ length: Math.min(100, count - offset) }, (_, i) => i)) {
+    for (const index of Array.from({ length: Math.min(50, count - offset) }, (_, i) => i)) {
       const change = offset + index + 1;
-      const commitId = await seedCommit(stash, `cmt_events_${change}`, change);
-      statements.push(bindings.DB.prepare(
-        `INSERT INTO versions
+      const commitId = `cmt_events_${change}`;
+      statements.push(
+        bindings.DB.prepare(
+          `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+           VALUES (?, ?, 'put', 1, 'test-fixture', ?)`,
+        ).bind(commitId, stash, change),
+        bindings.DB.prepare(
+          `INSERT INTO versions
            (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at, commit_id)
          VALUES (?, ?, 1, 'put', ?, 1, '', '', ?, ?)`,
-      ).bind(stash, `bulk/${change}.txt`, `hash-${change}`, change, commitId));
+        ).bind(stash, `bulk/${change}.txt`, `hash-${change}`, change, commitId),
+      );
     }
     await bindings.DB.batch(statements);
   }

--- a/workers/stash/test/routes/events.test.ts
+++ b/workers/stash/test/routes/events.test.ts
@@ -13,6 +13,7 @@ import type { Env } from "../../src/env.js";
 import { effectiveStashEventsLifetimeMs } from "../../src/routes/events.js";
 import { bearer, mintToken, request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv } from "../helpers/env.js";
+import { seedCommit } from "../helpers/seed-rows.js";
 
 const decoder = new TextDecoder();
 
@@ -468,14 +469,16 @@ function delayedAscendingSnapshot(db: D1Database): {
 
 async function seedChanges(bindings: Env, stash: string, count: number): Promise<void> {
   for (let offset = 0; offset < count; offset += 100) {
-    const statements = Array.from({ length: Math.min(100, count - offset) }, (_, index) => {
+    const statements: D1PreparedStatement[] = [];
+    for (const index of Array.from({ length: Math.min(100, count - offset) }, (_, i) => i)) {
       const change = offset + index + 1;
-      return bindings.DB.prepare(
+      const commitId = await seedCommit(stash, `cmt_events_${change}`, change);
+      statements.push(bindings.DB.prepare(
         `INSERT INTO versions
-           (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at)
-         VALUES (?, ?, 1, 'put', ?, 1, '', '', ?)`,
-      ).bind(stash, `bulk/${change}.txt`, `hash-${change}`, change);
-    });
+           (stash_name, path, version, kind, blob_hash, size_bytes, author, message, created_at, commit_id)
+         VALUES (?, ?, 1, 'put', ?, 1, '', '', ?, ?)`,
+      ).bind(stash, `bulk/${change}.txt`, `hash-${change}`, change, commitId));
+    }
     await bindings.DB.batch(statements);
   }
 }
@@ -869,7 +872,7 @@ describe("stash events route", () => {
         event: {
           type: "change",
           changeId: second.changeId,
-          commitId: `legacy:${second.changeId}`,
+          commitId: second.commitId,
           stash,
           path: "second.txt",
           version: 1,
@@ -912,7 +915,7 @@ describe("stash events route", () => {
       await publish(baseBindings, stash, {
         type: "change",
         changeId: created.changeId,
-        commitId: `legacy:${created.changeId}`,
+        commitId: created.commitId,
         stash,
         path: "gap.txt",
         version: created.version,
@@ -966,7 +969,7 @@ describe("stash events route", () => {
       await publish(baseBindings, stash, {
         type: "change",
         changeId: created.changeId,
-        commitId: `legacy:${created.changeId}`,
+        commitId: created.commitId,
         stash,
         path: "duplicate.txt",
         version: created.version,

--- a/workers/stash/test/routes/files.test.ts
+++ b/workers/stash/test/routes/files.test.ts
@@ -267,7 +267,7 @@ describe("file route writes", () => {
     const deletion = await jsonApi("POST", "/delete/cas.txt", { expectedVersion: 1 });
     expect(deletion.status).toBe(200);
     await expect(deletion.json()).resolves.toEqual({
-      commitId: "legacy:2",
+      commitId: expect.stringMatching(/^cmt_\d{13}[0-9a-f]{8}$/),
       version: 2,
       changeId: expect.any(Number),
       createdAt: expect.stringMatching(/Z$/),

--- a/workers/stash/test/routes/import.test.ts
+++ b/workers/stash/test/routes/import.test.ts
@@ -66,7 +66,7 @@ describe("POST stash import", () => {
     expect(response.status).toBe(201);
     const json = await response.json<Record<string, unknown>>();
     expect(json).toEqual({
-      commitId: "legacy:1",
+      commitId: expect.stringMatching(/^cmt_\d{13}[0-9a-f]{8}$/),
       path: "history.txt",
       headVersion: 1,
       firstChangeId: expect.any(Number),
@@ -105,7 +105,7 @@ describe("POST stash import", () => {
     expect(response.status).toBe(201);
     const json = await response.json<Record<string, unknown>>();
     expect(json).toEqual({
-      commitId: "legacy:1",
+      commitId: expect.stringMatching(/^cmt_\d{13}[0-9a-f]{8}$/),
       path: "history.txt",
       headVersion: 3,
       firstChangeId: expect.any(Number),

--- a/workers/stash/test/routes/limits.test.ts
+++ b/workers/stash/test/routes/limits.test.ts
@@ -12,6 +12,7 @@ import type { Env } from "../../src/env.js";
 import { request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv, wrapBlobs, type BlobCallCounts } from "../helpers/env.js";
 import { escapedImportRequest, type EncodedRequest } from "../helpers/large-json.js";
+import { seedCommit } from "../helpers/seed-rows.js";
 
 const STASH = "route-limits";
 const BASE = `http://stash.test/v1/stashes/${STASH}`;
@@ -235,11 +236,12 @@ describe.sequential("raised request and text limits", () => {
     )
       .bind(STASH, hash, body, R2_SPILL_BYTES + 1, createdAt)
       .run();
+    const commitId = await seedCommit(STASH, "cmt_limits_legacy", createdAt);
     await env.DB.prepare(
       `INSERT INTO versions (
         stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-        rollback_of, author, message, meta_json, created_at
-      ) VALUES (?, ?, 1, 'put', ?, ?, 'text/plain; charset=utf-8', NULL, ?, ?, ?, ?)`,
+        rollback_of, author, message, meta_json, created_at, commit_id
+      ) VALUES (?, ?, 1, 'put', ?, ?, 'text/plain; charset=utf-8', NULL, ?, ?, ?, ?, ?)`,
     )
       .bind(
         STASH,
@@ -250,6 +252,7 @@ describe.sequential("raised request and text limits", () => {
         "pre-spill row",
         '{"source":"legacy"}',
         createdAt,
+        commitId,
       )
       .run();
     await env.DB.prepare(

--- a/workers/stash/test/routes/raw-content.test.ts
+++ b/workers/stash/test/routes/raw-content.test.ts
@@ -5,6 +5,7 @@ import { contentDisposition, parseByteRange } from "../../src/routes/raw-content
 import type { Env } from "../../src/env.js";
 import { bearer, mintToken, request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv, wrapBlobs, type BlobCallCounts } from "../helpers/env.js";
+import { seedCommit } from "../helpers/seed-rows.js";
 
 const STASH = "raw-content";
 const BASE = `http://stash.test/v1/stashes/${STASH}`;
@@ -63,12 +64,18 @@ async function seedPath(path: string, inputs: readonly SeedInput[]): Promise<str
           .run();
       }
     }
+    const commitId = await seedCommit(
+      STASH,
+      `cmt_raw_${path}_${version}`,
+      version,
+      deleted ? "delete" : "put",
+    );
     await env.DB.prepare(
       `INSERT INTO versions
          (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
           author, message, meta_json, created_at, representation, application_etag,
-          content_storage)
-       VALUES (?, ?, ?, ?, ?, ?, ?, '', '', '{}', ?, ?, ?, ?)`,
+          content_storage, commit_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, '', '', '{}', ?, ?, ?, ?, ?)`,
     )
       .bind(
         STASH,
@@ -82,6 +89,7 @@ async function seedPath(path: string, inputs: readonly SeedInput[]): Promise<str
         input.representation,
         hash,
         input.storage,
+        commitId,
       )
       .run();
   }

--- a/workers/stash/test/routes/spilled-read.test.ts
+++ b/workers/stash/test/routes/spilled-read.test.ts
@@ -12,6 +12,7 @@ import { createStashStore } from "../../src/d1/store.js";
 import type { Env } from "../../src/env.js";
 import { request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv, wrapBlobs, type BlobCallCounts } from "../helpers/env.js";
+import { seedCommit } from "../helpers/seed-rows.js";
 
 const STASH = "spilled-read";
 const BASE = `http://stash.test/v1/stashes/${STASH}`;
@@ -99,11 +100,17 @@ async function seedFile(
         .run();
     }
 
+    const commitId = await seedCommit(
+      STASH,
+      `cmt_spilled_${path}_${version}`,
+      createdAt,
+      kind,
+    );
     await bindings.DB.prepare(
       `INSERT INTO versions (
         stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-        rollback_of, author, message, meta_json, created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, 'text/plain; charset=utf-8', ?, ?, ?, ?, ?)`,
+        rollback_of, author, message, meta_json, created_at, commit_id
+      ) VALUES (?, ?, ?, ?, ?, ?, 'text/plain; charset=utf-8', ?, ?, ?, ?, ?, ?)`,
     )
       .bind(
         STASH,
@@ -117,6 +124,7 @@ async function seedFile(
         `version ${version}`,
         JSON.stringify({ version }),
         createdAt,
+        commitId,
       )
       .run();
     versions.push({

--- a/workers/stash/test/routes/spilled-read.test.ts
+++ b/workers/stash/test/routes/spilled-read.test.ts
@@ -100,12 +100,7 @@ async function seedFile(
         .run();
     }
 
-    const commitId = await seedCommit(
-      STASH,
-      `cmt_spilled_${path}_${version}`,
-      createdAt,
-      kind,
-    );
+    const commitId = await seedCommit(STASH, `cmt_spilled_${path}_${version}`, createdAt, kind);
     await bindings.DB.prepare(
       `INSERT INTO versions (
         stash_name, path, version, kind, blob_hash, size_bytes, content_type,

--- a/workers/stash/test/routes/uploads.test.ts
+++ b/workers/stash/test/routes/uploads.test.ts
@@ -95,9 +95,29 @@ describe("single raw upload lifecycle", () => {
 
     const committed = await complete(session.id);
     expect(committed.status).toBe(201);
-    const value = await committed.json<{ version: number; hash: string; changeId: number }>();
+    const value = await committed.json<{
+      commitId: string;
+      version: number;
+      hash: string;
+      changeId: number;
+    }>();
     expect(value).toMatchObject({ version: 1, hash });
     expect(value.changeId).toBeGreaterThan(0);
+    await expect(
+      env.DB.prepare(
+        `SELECT source, source_id, entry_count, change_count, sealed,
+           first_change_id, last_change_id
+         FROM commits WHERE id = ?`,
+      ).bind(value.commitId).first(),
+    ).resolves.toEqual({
+      source: "upload",
+      source_id: session.id,
+      entry_count: 1,
+      change_count: 1,
+      sealed: 1,
+      first_change_id: value.changeId,
+      last_change_id: value.changeId,
+    });
     const downloaded = await request(
       createApp(),
       `http://stash.test/v1/stashes/${STASH}/raw/asset.bin`,
@@ -113,6 +133,9 @@ describe("single raw upload lifecycle", () => {
     await expect(env.DB.prepare("SELECT COUNT(*) AS count FROM versions").first()).resolves.toEqual(
       { count: 1 },
     );
+    await expect(env.DB.prepare("SELECT COUNT(*) AS count FROM commits").first()).resolves.toEqual({
+      count: 1,
+    });
     await expect(
       env.DB.prepare("SELECT COUNT(*) AS count FROM upload_staged_bytes").first(),
     ).resolves.toEqual({ count: 0 });

--- a/workers/stash/test/routes/uploads.test.ts
+++ b/workers/stash/test/routes/uploads.test.ts
@@ -108,7 +108,9 @@ describe("single raw upload lifecycle", () => {
         `SELECT source, source_id, entry_count, change_count, sealed,
            first_change_id, last_change_id
          FROM commits WHERE id = ?`,
-      ).bind(value.commitId).first(),
+      )
+        .bind(value.commitId)
+        .first(),
     ).resolves.toEqual({
       source: "upload",
       source_id: session.id,

--- a/workers/stash/test/rpc.test.ts
+++ b/workers/stash/test/rpc.test.ts
@@ -25,6 +25,8 @@ import {
   seedRpcFixture,
 } from "./helpers/rpc.js";
 
+let rpcCommitSequence = 0;
+
 const PARITY_HEADERS = [
   "etag",
   "x-stash-version",
@@ -151,7 +153,9 @@ async function putFixture(
   expectedVersion: number | null,
   idempotencyKey?: string,
 ): Promise<{ hash: string; version: number }> {
-  const result = await createStashStore(createTestEnv().env).writes.put(
+  const result = await createStashStore(createTestEnv().env, {
+    createId: () => `rpc-fixture-${++rpcCommitSequence}`,
+  }).writes.put(
     RPC_STASH,
     "docs/rpc.txt",
     { body, expectedVersion },
@@ -475,6 +479,7 @@ function fixedRandomValues<T extends ArrayBufferView | null>(value: T): T {
 }
 
 beforeEach(() => {
+  rpcCommitSequence = 0;
   vi.spyOn(Date, "now").mockReturnValue(RPC_FIXED_NOW);
   vi.spyOn(crypto, "getRandomValues").mockImplementation(fixedRandomValues);
   vi.spyOn(crypto, "randomUUID").mockReturnValue("11111111-1111-4111-8111-111111111111");
@@ -557,6 +562,7 @@ describe("HTTP and RPC parity", () => {
   it.each(scenarios)("matches $name byte-for-byte", async (scenario) => {
     const results: Partial<Record<"http" | "rpc", ResponseSnapshot>> = {};
     for (const transport of ["http", "rpc"] as const) {
+      rpcCommitSequence = 0;
       await resetDatabase();
       await seedRpcFixture();
       const state = (await scenario.seed?.()) ?? {};

--- a/workers/stash/test/store/commit-gate-proofs.test.ts
+++ b/workers/stash/test/store/commit-gate-proofs.test.ts
@@ -395,10 +395,13 @@ describe("change-id contiguity proof", () => {
     await db.prepare("DELETE FROM sqlite_sequence WHERE name = 'versions'").run();
 
     const onBeforeCommit = async (): Promise<void> => {
-      await db.prepare(
-        `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+      await db
+        .prepare(
+          `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
          VALUES ('cmt_proof_competing', ?, 'put', 1, 'proof', 1)`,
-      ).bind(LIVE_STASH).run();
+        )
+        .bind(LIVE_STASH)
+        .run();
       await db.batch([
         db
           .prepare(
@@ -413,10 +416,12 @@ describe("change-id contiguity proof", () => {
     await onBeforeCommit();
     await db.batch(
       ["a.txt", "b.txt", "c.txt"].map((path) =>
-        db.prepare(
-          `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+        db
+          .prepare(
+            `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
            VALUES (?, ?, 'put', 1, 'proof', 1)`,
-        ).bind(`cmt_proof_${path}`, LIVE_STASH),
+          )
+          .bind(`cmt_proof_${path}`, LIVE_STASH),
       ),
     );
     await db.batch(

--- a/workers/stash/test/store/commit-gate-proofs.test.ts
+++ b/workers/stash/test/store/commit-gate-proofs.test.ts
@@ -92,11 +92,19 @@ async function insertVersion(
   version: number,
   kind: "put" | "delete" | "rollback" = "put",
 ): Promise<void> {
+  const commitId = `cmt_proof_${path}_${version}`;
+  await db
+    .prepare(
+      `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+       VALUES (?, ?, ?, 1, 'proof', 1)`,
+    )
+    .bind(commitId, LIVE_STASH, kind)
+    .run();
   await db
     .prepare(
       `INSERT INTO versions
-         (stash_name, path, version, kind, blob_hash, rollback_of, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, 1)`,
+         (stash_name, path, version, kind, blob_hash, rollback_of, created_at, commit_id)
+       VALUES (?, ?, ?, ?, ?, ?, 1, ?)`,
     )
     .bind(
       LIVE_STASH,
@@ -105,6 +113,7 @@ async function insertVersion(
       kind,
       kind === "delete" ? null : `sha256-${path}-${version}`,
       kind === "rollback" ? 1 : null,
+      commitId,
     )
     .run();
 }
@@ -129,6 +138,7 @@ async function commitIds(clientKey: string): Promise<number[]> {
 async function resetProofRows(): Promise<void> {
   await db.batch([
     db.prepare("DELETE FROM versions"),
+    db.prepare("DELETE FROM commits"),
     db.prepare("DELETE FROM files"),
     db.prepare("DELETE FROM stashes"),
     db.prepare("DELETE FROM commit_gate_proof_payloads"),
@@ -381,14 +391,19 @@ describe("D1 batch transaction and metadata proofs", () => {
 describe("change-id contiguity proof", () => {
   it("keeps one commit batch consecutive when a competing batch runs at the pre-commit hook", async () => {
     await db.prepare("DELETE FROM versions").run();
+    await db.prepare("DELETE FROM commits").run();
     await db.prepare("DELETE FROM sqlite_sequence WHERE name = 'versions'").run();
 
     const onBeforeCommit = async (): Promise<void> => {
+      await db.prepare(
+        `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+         VALUES ('cmt_proof_competing', ?, 'put', 1, 'proof', 1)`,
+      ).bind(LIVE_STASH).run();
       await db.batch([
         db
           .prepare(
-            `INSERT INTO versions (stash_name, path, version, kind, blob_hash, created_at)
-           VALUES (?, 'competing.txt', 1, 'put', 'sha256-competing', 1)`,
+            `INSERT INTO versions (stash_name, path, version, kind, blob_hash, created_at, commit_id)
+           VALUES (?, 'competing.txt', 1, 'put', 'sha256-competing', 1, 'cmt_proof_competing')`,
           )
           .bind(LIVE_STASH),
       ]);
@@ -398,12 +413,20 @@ describe("change-id contiguity proof", () => {
     await onBeforeCommit();
     await db.batch(
       ["a.txt", "b.txt", "c.txt"].map((path) =>
+        db.prepare(
+          `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+           VALUES (?, ?, 'put', 1, 'proof', 1)`,
+        ).bind(`cmt_proof_${path}`, LIVE_STASH),
+      ),
+    );
+    await db.batch(
+      ["a.txt", "b.txt", "c.txt"].map((path) =>
         db
           .prepare(
-            `INSERT INTO versions (stash_name, path, version, kind, blob_hash, created_at)
-             VALUES (?, ?, 1, 'put', ?, 1)`,
+            `INSERT INTO versions (stash_name, path, version, kind, blob_hash, created_at, commit_id)
+             VALUES (?, ?, 1, 'put', ?, 1, ?)`,
           )
-          .bind(LIVE_STASH, path, `sha256-${path}`),
+          .bind(LIVE_STASH, path, `sha256-${path}`, `cmt_proof_${path}`),
       ),
     );
 

--- a/workers/stash/test/store/import.test.ts
+++ b/workers/stash/test/store/import.test.ts
@@ -16,6 +16,7 @@ import { wrapBlobs, type BlobCallCounts } from "../helpers/env.js";
 import { generation, generationFactory } from "../helpers/blob-generations.js";
 
 const workerEnv = env as Env;
+let idSequence = 0;
 
 async function seedStash(name: string): Promise<void> {
   await env.DB.prepare(
@@ -34,7 +35,7 @@ function importer(
   let generationSequence = 0;
   return createImport(bindings, {
     now: () => now,
-    createId: () => "unused",
+    createId: () => `import-${++idSequence}`,
     createBlobGeneration: createBlobGeneration ?? (() => generation((generationSequence += 1))),
     ...(onBeforeCommit ? { onBeforeCommit } : {}),
   });
@@ -116,11 +117,25 @@ describe("history import store", () => {
       statusCode: 201,
       value: { path: "history.txt", headVersion: 5 },
     });
+    if (!result.ok) throw new Error("Expected committed import");
+    await expect(
+      env.DB.prepare(
+        `SELECT source, entry_count, change_count, sealed, first_change_id, last_change_id
+         FROM commits WHERE id = ?`,
+      ).bind(result.value.commitId).first(),
+    ).resolves.toEqual({
+      source: "import",
+      entry_count: 5,
+      change_count: 5,
+      sealed: 1,
+      first_change_id: result.value.firstChangeId,
+      last_change_id: result.createdVersions.at(-1)?.changeId,
+    });
 
     const times = [1_001, 1_002, 1_003, 1_004, 1_005];
     const writes = createWrites(workerEnv, {
       now: () => times.shift() ?? 9_999,
-      createId: () => "unused",
+      createId: () => `written-${++idSequence}`,
     });
     await writes.put("written", "history.txt", {
       body: "one",
@@ -392,6 +407,11 @@ describe("history import store", () => {
         .first(),
     ).resolves.toBeNull();
     expect(await counts(stash)).toEqual({ blobs: 3, versions: 3, files: 1, idempotency: 0 });
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM commits WHERE stash_name = ?")
+        .bind(stash)
+        .first(),
+    ).resolves.toEqual({ count: 2 });
     const objectKeys = (await env.BLOBS.list({ prefix: `v2/${stash}/` })).objects
       .map(({ key }) => key)
       .sort();
@@ -691,7 +711,10 @@ describe("history import store", () => {
 
   it("keeps the SQL batch fenced and writes the final tombstone head last", async () => {
     await seedStash("batch-fence");
-    const writes = createWrites(workerEnv, { now: () => 1_000, createId: () => "unused" });
+    const writes = createWrites(workerEnv, {
+      now: () => 1_000,
+      createId: () => `fence-${++idSequence}`,
+    });
     await writes.put("batch-fence", "race.txt", { body: "one", expectedVersion: null });
     const db = env.DB.withSession("first-primary");
     const prepared: PreparedImportVersion[] = [

--- a/workers/stash/test/store/import.test.ts
+++ b/workers/stash/test/store/import.test.ts
@@ -122,7 +122,9 @@ describe("history import store", () => {
       env.DB.prepare(
         `SELECT source, entry_count, change_count, sealed, first_change_id, last_change_id
          FROM commits WHERE id = ?`,
-      ).bind(result.value.commitId).first(),
+      )
+        .bind(result.value.commitId)
+        .first(),
     ).resolves.toEqual({
       source: "import",
       entry_count: 5,

--- a/workers/stash/test/store/import.test.ts
+++ b/workers/stash/test/store/import.test.ts
@@ -710,6 +710,9 @@ describe("history import store", () => {
       },
     ];
     const built = importBatch(db, {
+      commitId: "cmt_batch_fence",
+      createdBy: "test",
+      createdAt: 1_001,
       stash: "batch-fence",
       path: "race.txt",
       expectedVersion: 1,

--- a/workers/stash/test/store/writes/acceptance.test.ts
+++ b/workers/stash/test/store/writes/acceptance.test.ts
@@ -6,6 +6,59 @@ import { rollbackBatch } from "../../../src/d1/sql/writes.js";
 import { counts, expectError, setup } from "./helpers.js";
 
 describe("stash writes", () => {
+  it("creates one sealed commit per changed write and none for an unchanged put", async () => {
+    const { stash, writes } = await setup();
+    const put = await writes.put(stash, "committed.txt", { body: "one", expectedVersion: null });
+    if (!put.ok || "unchanged" in put.value) throw new Error("Expected committed put");
+    const unchanged = await writes.put(stash, "committed.txt", {
+      body: "one",
+      expectedVersion: 1,
+      skipIfUnchanged: true,
+    });
+    expect(unchanged).toMatchObject({ ok: true, value: { unchanged: true } });
+    const deleted = await writes.delete(stash, "committed.txt", { expectedVersion: 1 });
+    if (!deleted.ok) throw new Error("Expected committed delete");
+    const rollback = await writes.rollback(stash, "committed.txt", {
+      expectedVersion: 2,
+      toVersion: 1,
+    });
+    if (!rollback.ok) throw new Error("Expected committed rollback");
+
+    const commits = await env.DB.prepare(
+      `SELECT id, source, entry_count, change_count, sealed, first_change_id, last_change_id
+       FROM commits WHERE stash_name = ? ORDER BY first_change_id`,
+    ).bind(stash).all();
+    expect(commits.results).toEqual([
+      {
+        id: put.value.commitId,
+        source: "put",
+        entry_count: 1,
+        change_count: 1,
+        sealed: 1,
+        first_change_id: put.value.changeId,
+        last_change_id: put.value.changeId,
+      },
+      {
+        id: deleted.value.commitId,
+        source: "delete",
+        entry_count: 1,
+        change_count: 1,
+        sealed: 1,
+        first_change_id: deleted.value.changeId,
+        last_change_id: deleted.value.changeId,
+      },
+      {
+        id: rollback.value.commitId,
+        source: "rollback",
+        entry_count: 1,
+        change_count: 1,
+        sealed: 1,
+        first_change_id: rollback.value.changeId,
+        last_change_id: rollback.value.changeId,
+      },
+    ]);
+  });
+
   it("preserves byte-exact bodies and reports the inserted version id", async () => {
     const { stash, writes } = await setup();
     const bodies = ["日本語", "line1\r\nline2", "trailing\n", ""];
@@ -198,6 +251,11 @@ describe("stash writes", () => {
       files: before.files,
       idempotency: before.idempotency,
     });
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM commits WHERE stash_name = ?")
+        .bind(initial.stash)
+        .first(),
+    ).resolves.toEqual({ count: 2 });
     expect(
       await env.DB.prepare("SELECT 1 FROM blobs WHERE stash_name = ? AND body = ?")
         .bind(initial.stash, "loser-unique-body")
@@ -227,6 +285,11 @@ describe("stash writes", () => {
     if (result.ok) throw new Error("expected stale delete");
     expect(result.current).toMatchObject({ version: 2, deleted: true, kind: "delete" });
     expect(await counts(initial.stash)).toEqual(afterWinner);
+    await expect(
+      env.DB.prepare("SELECT COUNT(*) AS count FROM commits WHERE stash_name = ?")
+        .bind(initial.stash)
+        .first(),
+    ).resolves.toEqual({ count: 2 });
   });
 
   it("allows exactly one real concurrent CAS writer", async () => {

--- a/workers/stash/test/store/writes/acceptance.test.ts
+++ b/workers/stash/test/store/writes/acceptance.test.ts
@@ -27,7 +27,9 @@ describe("stash writes", () => {
     const commits = await env.DB.prepare(
       `SELECT id, source, entry_count, change_count, sealed, first_change_id, last_change_id
        FROM commits WHERE stash_name = ? ORDER BY first_change_id`,
-    ).bind(stash).all();
+    )
+      .bind(stash)
+      .all();
     expect(commits.results).toEqual([
       {
         id: put.value.commitId,

--- a/workers/stash/test/store/writes/acceptance.test.ts
+++ b/workers/stash/test/store/writes/acceptance.test.ts
@@ -255,6 +255,8 @@ describe("stash writes", () => {
     const before = await counts(stash);
     const results = await db.batch(
       rollbackBatch(db, {
+        commitId: "cmt_tombstone_refusal",
+        createdBy: "test",
         stash,
         path: "hole.txt",
         expectedVersion: 2,

--- a/workers/stash/test/store/writes/helpers.ts
+++ b/workers/stash/test/store/writes/helpers.ts
@@ -10,6 +10,7 @@ export async function setup(overrides: Partial<WriteDependencies> = {}) {
   const stash = `writes-${sequence}`;
   const now = overrides.now ?? (() => 1_700_000_000_000 + sequence);
   let generationSequence = sequence * 1_000;
+  let idSequence = 0;
   await env.DB.prepare(
     "INSERT INTO stashes (name, description, meta_json, created_at) VALUES (?, '', '{}', ?)",
   )
@@ -18,7 +19,7 @@ export async function setup(overrides: Partial<WriteDependencies> = {}) {
   const workerEnv = env as Env;
   const deps: WriteDependencies = {
     now,
-    createId: overrides.createId ?? (() => `id-${sequence}`),
+    createId: overrides.createId ?? (() => `id-${sequence}-${++idSequence}`),
     createBlobGeneration:
       overrides.createBlobGeneration ?? (() => generation((generationSequence += 1))),
     ...(overrides.onBeforeCommit ? { onBeforeCommit: overrides.onBeforeCommit } : {}),


### PR DESCRIPTION
Parent: #206

Relates to #209.

## Summary

- add migration 0009 and make every persisted version belong to a sealed commit
- synthesize legacy commits for existing rows during migration
- mint one-entry commits inside all existing write, import, and upload batches

## Validation

- 566 Stash tests passed at topic completion
- typecheck, lint, formatting, and focused migration/write checks passed
- blocking topic review completed before integration
