### PR TITLE
Add filtered file listings and commit snapshots

### DIFF
--- a/workers/stash/src/d1/reads.ts
+++ b/workers/stash/src/d1/reads.ts
@@ -10,6 +10,7 @@ import {
   type JsonValue,
   type Representation,
   type VersionKind,
+  validatePath,
 } from "@takazudo/zudo-history-stash-core";
 import { parseBinarySettings } from "../binary-config.js";
 import type { Env } from "../env.js";
@@ -19,11 +20,15 @@ import {
   SELECT_CHANGES_ASC,
   SELECT_CHANGES_BEFORE,
   SELECT_CHANGES_NEWEST,
+  SELECT_FILE_COMMON_PREFIXES,
   SELECT_FILE_HEAD,
   SELECT_FILE_VERSION,
   SELECT_FILES,
   SELECT_HISTORY_HEAD,
   SELECT_HISTORY_VERSIONS,
+  SELECT_SNAPSHOT_COMMON_PREFIXES,
+  SELECT_SNAPSHOT_COMMIT,
+  SELECT_SNAPSHOT_FILES,
   type ChangeRow,
   type FileReadRow,
   type FileSummaryRow,
@@ -95,6 +100,14 @@ export interface ReadFileSummary {
 
 export interface ReadFileList {
   files: ReadFileSummary[];
+  commonPrefixes?: string[];
+  nextAfter: string | null;
+}
+
+export interface ReadSnapshot {
+  at: { commitId: string; changeId: number };
+  files: ReadFileSummary[];
+  commonPrefixes?: string[];
   nextAfter: string | null;
 }
 
@@ -137,6 +150,8 @@ export interface ListFilesOptions {
   includeDeleted?: boolean;
   limit?: number;
   after?: string;
+  prefix?: string;
+  delimiter?: string;
 }
 
 export interface ListHistoryOptions {
@@ -161,6 +176,11 @@ export interface StashReads {
   getByteObject(source: ReadFileSource, range?: ByteRange): Promise<ByteObject>;
   getFile(stash: string, path: string, options?: GetFileOptions): Promise<ReadFileRecord | null>;
   listFiles(stash: string, options?: ListFilesOptions): Promise<ReadFileList>;
+  getSnapshot(
+    stash: string,
+    commitId: string,
+    options?: ListFilesOptions,
+  ): Promise<ReadSnapshot | null>;
   listHistory(
     stash: string,
     path: string,
@@ -205,6 +225,49 @@ function validateSince(value: number | undefined): number | undefined {
 function validateString(value: string, name: string): string {
   if (typeof value !== "string") return validation(`${name} must be a string.`);
   return value;
+}
+
+interface PathRange {
+  lo: string | null;
+  hi: string | null;
+}
+
+interface NormalizedListOptions {
+  includeDeleted: boolean;
+  limit: number;
+  after: string | undefined;
+  delimiter: "/" | undefined;
+  range: PathRange;
+}
+
+function normalizePrefix(value: string | undefined): PathRange {
+  if (value === undefined) return { lo: null, hi: null };
+  const prefix = validateString(value, "prefix");
+  const path = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+  const result = validatePath(path);
+  if (!result.ok) throw new StashError(result.error, result.message);
+  return { lo: `${path}/`, hi: `${path}0` };
+}
+
+function normalizeListOptions(options: ListFilesOptions): NormalizedListOptions {
+  const includeDeleted = options.includeDeleted ?? false;
+  if (typeof includeDeleted !== "boolean") {
+    return validation("includeDeleted must be a boolean.");
+  }
+  const delimiter = options.delimiter;
+  if (delimiter !== undefined && delimiter !== "/") {
+    return validation("delimiter must be '/'.");
+  }
+  const limit = validateLimit(options.limit);
+  const after = options.after;
+  if (after !== undefined) validateString(after, "after");
+  return {
+    includeDeleted,
+    limit,
+    after,
+    delimiter,
+    range: normalizePrefix(options.prefix),
+  };
 }
 
 function isJsonValue(value: unknown): value is JsonValue {
@@ -366,6 +429,40 @@ function mapFileSummary(row: FileSummaryRow, jsonInlineMaxBytes: number): ReadFi
   };
 }
 
+interface CommonPrefixRow {
+  common_prefix: string;
+}
+
+interface ListedRows {
+  files: FileSummaryRow[];
+  commonPrefixes: string[];
+  nextAfter: string | null;
+}
+
+function pageListedRows(
+  fileRows: FileSummaryRow[],
+  prefixRows: CommonPrefixRow[],
+  limit: number,
+): ListedRows {
+  const entries = [
+    ...fileRows.map((row) => ({ path: row.path, row, commonPrefix: undefined })),
+    ...prefixRows.map((row) => ({
+      path: row.common_prefix,
+      row: undefined,
+      commonPrefix: row.common_prefix,
+    })),
+  ].sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  const hasMore = entries.length > limit;
+  const page = hasMore ? entries.slice(0, limit) : entries;
+  return {
+    files: page.flatMap((entry) => (entry.row === undefined ? [] : [entry.row])),
+    commonPrefixes: page.flatMap((entry) =>
+      entry.commonPrefix === undefined ? [] : [entry.commonPrefix],
+    ),
+    nextAfter: hasMore ? (page.at(-1)?.path ?? null) : null,
+  };
+}
+
 function mapChange(row: ChangeRow, jsonInlineMaxBytes: number): ReadChangeItem {
   return {
     changeId: row.change_id,
@@ -462,24 +559,125 @@ export function createReads(env: Env, _deps?: StoreDependencies): StashReads {
 
     async listFiles(stash, options = {}) {
       const stashName = validateString(stash, "stash");
-      const includeDeleted = options.includeDeleted ?? false;
-      if (typeof includeDeleted !== "boolean")
-        return validation("includeDeleted must be a boolean.");
-      const limit = validateLimit(options.limit);
-      const after = options.after;
-      if (after !== undefined) validateString(after, "after");
+      const normalized = normalizeListOptions(options);
 
       const session = env.DB.withSession("first-primary");
-      const result = await session
+      const fileResult = await session
         .prepare(SELECT_FILES)
-        .bind(stashName, includeDeleted ? 1 : 0, after ?? null, after ?? null, limit + 1)
+        .bind(
+          stashName,
+          normalized.includeDeleted ? 1 : 0,
+          normalized.range.lo,
+          normalized.range.lo,
+          normalized.range.hi,
+          normalized.after ?? null,
+          normalized.after ?? null,
+          normalized.delimiter ?? null,
+          normalized.range.lo,
+          normalized.limit + 1,
+        )
         .all<FileSummaryRow>();
-      const rows = result.results;
-      const hasMore = rows.length > limit;
-      if (hasMore) rows.pop();
+      const rows = fileResult.results;
+      if (normalized.delimiter === undefined) {
+        const hasMore = rows.length > normalized.limit;
+        if (hasMore) rows.pop();
+        return {
+          files: rows.map((row) => mapFileSummary(row, jsonInlineMaxBytes)),
+          nextAfter: hasMore ? (rows.at(-1)?.path ?? null) : null,
+        };
+      }
+
+      const prefixResult = await session
+        .prepare(SELECT_FILE_COMMON_PREFIXES)
+        .bind(
+          normalized.range.lo,
+          normalized.range.lo,
+          stashName,
+          normalized.includeDeleted ? 1 : 0,
+          normalized.range.lo,
+          normalized.range.lo,
+          normalized.range.hi,
+          normalized.after ?? null,
+          normalized.range.lo,
+          normalized.range.lo,
+          normalized.after ?? null,
+          normalized.delimiter,
+          normalized.range.lo,
+          normalized.limit + 1,
+        )
+        .all<CommonPrefixRow>();
+      const page = pageListedRows(rows, prefixResult.results, normalized.limit);
       return {
-        files: rows.map((row) => mapFileSummary(row, jsonInlineMaxBytes)),
-        nextAfter: hasMore ? (rows.at(-1)?.path ?? null) : null,
+        files: page.files.map((row) => mapFileSummary(row, jsonInlineMaxBytes)),
+        commonPrefixes: page.commonPrefixes,
+        nextAfter: page.nextAfter,
+      };
+    },
+
+    async getSnapshot(stash, commitId, options = {}) {
+      const stashName = validateString(stash, "stash");
+      const id = validateString(commitId, "commitId");
+      const normalized = normalizeListOptions(options);
+      const session = env.DB.withSession("first-primary");
+      const commit = await session
+        .prepare(SELECT_SNAPSHOT_COMMIT)
+        .bind(stashName, id)
+        .first<{ commit_id: string; last_change_id: number }>();
+      if (commit === null) return null;
+
+      const fileResult = await session
+        .prepare(SELECT_SNAPSHOT_FILES)
+        .bind(
+          commit.last_change_id,
+          stashName,
+          normalized.includeDeleted ? 1 : 0,
+          normalized.range.lo,
+          normalized.range.lo,
+          normalized.range.hi,
+          normalized.after ?? null,
+          normalized.after ?? null,
+          normalized.delimiter ?? null,
+          normalized.range.lo,
+          normalized.limit + 1,
+        )
+        .all<FileSummaryRow>();
+      const rows = fileResult.results;
+      if (normalized.delimiter === undefined) {
+        const hasMore = rows.length > normalized.limit;
+        if (hasMore) rows.pop();
+        return {
+          at: { commitId: commit.commit_id, changeId: commit.last_change_id },
+          files: rows.map((row) => mapFileSummary(row, jsonInlineMaxBytes)),
+          nextAfter: hasMore ? (rows.at(-1)?.path ?? null) : null,
+        };
+      }
+
+      const prefixResult = await session
+        .prepare(SELECT_SNAPSHOT_COMMON_PREFIXES)
+        .bind(
+          normalized.range.lo,
+          normalized.range.lo,
+          commit.last_change_id,
+          stashName,
+          normalized.includeDeleted ? 1 : 0,
+          normalized.range.lo,
+          normalized.range.lo,
+          normalized.range.hi,
+          normalized.after ?? null,
+          normalized.range.lo,
+          normalized.range.lo,
+          normalized.after ?? null,
+          normalized.delimiter,
+          normalized.range.lo,
+          normalized.limit + 1,
+        )
+        .all<CommonPrefixRow>();
+      const page = pageListedRows(rows, prefixResult.results, normalized.limit);
+      return {
+        at: { commitId: commit.commit_id, changeId: commit.last_change_id },
+        files: page.files.map((row) => mapFileSummary(row, jsonInlineMaxBytes)),
+        commonPrefixes: page.commonPrefixes,
+        nextAfter: page.nextAfter,
       };
     },
 

--- a/workers/stash/src/d1/sql/reads.ts
+++ b/workers/stash/src/d1/sql/reads.ts
@@ -98,8 +98,113 @@ export const SELECT_FILES = `
    AND v.version = f.head_version
   WHERE f.stash_name = ?
     AND (? = 1 OR f.deleted = 0)
+    AND (? IS NULL OR (f.path >= ? AND f.path < ?))
     AND (? IS NULL OR f.path > ?)
+    AND (? IS NULL OR instr(substr(f.path, length(COALESCE(?, '')) + 1), '/') = 0)
   ORDER BY f.path ASC
+  LIMIT ?
+`;
+
+export const SELECT_FILE_COMMON_PREFIXES = `
+  SELECT DISTINCT
+    substr(
+      f.path,
+      1,
+      length(COALESCE(?, '')) +
+        instr(substr(f.path, length(COALESCE(?, '')) + 1), '/')
+    ) AS common_prefix
+  FROM files AS f
+  WHERE f.stash_name = ?
+    AND (? = 1 OR f.deleted = 0)
+    AND (? IS NULL OR (f.path >= ? AND f.path < ?))
+    AND (? IS NULL OR (
+      substr(
+        f.path,
+        1,
+        length(COALESCE(?, '')) +
+          instr(substr(f.path, length(COALESCE(?, '')) + 1), '/')
+      ) > ?
+    ))
+    AND (? IS NOT NULL)
+    AND instr(substr(f.path, length(COALESCE(?, '')) + 1), '/') > 0
+  ORDER BY common_prefix ASC
+  LIMIT ?
+`;
+
+export const SELECT_SNAPSHOT_COMMIT = `
+  SELECT id AS commit_id, last_change_id
+  FROM commits
+  WHERE stash_name = ?
+    AND id = ?
+    AND sealed = 1
+    AND last_change_id IS NOT NULL
+  LIMIT 1
+`;
+
+export const SELECT_SNAPSHOT_FILES = `
+  SELECT
+    f.path AS path,
+    s.version AS head_version,
+    s.blob_hash AS hash,
+    s.size_bytes AS size,
+    CASE WHEN s.kind = 'delete' THEN 1 ELSE 0 END AS deleted,
+    s.created_at AS updated_at,
+    s.content_type AS content_type,
+    s.representation AS representation,
+    s.application_etag AS application_etag
+  FROM files AS f
+  JOIN versions AS s
+    ON s.id = (
+      SELECT v.id
+      FROM versions AS v
+      WHERE v.stash_name = f.stash_name
+        AND v.path = f.path
+        AND v.id <= ?
+      ORDER BY v.version DESC
+      LIMIT 1
+    )
+  WHERE f.stash_name = ?
+    AND (? = 1 OR s.kind <> 'delete')
+    AND (? IS NULL OR (f.path >= ? AND f.path < ?))
+    AND (? IS NULL OR f.path > ?)
+    AND (? IS NULL OR instr(substr(f.path, length(COALESCE(?, '')) + 1), '/') = 0)
+  ORDER BY f.path ASC
+  LIMIT ?
+`;
+
+export const SELECT_SNAPSHOT_COMMON_PREFIXES = `
+  SELECT DISTINCT
+    substr(
+      f.path,
+      1,
+      length(COALESCE(?, '')) +
+        instr(substr(f.path, length(COALESCE(?, '')) + 1), '/')
+    ) AS common_prefix
+  FROM files AS f
+  JOIN versions AS s
+    ON s.id = (
+      SELECT v.id
+      FROM versions AS v
+      WHERE v.stash_name = f.stash_name
+        AND v.path = f.path
+        AND v.id <= ?
+      ORDER BY v.version DESC
+      LIMIT 1
+    )
+  WHERE f.stash_name = ?
+    AND (? = 1 OR s.kind <> 'delete')
+    AND (? IS NULL OR (f.path >= ? AND f.path < ?))
+    AND (? IS NULL OR (
+      substr(
+        f.path,
+        1,
+        length(COALESCE(?, '')) +
+          instr(substr(f.path, length(COALESCE(?, '')) + 1), '/')
+      ) > ?
+    ))
+    AND (? IS NOT NULL)
+    AND instr(substr(f.path, length(COALESCE(?, '')) + 1), '/') > 0
+  ORDER BY common_prefix ASC
   LIMIT ?
 `;
 

--- a/workers/stash/src/routes/index.ts
+++ b/workers/stash/src/routes/index.ts
@@ -13,6 +13,7 @@ import importRoutes from "./import.js";
 import lifecycle from "./lifecycle.js";
 import meta from "./meta.js";
 import rawContent from "./raw-content.js";
+import snapshot from "./snapshot.js";
 import uploads from "./uploads.js";
 
 function middlewarePath(route: (typeof ROUTES)[number]): string {
@@ -37,6 +38,7 @@ routes.route("/", importRoutes);
 routes.route("/", lifecycle);
 routes.route("/", events);
 routes.route("/", rawContent);
+routes.route("/", snapshot);
 routes.route("/", uploads);
 routes.all("/v1/*", (c) => {
   void c.env.CHANGE_SET_TTL_DAYS;

--- a/workers/stash/src/routes/snapshot.ts
+++ b/workers/stash/src/routes/snapshot.ts
@@ -1,0 +1,27 @@
+import { SnapshotQuery, StashError } from "@takazudo/zudo-history-stash-core";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import type { AppEnv } from "../context.js";
+import { createStashStore } from "../d1/store.js";
+
+const snapshot = new Hono<AppEnv>();
+
+snapshot.get(
+  "/v1/stashes/:stash/snapshot",
+  zValidator("query", SnapshotQuery, (result) => {
+    if (!result.success) throw new StashError("validation", "Invalid snapshot query.");
+  }),
+  async (c) => {
+    const query = c.req.valid("query");
+    const commitId = query.at.slice("commit:".length);
+    const result = await createStashStore(c.env).reads.getSnapshot(
+      c.get("routeStash").name,
+      commitId,
+      query,
+    );
+    if (result === null) throw new StashError("not-found", "The requested resource was not found.");
+    return c.json(result);
+  },
+);
+
+export default snapshot;

--- a/workers/stash/src/rpc.ts
+++ b/workers/stash/src/rpc.ts
@@ -1,6 +1,7 @@
 import {
   createStashClient,
   parseClientResponse,
+  StashHttpError,
   type ChangesOptions,
   type ClientResult,
   type DiffOptions,
@@ -346,7 +347,29 @@ export class StashRpc extends WorkerEntrypoint<Env> implements StashRpcMethods {
     stash: string,
     options?: ListFilesOptions,
   ): Promise<ClientResult<FileListResponse>> {
-    return noThrow(() => rpcClient(this, token).files(stash).list(options));
+    return noThrow(async () => {
+      let response: Response;
+      try {
+        response = await this.request({
+          method: "GET",
+          path: `/v1/stashes/${stash}/files`,
+          query: optionalQuery({
+            includeDeleted: options?.includeDeleted,
+            limit: options?.limit,
+            after: options?.after,
+            prefix: options?.prefix,
+            delimiter: options?.delimiter,
+          }),
+          token,
+        });
+      } catch (error) {
+        throw new StashHttpError(0, undefined, undefined, error);
+      }
+      return (await parseClientResponse<FileListResponse>(
+        response,
+        "listFiles",
+      )) as ClientResult<FileListResponse>;
+    });
   }
 
   async getFile(

--- a/workers/stash/src/rpc.ts
+++ b/workers/stash/src/rpc.ts
@@ -14,6 +14,7 @@ import {
   type MutationOptions,
   type StashRpcMethods,
 } from "@takazudo/zudo-history-stash";
+import { statusForCode, validateStashName } from "@takazudo/zudo-history-stash-core";
 import type {
   CandidateDiffResult,
   ApproveChangeSetBody,
@@ -347,6 +348,17 @@ export class StashRpc extends WorkerEntrypoint<Env> implements StashRpcMethods {
     stash: string,
     options?: ListFilesOptions,
   ): Promise<ClientResult<FileListResponse>> {
+    const stashValidation = validateStashName(stash);
+    if (!stashValidation.ok) {
+      return {
+        ok: false,
+        error: {
+          code: stashValidation.error,
+          status: statusForCode(stashValidation.error),
+          message: stashValidation.message,
+        },
+      };
+    }
     return noThrow(async () => {
       let response: Response;
       try {

--- a/workers/stash/test/route-pin.test.ts
+++ b/workers/stash/test/route-pin.test.ts
@@ -16,7 +16,6 @@ const skeletonRouteProbes = [
   { id: "listCommits", method: "GET", path: "/v1/stashes/route-pin/commits" },
   { id: "getCommitDiff", method: "GET", path: "/v1/stashes/route-pin/commits/cmt_1/diff" },
   { id: "revertCommit", method: "POST", path: "/v1/stashes/route-pin/commits/cmt_1/revert" },
-  { id: "getSnapshot", method: "GET", path: "/v1/stashes/route-pin/snapshot?at=commit%3Acmt_1" },
   { id: "createChangeSet", method: "POST", path: "/v1/stashes/route-pin/change-sets" },
   { id: "listChangeSets", method: "GET", path: "/v1/stashes/route-pin/change-sets" },
   { id: "getChangeSet", method: "GET", path: "/v1/stashes/route-pin/change-sets/chs_1" },
@@ -136,7 +135,7 @@ describe("route contract pin", () => {
     expect(response.status).toBe(501);
   });
 
-  it("keeps all twelve raw skeleton RPC methods on generic request transport", async () => {
+  it("keeps the remaining raw skeleton RPC methods on generic request transport", async () => {
     await seedStash("route-pin");
     const rpc = new StashRpc(createExecutionContext(), createTestEnv().env);
     const entry = { op: "put" as const, path: "docs/a.md", expectedVersion: null, body: "a" };
@@ -164,7 +163,11 @@ describe("route contract pin", () => {
       rpc.approveChangeSet("test-admin", "route-pin", "chs_1", {}),
       rpc.rejectChangeSet("test-admin", "route-pin", "chs_1", {}),
     ]);
-    expect(responses.map(({ status }) => status)).toEqual(Array(12).fill(501));
+    expect(responses.map(({ status }) => status)).toEqual([
+      ...Array(5).fill(501),
+      404,
+      ...Array(6).fill(501),
+    ]);
   });
 
   it("exports one parser and transport-error identity from the client package root", async () => {

--- a/workers/stash/test/routes/files.test.ts
+++ b/workers/stash/test/routes/files.test.ts
@@ -117,6 +117,49 @@ describe("file route reads", () => {
     await expectCode(await api("/files?unexpected=true"), 400, "validation");
   });
 
+  it("bounds prefix ranges, paginates within them, and emits delimiter prefixes", async () => {
+    for (const [path, body] of [
+      ["site/a.css", "a"],
+      ["site/nested/b.css", "b"],
+      ["site/nested/deep/c.css", "c"],
+      ["site-old/x.css", "old"],
+    ] as const) {
+      expect((await put(path, body, null)).status).toBe(201);
+    }
+
+    const bounded = await api("/files?prefix=site%2F");
+    expect(bounded.status).toBe(200);
+    await expect(bounded.json()).resolves.toMatchObject({
+      files: [
+        { path: "site/a.css" },
+        { path: "site/nested/b.css" },
+        { path: "site/nested/deep/c.css" },
+      ],
+      nextAfter: null,
+    });
+
+    const first = await api("/files?prefix=site%2F&limit=1");
+    const firstPage = await first.json<{ files: { path: string }[]; nextAfter: string | null }>();
+    expect(firstPage).toMatchObject({ files: [{ path: "site/a.css" }], nextAfter: "site/a.css" });
+    const second = await api(
+      `/files?prefix=site%2F&limit=1&after=${encodeURIComponent(firstPage.nextAfter ?? "")}`,
+    );
+    await expect(second.json()).resolves.toMatchObject({
+      files: [{ path: "site/nested/b.css" }],
+      nextAfter: "site/nested/b.css",
+    });
+
+    const delimited = await api("/files?prefix=site%2F&delimiter=%2F");
+    await expect(delimited.json()).resolves.toMatchObject({
+      files: [{ path: "site/a.css" }],
+      commonPrefixes: ["site/nested/"],
+      nextAfter: null,
+    });
+
+    await expectCode(await api("/files?prefix=site%2F%2F"), 400, "invalid-path");
+    await expectCode(await api("/files?delimiter=."), 400, "validation");
+  });
+
   it("round-trips exact bodies and returns only the public file representation", async () => {
     const bodies = ["日本語", "line1\r\nline2", ""];
     for (const [index, body] of bodies.entries()) {

--- a/workers/stash/test/routes/snapshot.test.ts
+++ b/workers/stash/test/routes/snapshot.test.ts
@@ -1,0 +1,165 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it } from "vitest";
+import { app } from "../../src/app.js";
+import { SELECT_SNAPSHOT_FILES } from "../../src/d1/sql/reads.js";
+import { request, resetDatabase, seedStash } from "../helpers/app.js";
+
+const STASH = "route-snapshot";
+const BASE = `http://stash.test/v1/stashes/${STASH}`;
+
+async function api(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", "Bearer test-admin");
+  return request(app, `${BASE}${path}`, { ...init, headers });
+}
+
+async function put(
+  path: string,
+  body: string,
+  expectedVersion: number | null,
+): Promise<{
+  commitId: string;
+  version: number;
+}> {
+  const response = await api(`/files/${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body, expectedVersion }),
+  });
+  expect(response.status).toBe(201);
+  return response.json();
+}
+
+async function deleteFile(path: string, expectedVersion: number): Promise<{ commitId: string }> {
+  const response = await api(`/delete/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ expectedVersion }),
+  });
+  expect(response.status).toBe(200);
+  return response.json();
+}
+
+async function rollback(
+  path: string,
+  expectedVersion: number,
+  toVersion: number,
+): Promise<{ commitId: string }> {
+  const response = await api(`/rollback/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ expectedVersion, toVersion }),
+  });
+  expect(response.status).toBe(201);
+  return response.json();
+}
+
+async function snapshot(commitId: string, query = ""): Promise<Response> {
+  return api(`/snapshot?at=${encodeURIComponent(`commit:${commitId}`)}${query}`);
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  await seedStash(STASH);
+});
+
+describe("snapshot route reads", () => {
+  it("reconstructs state at every persisted commit, including rollback and late paths", async () => {
+    const first = await put("docs/readme.txt", "one", null);
+    const second = await put("docs/readme.txt", "two", 1);
+    const third = await deleteFile("docs/readme.txt", 2);
+    const fourth = await rollback("docs/readme.txt", 3, 1);
+    const fifth = await put("late.txt", "late", null);
+
+    const firstSnapshot = await snapshot(first.commitId);
+    await expect(firstSnapshot.json()).resolves.toMatchObject({
+      at: { commitId: first.commitId, changeId: expect.any(Number) },
+      files: [{ path: "docs/readme.txt", headVersion: 1, deleted: false }],
+      nextAfter: null,
+    });
+
+    const secondSnapshot = await snapshot(second.commitId);
+    await expect(secondSnapshot.json()).resolves.toMatchObject({
+      files: [{ path: "docs/readme.txt", headVersion: 2, deleted: false }],
+    });
+
+    const thirdSnapshot = await snapshot(third.commitId);
+    await expect(thirdSnapshot.json()).resolves.toMatchObject({ files: [], nextAfter: null });
+    const thirdWithDeleted = await snapshot(third.commitId, "&includeDeleted=true");
+    await expect(thirdWithDeleted.json()).resolves.toMatchObject({
+      files: [{ path: "docs/readme.txt", headVersion: 3, deleted: true, hash: null }],
+    });
+
+    const fourthSnapshot = await snapshot(fourth.commitId);
+    await expect(fourthSnapshot.json()).resolves.toMatchObject({
+      files: [{ path: "docs/readme.txt", headVersion: 4, deleted: false }],
+    });
+
+    const fifthSnapshot = await snapshot(fifth.commitId);
+    await expect(fifthSnapshot.json()).resolves.toMatchObject({
+      files: [
+        { path: "docs/readme.txt", headVersion: 4, deleted: false },
+        { path: "late.txt", headVersion: 1, deleted: false },
+      ],
+    });
+  });
+
+  it("applies prefix, delimiter, and keyset pagination to snapshot state", async () => {
+    await put("site/a.css", "a", null);
+    const second = await put("site/nested/b.css", "b", null);
+    await put("site-old/x.css", "old", null);
+
+    const bounded = await snapshot(second.commitId, "&prefix=site%2F");
+    await expect(bounded.json()).resolves.toMatchObject({
+      files: [{ path: "site/a.css" }, { path: "site/nested/b.css" }],
+    });
+
+    const delimited = await snapshot(second.commitId, "&prefix=site%2F&delimiter=%2F");
+    await expect(delimited.json()).resolves.toMatchObject({
+      files: [{ path: "site/a.css" }],
+      commonPrefixes: ["site/nested/"],
+      nextAfter: null,
+    });
+
+    const page = await snapshot(second.commitId, "&prefix=site%2F&limit=1");
+    const body = await page.json<{ files: { path: string }[]; nextAfter: string | null }>();
+    expect(body.files.map(({ path }) => path)).toEqual(["site/a.css"]);
+    expect(body.nextAfter).toBe("site/a.css");
+    const next = await snapshot(
+      second.commitId,
+      `&prefix=site%2F&limit=1&after=${encodeURIComponent(body.nextAfter ?? "")}`,
+    );
+    await expect(next.json()).resolves.toMatchObject({
+      files: [{ path: "site/nested/b.css" }],
+      nextAfter: null,
+    });
+  });
+
+  it("conceals unknown and unsealed commits", async () => {
+    const unknown = await snapshot("cmt_missing");
+    expect(unknown.status).toBe(404);
+    await expect(unknown.json()).resolves.toMatchObject({ error: { code: "not-found" } });
+
+    await env.DB.prepare(
+      `INSERT INTO commits (id, stash_name, source, entry_count, created_by, created_at)
+       VALUES ('cmt_unsealed', ?, 'put', 1, 'test', 1)`,
+    )
+      .bind(STASH)
+      .run();
+    const unsealed = await snapshot("cmt_unsealed");
+    expect(unsealed.status).toBe(404);
+    await expect(unsealed.json()).resolves.toMatchObject({ error: { code: "not-found" } });
+  });
+
+  it("uses the versions covering index for the correlated per-file seek", async () => {
+    const plan = await env.DB.prepare(`EXPLAIN QUERY PLAN ${SELECT_SNAPSHOT_FILES}`)
+      .bind(100, STASH, 0, null, null, null, null, null, null, null, 1)
+      .all<{ detail: string }>();
+    const details = plan.results.map(({ detail }) => detail).join("\n");
+    expect(details).toMatch(/SEARCH v USING COVERING INDEX .*versions/);
+    expect(details).not.toMatch(/SCAN v/);
+    expect(SELECT_SNAPSHOT_FILES).toContain("JOIN versions AS s");
+    expect(SELECT_SNAPSHOT_FILES).toContain("SELECT v.id");
+    expect(SELECT_SNAPSHOT_FILES).not.toMatch(/GROUP BY.*path/i);
+  });
+});

--- a/workers/stash/test/rpc.test.ts
+++ b/workers/stash/test/rpc.test.ts
@@ -994,4 +994,15 @@ describe("typed StashRpc methods", () => {
       },
     });
   });
+
+  it("preserves local stash validation before the raw list request", async () => {
+    const rpc = new StashRpc(createExecutionContext(), createTestEnv().env);
+    const request = vi.spyOn(rpc, "request");
+
+    await expect(rpc.listFiles(RPC_READ_TOKEN, "INVALID_STASH")).resolves.toEqual({
+      ok: false,
+      error: { code: "validation", status: 400, message: "Invalid stash name" },
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Parent: #206

Relates to #211.

## Summary

- add prefix and delimiter filtering to file listings
- add derived stash snapshots at sealed commit boundaries
- expose the read surface through HTTP and RPC with deterministic pagination

## Validation

- 74 focused route and RPC tests passed during integration
- typecheck, lint, and formatting passed
- blocking topic review completed before integration
