### PR TITLE
Add staged change sets and read APIs

### DIFF
--- a/workers/stash/migrations/0010_change_sets.sql
+++ b/workers/stash/migrations/0010_change_sets.sql
@@ -1,0 +1,46 @@
+CREATE TABLE change_sets (
+  id                      TEXT PRIMARY KEY, /* 'chs_' + 13-digit epoch ms + 8 hex */
+  stash_name              TEXT NOT NULL REFERENCES stashes(name),
+  status                  TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','applied','rejected')),
+  author                  TEXT NOT NULL DEFAULT '',
+  message                 TEXT NOT NULL DEFAULT '',
+  meta_json               TEXT NOT NULL DEFAULT '{}',
+  expires_at              INTEGER NOT NULL,
+  created_by              TEXT NOT NULL,
+  created_at              INTEGER NOT NULL,
+  idempotency_key         TEXT,
+  request_hash            TEXT,
+  expected_last_change_id INTEGER,
+  decision_attempt        TEXT,
+  decided_at              INTEGER,
+  decided_by              TEXT,
+  decision_reason         TEXT,
+  commit_id               TEXT REFERENCES commits(id)
+);
+
+CREATE INDEX change_sets_stash_status_created
+  ON change_sets (stash_name, status, created_at, id);
+CREATE UNIQUE INDEX change_sets_stash_idempotency
+  ON change_sets (stash_name, idempotency_key) WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE change_set_entries (
+  change_set_id       TEXT NOT NULL REFERENCES change_sets(id),
+  stash_name          TEXT NOT NULL REFERENCES stashes(name),
+  path                TEXT NOT NULL,
+  op                  TEXT NOT NULL CHECK (op IN ('put','copy','delete','rollback')),
+  base_version        INTEGER CHECK (base_version IS NULL OR base_version > 0),
+  blob_hash           TEXT,
+  content_storage     TEXT CHECK (content_storage IN ('legacy','bytes')),
+  representation      TEXT CHECK (representation IN ('text','binary')),
+  content_type        TEXT,
+  size_bytes          INTEGER CHECK (size_bytes IS NULL OR size_bytes >= 0),
+  rollback_to         INTEGER,
+  copied_from_path    TEXT,
+  copied_from_version INTEGER,
+  PRIMARY KEY (change_set_id, path),
+  CHECK ((op = 'rollback') = (rollback_to IS NOT NULL)),
+  CHECK (op <> 'delete' OR blob_hash IS NULL),
+  CHECK (op <> 'put' OR blob_hash IS NOT NULL)
+);
+
+CREATE INDEX change_set_entries_stash_path ON change_set_entries (stash_name, path);

--- a/workers/stash/src/d1/change-sets.ts
+++ b/workers/stash/src/d1/change-sets.ts
@@ -4,10 +4,12 @@ import {
   IDEMPOTENCY_KEY_MAX_CHARS,
   LIST_LIMIT_DEFAULT,
   LIST_LIMIT_MAX,
+  MAX_COMMIT_INLINE_BYTES,
   MAX_META_BYTES,
   StashError,
   canonicalJson,
   computeDiff,
+  isWellFormedString,
   sha256Hex,
   utf8ByteLength,
   validatePath,
@@ -22,7 +24,7 @@ import {
 } from "@takazudo/zudo-history-stash-core";
 import { parseBinarySettings } from "../binary-config.js";
 import type { Env } from "../env.js";
-import { prepareBlob, readBlob, type PreparedBlob } from "./blobs.js";
+import { blobKey, prepareBlob, readBlob, type PreparedBlob } from "./blobs.js";
 import { createByteStorageReader } from "./byte-reader.js";
 import type { ChangeSetEntryRow, ChangeSetRow } from "./schema.js";
 import {
@@ -66,6 +68,7 @@ interface HeadRow extends VersionMaterialRow {
 interface StagedEntry extends ChangeSetEntryRow {
   textBody?: string;
   binaryBody?: ArrayBuffer;
+  binaryR2Key?: string;
 }
 
 export interface ChangeSetDependencies extends StoreDependencies {
@@ -92,6 +95,14 @@ export interface ChangeSetDiffOptions {
 
 function validation(message: string): never {
   throw new StashError("validation", message);
+}
+
+async function ensureLive(db: D1DatabaseSession, stash: string): Promise<void> {
+  const row = await db
+    .prepare("SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL")
+    .bind(stash)
+    .first();
+  if (row === null) throw new StashError("not-found", "Stash not found.");
 }
 
 function internal(message = "Stored change-set data is unavailable or invalid."): never {
@@ -341,7 +352,12 @@ function decodeCursor(value: string | undefined): { createdAt: number; id: strin
     const separator = decoded.indexOf(":");
     const createdAt = Number(decoded.slice(0, separator));
     const id = decoded.slice(separator + 1);
-    if (separator < 1 || !Number.isSafeInteger(createdAt) || !CHANGE_SET_ID.test(id)) {
+    if (
+      separator < 1 ||
+      !Number.isSafeInteger(createdAt) ||
+      !CHANGE_SET_ID.test(id) ||
+      Number(id.slice(4, 17)) !== createdAt
+    ) {
       return validation("Invalid change-set cursor.");
     }
     return { createdAt, id };
@@ -404,17 +420,34 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
       input: CreateChangeSetInput,
       options: { idempotencyKey?: string; createdBy?: string } = {},
     ): Promise<ChangeSetCreateResult> {
+      if (input === null || typeof input !== "object" || !Array.isArray(input.entries)) {
+        validation("Invalid change-set input.");
+      }
+      let inlineBytes = 0;
+      for (const entry of input.entries) {
+        if (entry.op !== "put") continue;
+        if ("bytesBase64" in entry) {
+          inlineBytes += decodeBinary(entry.bytesBase64, entry.path).byteLength;
+        } else {
+          if (!isWellFormedString(entry.body)) {
+            throw new StashError(
+              "body-not-well-formed",
+              `Body for ${entry.path} is not well-formed Unicode.`,
+            );
+          }
+          inlineBytes += utf8ByteLength(entry.body);
+        }
+      }
+      if (inlineBytes > MAX_COMMIT_INLINE_BYTES) {
+        throw new StashError("payload-too-large", "Change-set bodies are too large.");
+      }
       const parsed = CreateChangeSetBody.safeParse(input);
       if (!parsed.success) validation("Invalid change-set input.");
       const key = validateKey(options.idempotencyKey);
       const now = deps.now();
       const requestHash = await sha256Hex(canonicalJson(input as JsonValue));
       const db = env.DB.withSession("first-primary");
-      const live = await db
-        .prepare("SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL")
-        .bind(stash)
-        .first();
-      if (live === null) throw new StashError("not-found", "Stash not found.");
+      await ensureLive(db, stash);
       if (key !== undefined) {
         const prior = await db
           .prepare(SELECT_CHANGE_SET_BY_KEY)
@@ -428,6 +461,18 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
             );
           }
           return { value: await mapRecord(db, prior, now), replayed: true };
+        }
+      }
+      if (input.expectedLastChangeId !== undefined) {
+        const latest = await db
+          .prepare("SELECT COALESCE(MAX(id), 0) AS id FROM versions WHERE stash_name = ?")
+          .bind(stash)
+          .first<{ id: number }>();
+        if ((latest?.id ?? 0) !== input.expectedLastChangeId) {
+          throw new StashError(
+            "commit-conflict",
+            `Expected last change ${input.expectedLastChangeId}, newest change is ${latest?.id ?? 0}.`,
+          );
         }
       }
       const explicitExpiry = input.expiresAt === undefined ? null : Date.parse(input.expiresAt);
@@ -446,6 +491,7 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
       const staged = await Promise.all(
         input.entries.map((entry) => stageEntry(db, id, stash, entry)),
       );
+      const d1InlineMaxBytes = parseBinarySettings(env).d1InlineMaxBytes;
       const prepared = new Map<string, PreparedBlob>();
       for (const entry of staged) {
         if (
@@ -463,6 +509,26 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
               deps.createBlobGeneration,
             ),
           );
+        }
+        if (
+          entry.binaryBody !== undefined &&
+          entry.blob_hash !== null &&
+          entry.binaryBody.byteLength > d1InlineMaxBytes
+        ) {
+          const key = blobKey(
+            stash,
+            entry.blob_hash,
+            deps.createBlobGeneration?.() ?? crypto.randomUUID(),
+          );
+          const object = await env.BLOBS.put(key, entry.binaryBody, {
+            onlyIf: { etagDoesNotMatch: "*" },
+            httpMetadata: { contentType: entry.content_type ?? "application/octet-stream" },
+            customMetadata: { sha256: entry.blob_hash.slice("sha256-".length) },
+            sha256: entry.blob_hash.slice("sha256-".length),
+          });
+          if (object === null) return internal("Binary change-set content could not be staged.");
+          entry.binaryR2Key = key;
+          entry.binaryBody = undefined;
         }
       }
       const row: ChangeSetRow = {
@@ -485,10 +551,19 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
         commit_id: null,
       };
       const statements: D1PreparedStatement[] = [];
-      const insertedHashes = new Set<string>();
+      const insertedBlobs = new Set<string>();
       for (const entry of staged) {
-        if (entry.blob_hash === null || insertedHashes.has(entry.blob_hash)) continue;
-        insertedHashes.add(entry.blob_hash);
+        if (
+          entry.blob_hash === null ||
+          (entry.textBody === undefined &&
+            entry.binaryBody === undefined &&
+            entry.binaryR2Key === undefined)
+        ) {
+          continue;
+        }
+        const blobKey = `${entry.content_storage}:${entry.blob_hash}`;
+        if (insertedBlobs.has(blobKey)) continue;
+        insertedBlobs.add(blobKey);
         const expectedFence =
           row.expected_last_change_id === null
             ? "1 = 1"
@@ -517,20 +592,24 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
                 ...expectedParams,
               ),
           );
-        } else if (entry.binaryBody !== undefined && entry.blob_hash !== null) {
+        } else if (
+          (entry.binaryBody !== undefined || entry.binaryR2Key !== undefined) &&
+          entry.blob_hash !== null
+        ) {
           statements.push(
             db
               .prepare(
                 `INSERT INTO byte_blobs
                  (stash_name, hash, body_bytes, r2_key, storage_generation, size_bytes, created_at)
-                 SELECT ?, ?, ?, NULL, 0, ?, ? WHERE EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
+                 SELECT ?, ?, ?, ?, 0, ?, ? WHERE EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
                    AND ${expectedFence}
                  ON CONFLICT(stash_name, hash) DO NOTHING`,
               )
               .bind(
                 stash,
                 entry.blob_hash,
-                entry.binaryBody,
+                entry.binaryBody ?? null,
+                entry.binaryR2Key ?? null,
                 entry.size_bytes,
                 now,
                 stash,
@@ -568,12 +647,25 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
           return { value: await mapRecord(db, winner, now), replayed: true };
         }
       }
+      if (input.expectedLastChangeId !== undefined) {
+        const latest = await db
+          .prepare("SELECT COALESCE(MAX(id), 0) AS id FROM versions WHERE stash_name = ?")
+          .bind(stash)
+          .first<{ id: number }>();
+        if ((latest?.id ?? 0) !== input.expectedLastChangeId) {
+          throw new StashError(
+            "commit-conflict",
+            `Expected last change ${input.expectedLastChangeId}, newest change is ${latest?.id ?? 0}.`,
+          );
+        }
+      }
       return internal("Change-set create failed its persistence fence.");
     },
 
     async getChangeSet(stash: string, id: string): Promise<ChangeSetRecord | null> {
       if (!CHANGE_SET_ID.test(id)) validation("Invalid change-set id.");
       const db = env.DB.withSession("first-primary");
+      await ensureLive(db, stash);
       const row = await db.prepare(SELECT_CHANGE_SET).bind(stash, id).first<ChangeSetRow>();
       return row === null ? null : mapRecord(db, row, deps.now());
     },
@@ -596,6 +688,7 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
       const after = decodeCursor(options.after);
       const now = deps.now();
       const db = env.DB.withSession("first-primary");
+      await ensureLive(db, stash);
       const query = { stash, status, path: options.path ?? null, now };
       const [page, count] = await Promise.all([
         selectChangeSets(db, { ...query, after, limit: limit + 1 }).all<ChangeSetRow>(),
@@ -623,7 +716,11 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
       ) {
         validation("Invalid diff context.");
       }
+      if (options.path !== undefined && !validatePath(options.path).ok) {
+        validation("Invalid change-set path.");
+      }
       const db = env.DB.withSession("first-primary");
+      await ensureLive(db, stash);
       const row = await db.prepare(SELECT_CHANGE_SET).bind(stash, id).first<ChangeSetRow>();
       if (row === null) return null;
       let entries = await entriesFor(db, id);

--- a/workers/stash/src/d1/change-sets.ts
+++ b/workers/stash/src/d1/change-sets.ts
@@ -1,0 +1,715 @@
+import {
+  COMMIT_DIFF_INLINE_ENTRIES,
+  CreateChangeSetBody,
+  IDEMPOTENCY_KEY_MAX_CHARS,
+  LIST_LIMIT_DEFAULT,
+  LIST_LIMIT_MAX,
+  MAX_META_BYTES,
+  StashError,
+  canonicalJson,
+  computeDiff,
+  sha256Hex,
+  utf8ByteLength,
+  validatePath,
+  type ChangeSetDiffResult,
+  type ChangeSetEntryInput,
+  type ChangeSetListResponse,
+  type ChangeSetRecord,
+  type ChangeSetStatus,
+  type CreateChangeSetBody as CreateChangeSetInput,
+  type Current,
+  type JsonValue,
+} from "@takazudo/zudo-history-stash-core";
+import { parseBinarySettings } from "../binary-config.js";
+import type { Env } from "../env.js";
+import { prepareBlob, readBlob, type PreparedBlob } from "./blobs.js";
+import { createByteStorageReader } from "./byte-reader.js";
+import type { ChangeSetEntryRow, ChangeSetRow } from "./schema.js";
+import {
+  SELECT_CHANGE_SET,
+  SELECT_CHANGE_SET_BY_KEY,
+  SELECT_CHANGE_SET_ENTRIES,
+  countChangeSets,
+  insertChangeSetStatement,
+  insertEntryStatement,
+  selectChangeSets,
+} from "./sql/change-sets.js";
+import type { StoreDependencies } from "./store.js";
+
+const DAY_MS = 86_400_000;
+const DEFAULT_TTL_DAYS = 14;
+const CHANGE_SET_ID = /^chs_\d{13}[0-9a-f]{8}$/;
+const DEFAULT_CONTENT_TYPE = "text/plain; charset=utf-8";
+
+interface VersionMaterialRow {
+  stash_name: string;
+  version: number;
+  kind: "put" | "delete" | "rollback";
+  blob_hash: string | null;
+  size_bytes: number;
+  content_type: string;
+  representation: "text" | "binary";
+  content_storage: "legacy" | "bytes";
+  author: string;
+  created_at: number;
+  blob_body: string | null;
+  blob_r2_key: string | null;
+  blob_size: number | null;
+}
+
+interface HeadRow extends VersionMaterialRow {
+  head_version: number;
+  head_hash: string | null;
+  deleted: 0 | 1;
+}
+
+interface StagedEntry extends ChangeSetEntryRow {
+  textBody?: string;
+  binaryBody?: ArrayBuffer;
+}
+
+export interface ChangeSetDependencies extends StoreDependencies {
+  createBlobGeneration?: () => string;
+  onBeforeCommit?: () => void | Promise<void>;
+}
+
+export interface ChangeSetCreateResult {
+  value: ChangeSetRecord;
+  replayed?: true;
+}
+
+export interface ListChangeSetOptions {
+  status?: "open" | "applied" | "rejected" | "expired" | "all";
+  path?: string;
+  limit?: number;
+  after?: string;
+}
+
+export interface ChangeSetDiffOptions {
+  context?: number;
+  path?: string;
+}
+
+function validation(message: string): never {
+  throw new StashError("validation", message);
+}
+
+function internal(message = "Stored change-set data is unavailable or invalid."): never {
+  throw new StashError("internal", message);
+}
+
+function toIso(value: number): string {
+  if (!Number.isSafeInteger(value)) return internal();
+  return new Date(value).toISOString();
+}
+
+function parseMeta(value: string): Record<string, JsonValue> {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return internal();
+    return parsed as Record<string, JsonValue>;
+  } catch {
+    return internal();
+  }
+}
+
+function computedStatus(
+  row: Pick<ChangeSetRow, "status" | "expires_at">,
+  now: number,
+): ChangeSetStatus {
+  return row.status === "open" && row.expires_at <= now ? "expired" : row.status;
+}
+
+function current(row: HeadRow | VersionMaterialRow | null): Current | null {
+  if (row === null) return null;
+  return {
+    version: "head_version" in row ? row.head_version : row.version,
+    hash: row.blob_hash,
+    deleted: row.kind === "delete" || ("deleted" in row && row.deleted === 1),
+    kind: row.kind,
+    author: row.author,
+    createdAt: toIso(row.created_at),
+  };
+}
+
+function ttlDays(env: Env): number {
+  const source = env.CHANGE_SET_TTL_DAYS || String(DEFAULT_TTL_DAYS);
+  if (!/^[1-9]\d*$/.test(source)) return internal("Invalid CHANGE_SET_TTL_DAYS configuration.");
+  const value = Number(source);
+  if (!Number.isSafeInteger(value) || value * DAY_MS > Number.MAX_SAFE_INTEGER) return internal();
+  return value;
+}
+
+function mintId(now: number, entropy: string): string {
+  if (!Number.isSafeInteger(now) || now < 0 || now > 9_999_999_999_999) return internal();
+  let hash = 0x811c9dc5;
+  for (const character of entropy) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `chs_${String(now).padStart(13, "0")}${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function validateKey(key: string | undefined): string | undefined {
+  if (key === undefined) return undefined;
+  if (key.length < 1 || key.length > IDEMPOTENCY_KEY_MAX_CHARS) {
+    validation("Invalid idempotency key.");
+  }
+  return key;
+}
+
+function decodeBinary(value: string, path: string): ArrayBuffer {
+  try {
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+      return validation(`Invalid binary body for ${path}.`);
+    }
+    return Uint8Array.from(atob(value), (character) => character.charCodeAt(0)).buffer;
+  } catch {
+    return validation(`Invalid binary body for ${path}.`);
+  }
+}
+
+async function selectHead(
+  db: D1DatabaseSession,
+  stash: string,
+  path: string,
+): Promise<HeadRow | null> {
+  return db
+    .prepare(
+      `SELECT v.stash_name, f.head_version, f.head_hash, f.deleted, v.version, v.kind, v.blob_hash,
+         v.size_bytes, v.content_type, v.representation, v.content_storage, v.author, v.created_at,
+         b.body AS blob_body, b.r2_key AS blob_r2_key, b.size_bytes AS blob_size
+       FROM files f JOIN versions v
+         ON v.stash_name = f.stash_name AND v.path = f.path AND v.version = f.head_version
+       LEFT JOIN blobs b ON b.stash_name = v.stash_name AND b.hash = v.blob_hash
+       WHERE f.stash_name = ? AND f.path = ? LIMIT 1`,
+    )
+    .bind(stash, path)
+    .first<HeadRow>();
+}
+
+async function selectVersion(
+  db: D1DatabaseSession,
+  stash: string,
+  path: string,
+  version: number,
+): Promise<VersionMaterialRow | null> {
+  return db
+    .prepare(
+      `SELECT v.stash_name, v.version, v.kind, v.blob_hash, v.size_bytes, v.content_type, v.representation,
+         v.content_storage, v.author, v.created_at, b.body AS blob_body,
+         b.r2_key AS blob_r2_key, b.size_bytes AS blob_size
+       FROM versions v LEFT JOIN blobs b
+         ON b.stash_name = v.stash_name AND b.hash = v.blob_hash
+       WHERE v.stash_name = ? AND v.path = ? AND v.version = ? LIMIT 1`,
+    )
+    .bind(stash, path, version)
+    .first<VersionMaterialRow>();
+}
+
+function sourceEntry(id: string, stash: string, input: ChangeSetEntryInput): ChangeSetEntryRow {
+  return {
+    change_set_id: id,
+    stash_name: stash,
+    path: input.path,
+    op: input.op,
+    base_version: input.baseVersion,
+    blob_hash: null,
+    content_storage: null,
+    representation: null,
+    content_type: null,
+    size_bytes: null,
+    rollback_to: input.op === "rollback" ? input.toVersion : null,
+    copied_from_path: input.op === "copy" ? input.from.path : null,
+    copied_from_version: input.op === "copy" ? input.from.version : null,
+  };
+}
+
+function pathError(path: string, reason: string): never {
+  return validation(`Invalid change-set entry ${path}: ${reason}`);
+}
+
+async function stageEntry(
+  db: D1DatabaseSession,
+  id: string,
+  stash: string,
+  input: ChangeSetEntryInput,
+): Promise<StagedEntry> {
+  const entry: StagedEntry = sourceEntry(id, stash, input);
+  const head = await selectHead(db, stash, input.path);
+  if (input.baseVersion === null) {
+    if (head !== null) pathError(input.path, "the path already exists");
+  } else if (head === null) {
+    pathError(input.path, "the base path does not exist");
+  } else if ((await selectVersion(db, stash, input.path, input.baseVersion)) === null) {
+    pathError(input.path, `base version ${input.baseVersion} does not exist`);
+  }
+  if (input.op === "delete") {
+    if (head === null) pathError(input.path, "the path does not exist");
+    if (head.deleted === 1) pathError(input.path, "the current head is already deleted");
+    return entry;
+  }
+  if (input.op === "put") {
+    if ("bytesBase64" in input) {
+      const bytes = decodeBinary(input.bytesBase64, input.path);
+      entry.binaryBody = bytes;
+      entry.blob_hash = await sha256Hex(bytes);
+      entry.content_storage = "bytes";
+      entry.representation = "binary";
+      entry.content_type = input.contentType;
+      entry.size_bytes = bytes.byteLength;
+    } else {
+      entry.textBody = input.body;
+      entry.blob_hash = await sha256Hex(input.body);
+      entry.content_storage = "legacy";
+      entry.representation = "text";
+      entry.content_type = input.contentType ?? DEFAULT_CONTENT_TYPE;
+      entry.size_bytes = utf8ByteLength(input.body);
+    }
+    return entry;
+  }
+  const sourcePath = input.op === "copy" ? input.from.path : input.path;
+  const sourceVersion = input.op === "copy" ? input.from.version : input.toVersion;
+  const source = await selectVersion(db, stash, sourcePath, sourceVersion);
+  if (source === null || source.kind === "delete" || source.blob_hash === null) {
+    pathError(input.path, `${input.op} source has no content blob`);
+  }
+  const sourceBlobExists =
+    source.content_storage === "legacy"
+      ? source.blob_size !== null
+      : (await db
+          .prepare("SELECT 1 FROM byte_blobs WHERE stash_name = ? AND hash = ?")
+          .bind(stash, source.blob_hash)
+          .first()) !== null;
+  if (!sourceBlobExists) pathError(input.path, `${input.op} source has no content blob`);
+  entry.blob_hash = source.blob_hash;
+  entry.content_storage = source.content_storage;
+  entry.representation = source.representation;
+  entry.content_type = source.content_type;
+  entry.size_bytes = source.size_bytes;
+  return entry;
+}
+
+async function entriesFor(db: D1DatabaseSession, id: string): Promise<ChangeSetEntryRow[]> {
+  return (await db.prepare(SELECT_CHANGE_SET_ENTRIES).bind(id).all<ChangeSetEntryRow>()).results;
+}
+
+async function mapRecord(
+  db: D1DatabaseSession,
+  row: ChangeSetRow,
+  now: number,
+): Promise<ChangeSetRecord> {
+  const entries = await entriesFor(db, row.id);
+  return {
+    id: row.id,
+    stash: row.stash_name,
+    status: computedStatus(row, now),
+    author: row.author,
+    message: row.message,
+    meta: parseMeta(row.meta_json),
+    expiresAt: toIso(row.expires_at),
+    createdBy: row.created_by,
+    createdAt: toIso(row.created_at),
+    decidedAt: row.decided_at === null ? null : toIso(row.decided_at),
+    decidedBy: row.decided_by,
+    decisionReason: row.decision_reason,
+    commitId: row.commit_id,
+    entries: await Promise.all(
+      entries.map(async (entry) => {
+        const head = await selectHead(db, row.stash_name, entry.path);
+        return {
+          path: entry.path,
+          op: entry.op,
+          baseVersion: entry.base_version,
+          current: current(head),
+          stale: (head?.head_version ?? null) !== entry.base_version,
+        };
+      }),
+    ),
+  };
+}
+
+function encodeCursor(row: Pick<ChangeSetRow, "created_at" | "id">): string {
+  return btoa(`${row.created_at}:${row.id}`);
+}
+
+function decodeCursor(value: string | undefined): { createdAt: number; id: string } | null {
+  if (value === undefined) return null;
+  try {
+    const decoded = atob(value);
+    if (btoa(decoded) !== value) return validation("Invalid change-set cursor.");
+    const separator = decoded.indexOf(":");
+    const createdAt = Number(decoded.slice(0, separator));
+    const id = decoded.slice(separator + 1);
+    if (separator < 1 || !Number.isSafeInteger(createdAt) || !CHANGE_SET_ID.test(id)) {
+      return validation("Invalid change-set cursor.");
+    }
+    return { createdAt, id };
+  } catch {
+    return validation("Invalid change-set cursor.");
+  }
+}
+
+async function textFor(env: Env, row: VersionMaterialRow | ChangeSetEntryRow): Promise<string> {
+  if (row.blob_hash === null) return "";
+  if (
+    row.representation !== "text" ||
+    row.content_storage === null ||
+    row.size_bytes === null ||
+    row.content_type === null
+  ) {
+    return internal();
+  }
+  if (row.content_storage === "bytes") {
+    const object = await createByteStorageReader(env).get({
+      stash: row.stash_name,
+      hash: row.blob_hash,
+      storage: "bytes",
+      size: row.size_bytes,
+      etag: row.blob_hash,
+      contentType: row.content_type,
+    });
+    if (object === null) return internal();
+    try {
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+        await new Response(object.stream).arrayBuffer(),
+      );
+    } catch {
+      return internal();
+    }
+  }
+  const material =
+    "blob_body" in row
+      ? row
+      : await env.DB.prepare(
+          "SELECT body AS blob_body, r2_key AS blob_r2_key, size_bytes AS blob_size FROM blobs WHERE stash_name = ? AND hash = ?",
+        )
+          .bind(row.stash_name, row.blob_hash)
+          .first<{ blob_body: string | null; blob_r2_key: string | null; blob_size: number }>();
+  if (material === null || material.blob_size === null || material.blob_size !== row.size_bytes) {
+    return internal();
+  }
+  return readBlob(env, {
+    hash: row.blob_hash,
+    body: material.blob_body,
+    r2_key: material.blob_r2_key,
+    size_bytes: material.blob_size,
+  });
+}
+
+export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
+  return {
+    async createChangeSet(
+      stash: string,
+      input: CreateChangeSetInput,
+      options: { idempotencyKey?: string; createdBy?: string } = {},
+    ): Promise<ChangeSetCreateResult> {
+      const parsed = CreateChangeSetBody.safeParse(input);
+      if (!parsed.success) validation("Invalid change-set input.");
+      const key = validateKey(options.idempotencyKey);
+      const now = deps.now();
+      const requestHash = await sha256Hex(canonicalJson(input as JsonValue));
+      const db = env.DB.withSession("first-primary");
+      const live = await db
+        .prepare("SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL")
+        .bind(stash)
+        .first();
+      if (live === null) throw new StashError("not-found", "Stash not found.");
+      if (key !== undefined) {
+        const prior = await db
+          .prepare(SELECT_CHANGE_SET_BY_KEY)
+          .bind(stash, key)
+          .first<ChangeSetRow>();
+        if (prior !== null) {
+          if (prior.request_hash !== requestHash) {
+            throw new StashError(
+              "idempotency-key-reused",
+              "Idempotency key was already used for a different change set.",
+            );
+          }
+          return { value: await mapRecord(db, prior, now), replayed: true };
+        }
+      }
+      const explicitExpiry = input.expiresAt === undefined ? null : Date.parse(input.expiresAt);
+      if (
+        explicitExpiry !== null &&
+        (!Number.isSafeInteger(explicitExpiry) || explicitExpiry <= now)
+      ) {
+        validation("expiresAt must be in the future.");
+      }
+      const expiresAt = explicitExpiry ?? now + ttlDays(env) * DAY_MS;
+      const id = mintId(now, deps.createId());
+      const metaJson = canonicalJson({ ...(input.meta ?? {}), changeSetId: id });
+      if (utf8ByteLength(metaJson) > MAX_META_BYTES) {
+        validation("Stamped change-set meta is too large.");
+      }
+      const staged = await Promise.all(
+        input.entries.map((entry) => stageEntry(db, id, stash, entry)),
+      );
+      const prepared = new Map<string, PreparedBlob>();
+      for (const entry of staged) {
+        if (
+          entry.textBody !== undefined &&
+          entry.blob_hash !== null &&
+          !prepared.has(entry.blob_hash)
+        ) {
+          prepared.set(
+            entry.blob_hash,
+            await prepareBlob(
+              env,
+              stash,
+              entry.blob_hash,
+              entry.textBody,
+              deps.createBlobGeneration,
+            ),
+          );
+        }
+      }
+      const row: ChangeSetRow = {
+        id,
+        stash_name: stash,
+        status: "open",
+        author: input.author ?? "",
+        message: input.message ?? "",
+        meta_json: metaJson,
+        expires_at: expiresAt,
+        created_by: options.createdBy ?? "system",
+        created_at: now,
+        idempotency_key: key ?? null,
+        request_hash: key === undefined ? null : requestHash,
+        expected_last_change_id: input.expectedLastChangeId ?? null,
+        decision_attempt: null,
+        decided_at: null,
+        decided_by: null,
+        decision_reason: null,
+        commit_id: null,
+      };
+      const statements: D1PreparedStatement[] = [];
+      const insertedHashes = new Set<string>();
+      for (const entry of staged) {
+        if (entry.blob_hash === null || insertedHashes.has(entry.blob_hash)) continue;
+        insertedHashes.add(entry.blob_hash);
+        const expectedFence =
+          row.expected_last_change_id === null
+            ? "1 = 1"
+            : "COALESCE((SELECT MAX(id) FROM versions WHERE stash_name = ?), 0) = ?";
+        const expectedParams =
+          row.expected_last_change_id === null ? [] : [stash, row.expected_last_change_id];
+        if (entry.textBody !== undefined && entry.blob_hash !== null) {
+          const blob = prepared.get(entry.blob_hash);
+          if (blob === undefined) return internal();
+          statements.push(
+            db
+              .prepare(
+                `INSERT INTO blobs (stash_name, hash, body, r2_key, size_bytes, created_at)
+                 SELECT ?, ?, ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
+                   AND ${expectedFence}
+                 ON CONFLICT(stash_name, hash) DO NOTHING`,
+              )
+              .bind(
+                stash,
+                entry.blob_hash,
+                blob.body,
+                blob.r2_key,
+                entry.size_bytes,
+                now,
+                stash,
+                ...expectedParams,
+              ),
+          );
+        } else if (entry.binaryBody !== undefined && entry.blob_hash !== null) {
+          statements.push(
+            db
+              .prepare(
+                `INSERT INTO byte_blobs
+                 (stash_name, hash, body_bytes, r2_key, storage_generation, size_bytes, created_at)
+                 SELECT ?, ?, ?, NULL, 0, ?, ? WHERE EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
+                   AND ${expectedFence}
+                 ON CONFLICT(stash_name, hash) DO NOTHING`,
+              )
+              .bind(
+                stash,
+                entry.blob_hash,
+                entry.binaryBody,
+                entry.size_bytes,
+                now,
+                stash,
+                ...expectedParams,
+              ),
+          );
+        }
+      }
+      statements.push(insertChangeSetStatement(db, row));
+      statements.push(...staged.map((entry) => insertEntryStatement(db, entry)));
+      await deps.onBeforeCommit?.();
+      try {
+        const result = await db.batch(statements);
+        const setResult = result.at(statements.length - staged.length - 1);
+        if (setResult?.meta.changes === 1) {
+          const created = await db.prepare(SELECT_CHANGE_SET).bind(stash, id).first<ChangeSetRow>();
+          if (created === null) return internal();
+          return { value: await mapRecord(db, created, now) };
+        }
+      } catch {
+        /* Resolve same-key races below. */
+      }
+      if (key !== undefined) {
+        const winner = await db
+          .prepare(SELECT_CHANGE_SET_BY_KEY)
+          .bind(stash, key)
+          .first<ChangeSetRow>();
+        if (winner !== null) {
+          if (winner.request_hash !== requestHash) {
+            throw new StashError(
+              "idempotency-key-reused",
+              "Idempotency key was already used for a different change set.",
+            );
+          }
+          return { value: await mapRecord(db, winner, now), replayed: true };
+        }
+      }
+      return internal("Change-set create failed its persistence fence.");
+    },
+
+    async getChangeSet(stash: string, id: string): Promise<ChangeSetRecord | null> {
+      if (!CHANGE_SET_ID.test(id)) validation("Invalid change-set id.");
+      const db = env.DB.withSession("first-primary");
+      const row = await db.prepare(SELECT_CHANGE_SET).bind(stash, id).first<ChangeSetRow>();
+      return row === null ? null : mapRecord(db, row, deps.now());
+    },
+
+    async listChangeSets(
+      stash: string,
+      options: ListChangeSetOptions = {},
+    ): Promise<ChangeSetListResponse> {
+      const status = options.status ?? "open";
+      if (!["open", "applied", "rejected", "expired", "all"].includes(status)) {
+        validation("Invalid change-set status.");
+      }
+      const limit = options.limit ?? LIST_LIMIT_DEFAULT;
+      if (!Number.isSafeInteger(limit) || limit < 1 || limit > LIST_LIMIT_MAX) {
+        validation("Invalid change-set limit.");
+      }
+      if (options.path !== undefined && !validatePath(options.path).ok) {
+        validation("Invalid change-set path.");
+      }
+      const after = decodeCursor(options.after);
+      const now = deps.now();
+      const db = env.DB.withSession("first-primary");
+      const query = { stash, status, path: options.path ?? null, now };
+      const [page, count] = await Promise.all([
+        selectChangeSets(db, { ...query, after, limit: limit + 1 }).all<ChangeSetRow>(),
+        countChangeSets(db, query).first<{ total: number }>(),
+      ]);
+      const rows = page.results;
+      const hasMore = rows.length > limit;
+      if (hasMore) rows.pop();
+      return {
+        changeSets: await Promise.all(rows.map((item) => mapRecord(db, item, now))),
+        nextAfter: hasMore && rows.at(-1) !== undefined ? encodeCursor(rows.at(-1)!) : null,
+        total: count?.total ?? 0,
+      };
+    },
+
+    async getChangeSetDiff(
+      stash: string,
+      id: string,
+      options: ChangeSetDiffOptions = {},
+    ): Promise<ChangeSetDiffResult | null> {
+      if (!CHANGE_SET_ID.test(id)) validation("Invalid change-set id.");
+      if (
+        options.context !== undefined &&
+        (!Number.isSafeInteger(options.context) || options.context < 0)
+      ) {
+        validation("Invalid diff context.");
+      }
+      const db = env.DB.withSession("first-primary");
+      const row = await db.prepare(SELECT_CHANGE_SET).bind(stash, id).first<ChangeSetRow>();
+      if (row === null) return null;
+      let entries = await entriesFor(db, id);
+      if (options.path !== undefined) {
+        entries = entries.filter((entry) => entry.path === options.path);
+        if (entries.length === 0) throw new StashError("not-found", "Change-set entry not found.");
+      }
+      const aggregateHeads = await Promise.all(
+        entries.map((entry) => selectHead(db, stash, entry.path)),
+      );
+      const aggregateStale = entries.some(
+        (entry, index) => (aggregateHeads[index]?.head_version ?? null) !== entry.base_version,
+      );
+      const truncated = options.path === undefined && entries.length > COMMIT_DIFF_INLINE_ENTRIES;
+      if (truncated) entries = entries.slice(0, COMMIT_DIFF_INLINE_ENTRIES);
+      const diffMaxBytes = parseBinarySettings(env).diffMaxBytes;
+      const mapped = await Promise.all(
+        entries.map(async (entry) => {
+          const [baseRow, head] = await Promise.all([
+            entry.base_version === null
+              ? Promise.resolve(null)
+              : selectVersion(db, stash, entry.path, entry.base_version),
+            selectHead(db, stash, entry.path),
+          ]);
+          if (entry.base_version !== null && baseRow === null) {
+            return internal("Change-set base version is missing.");
+          }
+          const stale = (head?.head_version ?? null) !== entry.base_version;
+          const candidate =
+            entry.op === "delete"
+              ? null
+              : {
+                  version: (entry.base_version ?? 0) + 1,
+                  hash: entry.blob_hash,
+                  deleted: false,
+                  kind: entry.op === "rollback" ? ("rollback" as const) : ("put" as const),
+                  author: row.author,
+                  createdAt: toIso(row.created_at),
+                };
+          let diff: ChangeSetDiffResult["entries"][number]["diff"];
+          if (
+            entry.op === "copy" ||
+            entry.representation === "binary" ||
+            (baseRow !== null && baseRow.representation === "binary")
+          ) {
+            diff = { state: "binary" };
+          } else if (
+            (baseRow?.size_bytes ?? 0) > diffMaxBytes ||
+            (entry.size_bytes ?? 0) > diffMaxBytes
+          ) {
+            diff = { state: "oversized" };
+          } else {
+            const [fromText, toText] = await Promise.all([
+              baseRow === null || baseRow.kind === "delete"
+                ? Promise.resolve("")
+                : textFor(env, baseRow),
+              entry.op === "delete" ? Promise.resolve("") : textFor(env, entry),
+            ]);
+            diff = computeDiff({
+              fromText,
+              toText,
+              fromLabel:
+                entry.base_version === null
+                  ? `a/${entry.path}@empty`
+                  : `a/${entry.path}@v${entry.base_version}`,
+              toLabel: `b/${entry.path}@${id}`,
+              context: options.context,
+            });
+          }
+          return {
+            path: entry.path,
+            op: entry.op,
+            base: current(baseRow),
+            candidate,
+            current: current(head),
+            stale,
+            diff,
+          };
+        }),
+      );
+      return {
+        entries: mapped,
+        stale: aggregateStale,
+        status: computedStatus(row, deps.now()),
+        truncated,
+      };
+    },
+  };
+}

--- a/workers/stash/src/d1/schema.ts
+++ b/workers/stash/src/d1/schema.ts
@@ -89,6 +89,42 @@ export interface CommitRow {
   created_at: number;
 }
 
+export interface ChangeSetRow {
+  id: string;
+  stash_name: string;
+  status: "open" | "applied" | "rejected";
+  author: string;
+  message: string;
+  meta_json: string;
+  expires_at: number;
+  created_by: string;
+  created_at: number;
+  idempotency_key: string | null;
+  request_hash: string | null;
+  expected_last_change_id: number | null;
+  decision_attempt: string | null;
+  decided_at: number | null;
+  decided_by: string | null;
+  decision_reason: string | null;
+  commit_id: string | null;
+}
+
+export interface ChangeSetEntryRow {
+  change_set_id: string;
+  stash_name: string;
+  path: string;
+  op: "put" | "copy" | "delete" | "rollback";
+  base_version: number | null;
+  blob_hash: string | null;
+  content_storage: "legacy" | "bytes" | null;
+  representation: "text" | "binary" | null;
+  content_type: string | null;
+  size_bytes: number | null;
+  rollback_to: number | null;
+  copied_from_path: string | null;
+  copied_from_version: number | null;
+}
+
 export type UploadSessionState =
   "open" | "uploaded" | "finalizing" | "committed" | "aborted" | "expired" | "stale" | "failed";
 
@@ -210,6 +246,8 @@ export const TABLE_NAMES = [
   "blobs",
   "files",
   "versions",
+  "change_set_entries",
+  "change_sets",
   "commits",
   "idempotency",
   "gc_jobs",
@@ -256,6 +294,40 @@ export const TABLE_COLUMNS = {
     "representation",
     "application_etag",
     "content_storage",
+    "commit_id",
+  ],
+  change_set_entries: [
+    "change_set_id",
+    "stash_name",
+    "path",
+    "op",
+    "base_version",
+    "blob_hash",
+    "content_storage",
+    "representation",
+    "content_type",
+    "size_bytes",
+    "rollback_to",
+    "copied_from_path",
+    "copied_from_version",
+  ],
+  change_sets: [
+    "id",
+    "stash_name",
+    "status",
+    "author",
+    "message",
+    "meta_json",
+    "expires_at",
+    "created_by",
+    "created_at",
+    "idempotency_key",
+    "request_hash",
+    "expected_last_change_id",
+    "decision_attempt",
+    "decided_at",
+    "decided_by",
+    "decision_reason",
     "commit_id",
   ],
   commits: [
@@ -376,6 +448,8 @@ export interface DatabaseSchema {
   blobs: BlobRow;
   files: FileRow;
   versions: VersionRow;
+  change_sets: ChangeSetRow;
+  change_set_entries: ChangeSetEntryRow;
   idempotency: IdempotencyRow;
   gc_jobs: GcJobRow;
   gc_runs: GcRunRow;

--- a/workers/stash/src/d1/sql/change-sets.ts
+++ b/workers/stash/src/d1/sql/change-sets.ts
@@ -48,9 +48,9 @@ export function selectChangeSets(db: Preparer, input: ListChangeSetSqlInput): D1
       `SELECT cs.* FROM change_sets cs
        JOIN stashes s ON s.name = cs.stash_name AND s.deleted_at IS NULL
        WHERE cs.stash_name = ? AND ${statusPredicate(input.status)}
-         AND (? IS NULL OR EXISTS (
-           SELECT 1 FROM change_set_entries e
-           WHERE e.change_set_id = cs.id AND e.stash_name = cs.stash_name AND e.path = ?
+         AND (? IS NULL OR cs.id IN (
+           SELECT e.change_set_id FROM change_set_entries e
+           WHERE e.stash_name = cs.stash_name AND e.path = ?
          ))
          AND (? IS NULL OR cs.created_at < ? OR (cs.created_at = ? AND cs.id < ?))
        ORDER BY cs.created_at DESC, cs.id DESC LIMIT ?`,
@@ -77,9 +77,9 @@ export function countChangeSets(
       `SELECT COUNT(*) AS total FROM change_sets cs
        JOIN stashes s ON s.name = cs.stash_name AND s.deleted_at IS NULL
        WHERE cs.stash_name = ? AND ${statusPredicate(input.status)}
-         AND (? IS NULL OR EXISTS (
-           SELECT 1 FROM change_set_entries e
-           WHERE e.change_set_id = cs.id AND e.stash_name = cs.stash_name AND e.path = ?
+         AND (? IS NULL OR cs.id IN (
+           SELECT e.change_set_id FROM change_set_entries e
+           WHERE e.stash_name = cs.stash_name AND e.path = ?
          ))`,
     )
     .bind(

--- a/workers/stash/src/d1/sql/change-sets.ts
+++ b/workers/stash/src/d1/sql/change-sets.ts
@@ -1,0 +1,160 @@
+import type { ChangeSetEntryRow, ChangeSetRow } from "../schema.js";
+
+type Preparer = Pick<D1DatabaseSession, "prepare">;
+
+export const SELECT_CHANGE_SET = `
+  SELECT cs.* FROM change_sets cs
+  JOIN stashes s ON s.name = cs.stash_name AND s.deleted_at IS NULL
+  WHERE cs.stash_name = ? AND cs.id = ? LIMIT 1
+`;
+
+export const SELECT_CHANGE_SET_BY_KEY = `
+  SELECT cs.* FROM change_sets cs
+  JOIN stashes s ON s.name = cs.stash_name AND s.deleted_at IS NULL
+  WHERE cs.stash_name = ? AND cs.idempotency_key = ? LIMIT 1
+`;
+
+export const SELECT_CHANGE_SET_ENTRIES = `
+  SELECT * FROM change_set_entries WHERE change_set_id = ? ORDER BY path
+`;
+
+export interface ListChangeSetSqlInput {
+  stash: string;
+  status: "open" | "applied" | "rejected" | "expired" | "all";
+  path: string | null;
+  now: number;
+  after: { createdAt: number; id: string } | null;
+  limit: number;
+}
+
+function statusPredicate(status: ListChangeSetSqlInput["status"]): string {
+  if (status === "all") return "1 = 1";
+  if (status === "open") return "cs.status = 'open' AND cs.expires_at > ?";
+  if (status === "expired") return "cs.status = 'open' AND cs.expires_at <= ?";
+  return "cs.status = ?";
+}
+
+function statusParams(input: ListChangeSetSqlInput): unknown[] {
+  return input.status === "all"
+    ? []
+    : input.status === "open" || input.status === "expired"
+      ? [input.now]
+      : [input.status];
+}
+
+export function selectChangeSets(db: Preparer, input: ListChangeSetSqlInput): D1PreparedStatement {
+  return db
+    .prepare(
+      `SELECT cs.* FROM change_sets cs
+       JOIN stashes s ON s.name = cs.stash_name AND s.deleted_at IS NULL
+       WHERE cs.stash_name = ? AND ${statusPredicate(input.status)}
+         AND (? IS NULL OR EXISTS (
+           SELECT 1 FROM change_set_entries e
+           WHERE e.change_set_id = cs.id AND e.stash_name = cs.stash_name AND e.path = ?
+         ))
+         AND (? IS NULL OR cs.created_at < ? OR (cs.created_at = ? AND cs.id < ?))
+       ORDER BY cs.created_at DESC, cs.id DESC LIMIT ?`,
+    )
+    .bind(
+      input.stash,
+      ...statusParams(input),
+      input.path,
+      input.path,
+      input.after?.id ?? null,
+      input.after?.createdAt ?? null,
+      input.after?.createdAt ?? null,
+      input.after?.id ?? null,
+      input.limit,
+    );
+}
+
+export function countChangeSets(
+  db: Preparer,
+  input: Omit<ListChangeSetSqlInput, "after" | "limit">,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `SELECT COUNT(*) AS total FROM change_sets cs
+       JOIN stashes s ON s.name = cs.stash_name AND s.deleted_at IS NULL
+       WHERE cs.stash_name = ? AND ${statusPredicate(input.status)}
+         AND (? IS NULL OR EXISTS (
+           SELECT 1 FROM change_set_entries e
+           WHERE e.change_set_id = cs.id AND e.stash_name = cs.stash_name AND e.path = ?
+         ))`,
+    )
+    .bind(
+      input.stash,
+      ...statusParams({ ...input, after: null, limit: 1 }),
+      input.path,
+      input.path,
+    );
+}
+
+export function insertChangeSetStatement(db: Preparer, row: ChangeSetRow): D1PreparedStatement {
+  const expectedFence =
+    row.expected_last_change_id === null
+      ? "1 = 1"
+      : "COALESCE((SELECT MAX(id) FROM versions WHERE stash_name = ?), 0) = ?";
+  const expectedParams =
+    row.expected_last_change_id === null ? [] : [row.stash_name, row.expected_last_change_id];
+  return db
+    .prepare(
+      `INSERT INTO change_sets
+       (id, stash_name, status, author, message, meta_json, expires_at, created_by, created_at,
+        idempotency_key, request_hash, expected_last_change_id, decision_attempt, decided_at,
+        decided_by, decision_reason, commit_id)
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+       WHERE EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
+         AND ${expectedFence}`,
+    )
+    .bind(
+      row.id,
+      row.stash_name,
+      row.status,
+      row.author,
+      row.message,
+      row.meta_json,
+      row.expires_at,
+      row.created_by,
+      row.created_at,
+      row.idempotency_key,
+      row.request_hash,
+      row.expected_last_change_id,
+      row.decision_attempt,
+      row.decided_at,
+      row.decided_by,
+      row.decision_reason,
+      row.commit_id,
+      row.stash_name,
+      ...expectedParams,
+    );
+}
+
+export function insertEntryStatement(db: Preparer, row: ChangeSetEntryRow): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO change_set_entries
+       (change_set_id, stash_name, path, op, base_version, blob_hash, content_storage,
+        representation, content_type, size_bytes, rollback_to, copied_from_path,
+        copied_from_version)
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+       WHERE EXISTS (SELECT 1 FROM change_sets WHERE id = ? AND stash_name = ?)`,
+    )
+    .bind(
+      row.change_set_id,
+      row.stash_name,
+      row.path,
+      row.op,
+      row.base_version,
+      row.blob_hash,
+      row.content_storage,
+      row.representation,
+      row.content_type,
+      row.size_bytes,
+      row.rollback_to,
+      row.copied_from_path,
+      row.copied_from_version,
+      row.change_set_id,
+      row.stash_name,
+    );
+}

--- a/workers/stash/src/d1/store.ts
+++ b/workers/stash/src/d1/store.ts
@@ -1,5 +1,6 @@
 import { createReads } from "./reads.js";
 import { createWrites } from "./writes.js";
+import { createChangeSets } from "./change-sets.js";
 import type { Env } from "../env.js";
 
 export interface StoreDependencies {
@@ -17,6 +18,7 @@ export function createStashStore(env: Env, deps: Partial<StoreDependencies> = {}
   return {
     reads: createReads(env, dependencies),
     writes: createWrites(env, dependencies),
+    changeSets: createChangeSets(env, dependencies),
     deps: dependencies,
   };
 }

--- a/workers/stash/src/routes/change-sets.ts
+++ b/workers/stash/src/routes/change-sets.ts
@@ -1,0 +1,99 @@
+import {
+  ChangeSetDiffQuery,
+  CreateChangeSetBody,
+  ListChangeSetsQuery,
+  StashError,
+} from "@takazudo/zudo-history-stash-core";
+import { zValidator } from "@hono/zod-validator";
+import { Hono, type Handler } from "hono";
+import type { AppEnv } from "../context.js";
+import { createStashStore } from "../d1/store.js";
+import { eventOrigin, publishEvents } from "../events/publish.js";
+
+const changeSets = new Hono<AppEnv>();
+
+function invalid(message: string): never {
+  throw new StashError("validation", message);
+}
+
+changeSets.post(
+  "/v1/stashes/:stash/change-sets",
+  zValidator("json", CreateChangeSetBody, (result) => {
+    if (!result.success) invalid("Invalid change-set input.");
+  }),
+  async (c) => {
+    const stash = c.get("routeStash").name;
+    const principal = c.get("principal");
+    const result = await createStashStore(c.env, c.get("deps")).changeSets.createChangeSet(
+      stash,
+      c.req.valid("json"),
+      {
+        idempotencyKey: c.req.header("Idempotency-Key"),
+        createdBy: principal.kind === "admin" ? "admin" : principal.tokenId,
+      },
+    );
+    if (result.replayed) c.header("Idempotent-Replayed", "true");
+    if (!result.replayed) {
+      publishEvents(c.env, c.executionCtx, stash, [
+        {
+          type: "change-set",
+          changeSetId: result.value.id,
+          stash,
+          status: result.value.status,
+          paths: result.value.entries.map(({ path }) => path),
+          origin: eventOrigin(c.req.raw),
+        },
+      ]);
+    }
+    return c.json(result.value, 201);
+  },
+);
+
+changeSets.get(
+  "/v1/stashes/:stash/change-sets",
+  zValidator("query", ListChangeSetsQuery, (result) => {
+    if (!result.success) invalid("Invalid change-set query.");
+  }),
+  async (c) =>
+    c.json(
+      await createStashStore(c.env, c.get("deps")).changeSets.listChangeSets(
+        c.get("routeStash").name,
+        c.req.valid("query"),
+      ),
+    ),
+);
+
+changeSets.get("/v1/stashes/:stash/change-sets/:id", async (c) => {
+  const value = await createStashStore(c.env, c.get("deps")).changeSets.getChangeSet(
+    c.get("routeStash").name,
+    c.req.param("id"),
+  );
+  if (value === null) throw new StashError("not-found", "Change set not found.");
+  return c.json(value);
+});
+
+changeSets.get(
+  "/v1/stashes/:stash/change-sets/:id/diff",
+  zValidator("query", ChangeSetDiffQuery, (result) => {
+    if (!result.success) invalid("Invalid change-set diff query.");
+  }),
+  async (c) => {
+    const value = await createStashStore(c.env, c.get("deps")).changeSets.getChangeSetDiff(
+      c.get("routeStash").name,
+      c.req.param("id"),
+      c.req.valid("query"),
+    );
+    if (value === null) throw new StashError("not-found", "Change set not found.");
+    return c.json(value);
+  },
+);
+
+const notImplemented: Handler<AppEnv> = (c) =>
+  c.json(
+    { error: { code: "not-implemented", message: "This route is not implemented yet." } },
+    501,
+  );
+changeSets.post("/v1/stashes/:stash/change-sets/:id/approve", notImplemented);
+changeSets.post("/v1/stashes/:stash/change-sets/:id/reject", notImplemented);
+
+export default changeSets;

--- a/workers/stash/src/routes/change-sets.ts
+++ b/workers/stash/src/routes/change-sets.ts
@@ -19,7 +19,16 @@ function invalid(message: string): never {
 changeSets.post(
   "/v1/stashes/:stash/change-sets",
   zValidator("json", CreateChangeSetBody, (result) => {
-    if (!result.success) invalid("Invalid change-set input.");
+    if (!result.success) {
+      const bodyIssue = result.error.issues.find((issue) => issue.path.at(-1) === "body");
+      if (bodyIssue?.message === "String is not well-formed") {
+        throw new StashError("body-not-well-formed", "Body is not well-formed Unicode.");
+      }
+      if (bodyIssue?.message.startsWith("Body exceeds ")) {
+        throw new StashError("payload-too-large", "Change-set body is too large.");
+      }
+      invalid("Invalid change-set input.");
+    }
   }),
   async (c) => {
     const stash = c.get("routeStash").name;

--- a/workers/stash/src/routes/index.ts
+++ b/workers/stash/src/routes/index.ts
@@ -4,6 +4,7 @@ import { requireRoute } from "../auth.js";
 import type { AppEnv } from "../context.js";
 import { rateLimit } from "../rate-limit.js";
 import admin from "./admin.js";
+import changeSets from "./change-sets.js";
 import diff from "./diff.js";
 import events from "./events.js";
 import files from "./files.js";
@@ -29,6 +30,7 @@ for (const route of ROUTES) {
 }
 routes.route("/", meta);
 routes.route("/", admin);
+routes.route("/", changeSets);
 routes.route("/", files);
 routes.route("/", gc);
 routes.route("/", history);

--- a/workers/stash/src/rpc.ts
+++ b/workers/stash/src/rpc.ts
@@ -264,28 +264,33 @@ export class StashRpc extends WorkerEntrypoint<Env> implements StashRpcMethods {
     input: CreateChangeSetBody,
     idempotencyKey?: string,
   ): Promise<Response> {
-    return this.jsonSkeleton(
-      "POST",
-      `/v1/stashes/${stash}/change-sets`,
+    return this.request({
+      method: "POST",
+      path: `/v1/stashes/${stash}/change-sets`,
+      headers: {
+        "Content-Type": "application/json",
+        ...(idempotencyKey === undefined ? {} : { "Idempotency-Key": idempotencyKey }),
+      },
+      body: JSON.stringify(input),
       token,
-      input,
-      idempotencyKey,
-    );
+    });
   }
   async listChangeSets(
     token: string,
     stash: string,
     query: Partial<ListChangeSetsQuery> = {},
   ): Promise<Response> {
+    const options = optionalQuery(query);
     return this.request({
       method: "GET",
       path: `/v1/stashes/${stash}/change-sets`,
-      query: optionalQuery(query),
+      query: options,
       token,
     });
   }
   async getChangeSet(token: string, stash: string, id: string): Promise<Response> {
-    return this.request({ method: "GET", path: `/v1/stashes/${stash}/change-sets/${id}`, token });
+    const path = `/v1/stashes/${stash}/change-sets/${id}`;
+    return this.request({ method: "GET", path, token });
   }
   async getChangeSetDiff(
     token: string,
@@ -293,10 +298,11 @@ export class StashRpc extends WorkerEntrypoint<Env> implements StashRpcMethods {
     id: string,
     query: ChangeSetDiffQuery = {},
   ): Promise<Response> {
+    const options = optionalQuery(query);
     return this.request({
       method: "GET",
       path: `/v1/stashes/${stash}/change-sets/${id}/diff`,
-      query: optionalQuery(query),
+      query: options,
       token,
     });
   }

--- a/workers/stash/test/helpers/app.ts
+++ b/workers/stash/test/helpers/app.ts
@@ -35,6 +35,8 @@ export async function resetDatabase(): Promise<void> {
     "upload_sessions",
     "gc_runs",
     "idempotency",
+    "change_set_entries",
+    "change_sets",
     "versions",
     "commits",
     "files",

--- a/workers/stash/test/migrations.test.ts
+++ b/workers/stash/test/migrations.test.ts
@@ -91,6 +91,21 @@ describe("D1 migrations", () => {
     }>();
     expect(versionColumns.results.find(({ name }) => name === "commit_id")?.notnull).toBe(1);
 
+    const changeSetIndexes = await env.DB.prepare("PRAGMA index_list(change_sets)").all<{
+      name: string;
+      partial: number;
+    }>();
+    expect(changeSetIndexes.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "change_sets_stash_status_created", partial: 0 }),
+        expect.objectContaining({ name: "change_sets_stash_idempotency", partial: 1 }),
+      ]),
+    );
+    const entryIndexes = await env.DB.prepare("PRAGMA index_list(change_set_entries)").all<{
+      name: string;
+    }>();
+    expect(entryIndexes.results.map(({ name }) => name)).toContain("change_set_entries_stash_path");
+
     await expect(env.DB.prepare("SELECT 1 FROM proposals").first()).rejects.toThrow();
 
     const jobs = await env.DB.prepare(

--- a/workers/stash/test/route-pin.test.ts
+++ b/workers/stash/test/route-pin.test.ts
@@ -17,10 +17,6 @@ const skeletonRouteProbes = [
   { id: "getCommitDiff", method: "GET", path: "/v1/stashes/route-pin/commits/cmt_1/diff" },
   { id: "revertCommit", method: "POST", path: "/v1/stashes/route-pin/commits/cmt_1/revert" },
   { id: "getSnapshot", method: "GET", path: "/v1/stashes/route-pin/snapshot?at=commit%3Acmt_1" },
-  { id: "createChangeSet", method: "POST", path: "/v1/stashes/route-pin/change-sets" },
-  { id: "listChangeSets", method: "GET", path: "/v1/stashes/route-pin/change-sets" },
-  { id: "getChangeSet", method: "GET", path: "/v1/stashes/route-pin/change-sets/chs_1" },
-  { id: "getChangeSetDiff", method: "GET", path: "/v1/stashes/route-pin/change-sets/chs_1/diff" },
   {
     id: "approveChangeSet",
     method: "POST",
@@ -136,7 +132,7 @@ describe("route contract pin", () => {
     expect(response.status).toBe(501);
   });
 
-  it("keeps all twelve raw skeleton RPC methods on generic request transport", async () => {
+  it("keeps raw commit and change-set RPC methods on generic request transport", async () => {
     await seedStash("route-pin");
     const rpc = new StashRpc(createExecutionContext(), createTestEnv().env);
     const entry = { op: "put" as const, path: "docs/a.md", expectedVersion: null, body: "a" };
@@ -164,7 +160,9 @@ describe("route contract pin", () => {
       rpc.approveChangeSet("test-admin", "route-pin", "chs_1", {}),
       rpc.rejectChangeSet("test-admin", "route-pin", "chs_1", {}),
     ]);
-    expect(responses.map(({ status }) => status)).toEqual(Array(12).fill(501));
+    expect(responses.map(({ status }) => status)).toEqual([
+      501, 501, 501, 501, 501, 501, 201, 200, 400, 400, 501, 501,
+    ]);
   });
 
   it("exports one parser and transport-error identity from the client package root", async () => {

--- a/workers/stash/test/routes/change-sets.test.ts
+++ b/workers/stash/test/routes/change-sets.test.ts
@@ -1,4 +1,5 @@
 import { env } from "cloudflare:workers";
+import { StashEventSchema, type StashEvent } from "@takazudo/zudo-history-stash-core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../../src/app.js";
 import { bearer, request, resetDatabase, seedStash } from "../helpers/app.js";
@@ -25,6 +26,24 @@ describe("change-set routes", () => {
   it("creates, gets, lists, diffs, and publishes the replay header", async () => {
     await seedStash(STASH);
     const worker = app();
+    const events: StashEvent[] = [];
+    const bindings = {
+      ...env,
+      STASH_EVENTS: new Proxy(env.STASH_EVENTS, {
+        get(target, property, receiver) {
+          if (property === "getByName") {
+            return () => ({
+              fetch: async (eventRequest: Request) => {
+                events.push(StashEventSchema.parse(await eventRequest.json()));
+                return new Response(null, { status: 204 });
+              },
+            });
+          }
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }),
+    };
     const input = {
       entries: [{ op: "put", path: "route.txt", baseVersion: null, body: "candidate\n" }],
       author: "route-test",
@@ -33,20 +52,31 @@ describe("change-set routes", () => {
       worker,
       `http://localhost/v1/stashes/${STASH}/change-sets`,
       json(input, { "Idempotency-Key": "route-replay" }),
-      env,
+      bindings,
     );
     expect(first.status).toBe(201);
     const created = await first.json<{ id: string }>();
+    expect(events).toEqual([
+      {
+        type: "change-set",
+        changeSetId: created.id,
+        stash: STASH,
+        status: "open",
+        paths: ["route.txt"],
+        origin: null,
+      },
+    ]);
 
     const replay = await request(
       worker,
       `http://localhost/v1/stashes/${STASH}/change-sets`,
       json(input, { "Idempotency-Key": "route-replay" }),
-      env,
+      bindings,
     );
     expect(replay.status).toBe(201);
     expect(replay.headers.get("Idempotent-Replayed")).toBe("true");
     await expect(replay.json()).resolves.toMatchObject({ id: created.id });
+    expect(events).toHaveLength(1);
 
     const listed = await request(
       worker,

--- a/workers/stash/test/routes/change-sets.test.ts
+++ b/workers/stash/test/routes/change-sets.test.ts
@@ -1,0 +1,131 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../../src/app.js";
+import { bearer, request, resetDatabase, seedStash } from "../helpers/app.js";
+
+const STASH = "change-set-route";
+const NOW = 1_800_000_000_000;
+
+function app() {
+  let sequence = 0;
+  return createApp({ now: () => NOW, createId: () => `route-${(sequence += 1)}` });
+}
+
+function json(input: unknown, headers: HeadersInit = {}): RequestInit {
+  return {
+    method: "POST",
+    headers: { ...bearer(env.STASH_ADMIN_TOKEN), "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(input),
+  };
+}
+
+beforeEach(resetDatabase);
+
+describe("change-set routes", () => {
+  it("creates, gets, lists, diffs, and publishes the replay header", async () => {
+    await seedStash(STASH);
+    const worker = app();
+    const input = {
+      entries: [{ op: "put", path: "route.txt", baseVersion: null, body: "candidate\n" }],
+      author: "route-test",
+    };
+    const first = await request(
+      worker,
+      `http://localhost/v1/stashes/${STASH}/change-sets`,
+      json(input, { "Idempotency-Key": "route-replay" }),
+      env,
+    );
+    expect(first.status).toBe(201);
+    const created = await first.json<{ id: string }>();
+
+    const replay = await request(
+      worker,
+      `http://localhost/v1/stashes/${STASH}/change-sets`,
+      json(input, { "Idempotency-Key": "route-replay" }),
+      env,
+    );
+    expect(replay.status).toBe(201);
+    expect(replay.headers.get("Idempotent-Replayed")).toBe("true");
+    await expect(replay.json()).resolves.toMatchObject({ id: created.id });
+
+    const listed = await request(
+      worker,
+      `http://localhost/v1/stashes/${STASH}/change-sets?status=all&path=route.txt`,
+      { headers: bearer(env.STASH_ADMIN_TOKEN) },
+      env,
+    );
+    await expect(listed.json()).resolves.toMatchObject({
+      total: 1,
+      changeSets: [{ id: created.id }],
+    });
+
+    const got = await request(
+      worker,
+      `http://localhost/v1/stashes/${STASH}/change-sets/${created.id}`,
+      { headers: bearer(env.STASH_ADMIN_TOKEN) },
+      env,
+    );
+    await expect(got.json()).resolves.toMatchObject({
+      id: created.id,
+      entries: [{ path: "route.txt", stale: false }],
+    });
+
+    const diff = await request(
+      worker,
+      `http://localhost/v1/stashes/${STASH}/change-sets/${created.id}/diff?path=route.txt`,
+      { headers: bearer(env.STASH_ADMIN_TOKEN) },
+      env,
+    );
+    await expect(diff.json()).resolves.toMatchObject({
+      stale: false,
+      entries: [{ path: "route.txt", diff: { state: "ready" } }],
+    });
+  });
+
+  it("returns validation and idempotency reuse errors and leaves decisions unimplemented", async () => {
+    await seedStash(STASH);
+    const worker = app();
+    const collection = `http://localhost/v1/stashes/${STASH}/change-sets`;
+    const missingDelete = await request(
+      worker,
+      collection,
+      json({ entries: [{ op: "delete", path: "missing.txt", baseVersion: 1 }] }),
+      env,
+    );
+    expect(missingDelete.status).toBe(400);
+    await expect(missingDelete.json()).resolves.toMatchObject({
+      error: { code: "validation", message: expect.stringContaining("missing.txt") },
+    });
+
+    const first = await request(
+      worker,
+      collection,
+      json(
+        { entries: [{ op: "put", path: "one.txt", baseVersion: null, body: "one" }] },
+        { "Idempotency-Key": "reuse" },
+      ),
+      env,
+    );
+    const created = await first.json<{ id: string }>();
+    const reused = await request(
+      worker,
+      collection,
+      json(
+        { entries: [{ op: "put", path: "one.txt", baseVersion: null, body: "two" }] },
+        { "Idempotency-Key": "reuse" },
+      ),
+      env,
+    );
+    expect(reused.status).toBe(422);
+
+    for (const decision of ["approve", "reject"]) {
+      const response = await request(
+        worker,
+        `${collection}/${created.id}/${decision}`,
+        json({}),
+        env,
+      );
+      expect(response.status).toBe(501);
+    }
+  });
+});

--- a/workers/stash/test/store/change-sets.test.ts
+++ b/workers/stash/test/store/change-sets.test.ts
@@ -133,4 +133,47 @@ describe("change-set store", () => {
       store.changeSets.listChangeSets(STASH, { status: "all", path: "one.txt" }),
     ).resolves.toMatchObject({ total: 1, changeSets: [{ entries: [{ path: "one.txt" }] }] });
   });
+
+  it("returns metadata outcomes for binary and copy entries", async () => {
+    await seedStash(STASH);
+    const store = createStashStore(env as Env, dependencies());
+    await store.writes.put(STASH, "source.txt", { body: "source", expectedVersion: null });
+    const created = await store.changeSets.createChangeSet(STASH, {
+      entries: [
+        {
+          op: "put",
+          path: "binary.bin",
+          baseVersion: null,
+          representation: "binary",
+          contentType: "application/octet-stream",
+          bytesBase64: "AAEC",
+        },
+        {
+          op: "copy",
+          path: "copy.txt",
+          baseVersion: null,
+          from: { path: "source.txt", version: 1 },
+        },
+      ],
+    });
+    const diff = await store.changeSets.getChangeSetDiff(STASH, created.value.id);
+    expect(diff?.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "binary.bin", diff: { state: "binary" } }),
+        expect.objectContaining({ path: "copy.txt", diff: { state: "binary" } }),
+      ]),
+    );
+  });
+
+  it("reports expected-last-change conflicts instead of persistence failures", async () => {
+    await seedStash(STASH);
+    const store = createStashStore(env as Env, dependencies());
+    await store.writes.put(STASH, "existing.txt", { body: "one", expectedVersion: null });
+    await expect(
+      store.changeSets.createChangeSet(STASH, {
+        entries: [{ op: "put", path: "new.txt", baseVersion: null, body: "candidate" }],
+        expectedLastChangeId: 0,
+      }),
+    ).rejects.toMatchObject({ code: "commit-conflict", status: 409 });
+  });
 });

--- a/workers/stash/test/store/change-sets.test.ts
+++ b/workers/stash/test/store/change-sets.test.ts
@@ -1,0 +1,136 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createStashStore } from "../../src/d1/store.js";
+import type { Env } from "../../src/env.js";
+import { resetDatabase, seedStash } from "../helpers/app.js";
+
+const STASH = "change-set-store";
+const NOW = 1_800_000_000_000;
+
+function dependencies(now = () => NOW) {
+  let sequence = 0;
+  return { now, createId: () => `change-set-${(sequence += 1)}` };
+}
+
+beforeEach(resetDatabase);
+
+describe("change-set store", () => {
+  it("stages put, delete, and rollback entries and recomputes stale diffs", async () => {
+    await seedStash(STASH);
+    const store = createStashStore(env as Env, dependencies());
+    await store.writes.put(STASH, "delete.txt", { body: "remove\n", expectedVersion: null });
+    await store.writes.put(STASH, "rollback.txt", { body: "first\n", expectedVersion: null });
+    await store.writes.put(STASH, "rollback.txt", { body: "second\n", expectedVersion: 1 });
+
+    const created = await store.changeSets.createChangeSet(STASH, {
+      entries: [
+        { op: "put", path: "new.txt", baseVersion: null, body: "candidate\n" },
+        { op: "delete", path: "delete.txt", baseVersion: 1 },
+        { op: "rollback", path: "rollback.txt", baseVersion: 2, toVersion: 1 },
+      ],
+      author: "reviewer",
+      message: "three entries",
+      meta: {},
+    });
+    expect(created.value.entries).toHaveLength(3);
+    const before = await store.changeSets.getChangeSetDiff(STASH, created.value.id);
+    expect(before).toMatchObject({ stale: false, truncated: false });
+    expect(before?.entries.map(({ path, stale }) => ({ path, stale }))).toEqual([
+      { path: "delete.txt", stale: false },
+      { path: "new.txt", stale: false },
+      { path: "rollback.txt", stale: false },
+    ]);
+    expect(before?.entries.every(({ diff }) => diff.state === "ready")).toBe(true);
+
+    await store.writes.put(STASH, "new.txt", { body: "competitor\n", expectedVersion: null });
+    const after = await store.changeSets.getChangeSetDiff(STASH, created.value.id);
+    expect(after).toMatchObject({ stale: true });
+    expect(after?.entries.find(({ path }) => path === "new.txt")).toMatchObject({
+      stale: true,
+      current: { version: 1 },
+    });
+  });
+
+  it("rejects deleting a never-existing path with a path-naming validation error", async () => {
+    await seedStash(STASH);
+    const store = createStashStore(env as Env, dependencies());
+    await expect(
+      store.changeSets.createChangeSet(STASH, {
+        entries: [{ op: "delete", path: "missing.txt", baseVersion: 1 }],
+      }),
+    ).rejects.toMatchObject({
+      code: "validation",
+      message: expect.stringContaining("missing.txt"),
+    });
+  });
+
+  it("replays the same canonical request and rejects different same-key reuse", async () => {
+    await seedStash(STASH);
+    const store = createStashStore(env as Env, dependencies());
+    const input = {
+      entries: [{ op: "put" as const, path: "new.txt", baseVersion: null, body: "candidate" }],
+    };
+    const first = await store.changeSets.createChangeSet(STASH, input, {
+      idempotencyKey: "retry",
+    });
+    await expect(
+      store.changeSets.createChangeSet(STASH, input, { idempotencyKey: "retry" }),
+    ).resolves.toEqual({ value: first.value, replayed: true });
+    await expect(
+      store.changeSets.createChangeSet(
+        STASH,
+        {
+          entries: [{ op: "put", path: "new.txt", baseVersion: null, body: "different" }],
+        },
+        { idempotencyKey: "retry" },
+      ),
+    ).rejects.toMatchObject({ code: "idempotency-key-reused", status: 422 });
+  });
+
+  it("computes expiry at the exact expiresAt boundary", async () => {
+    await seedStash(STASH);
+    let clock = NOW;
+    const store = createStashStore(
+      env as Env,
+      dependencies(() => clock),
+    );
+    const created = await store.changeSets.createChangeSet(STASH, {
+      entries: [{ op: "put", path: "expires.txt", baseVersion: null, body: "candidate" }],
+      expiresAt: new Date(NOW + 1).toISOString(),
+    });
+    expect(created.value.status).toBe("open");
+    clock = NOW + 1;
+    await expect(store.changeSets.getChangeSet(STASH, created.value.id)).resolves.toMatchObject({
+      status: "expired",
+    });
+    await expect(
+      store.changeSets.listChangeSets(STASH, { status: "expired" }),
+    ).resolves.toMatchObject({ total: 1, changeSets: [{ id: created.value.id }] });
+    await expect(store.changeSets.listChangeSets(STASH)).resolves.toMatchObject({
+      total: 0,
+      changeSets: [],
+    });
+  });
+
+  it("paginates equal timestamps by id and preserves the filtered total", async () => {
+    await seedStash(STASH);
+    const store = createStashStore(env as Env, dependencies());
+    for (const path of ["one.txt", "two.txt", "three.txt"]) {
+      await store.changeSets.createChangeSet(STASH, {
+        entries: [{ op: "put", path, baseVersion: null, body: path }],
+      });
+    }
+    const first = await store.changeSets.listChangeSets(STASH, { status: "all", limit: 2 });
+    expect(first).toMatchObject({ total: 3, nextAfter: expect.any(String) });
+    const second = await store.changeSets.listChangeSets(STASH, {
+      status: "all",
+      limit: 2,
+      after: first.nextAfter ?? undefined,
+    });
+    expect(second).toMatchObject({ total: 3, nextAfter: null });
+    expect([...first.changeSets, ...second.changeSets].map(({ id }) => id)).toHaveLength(3);
+    await expect(
+      store.changeSets.listChangeSets(STASH, { status: "all", path: "one.txt" }),
+    ).resolves.toMatchObject({ total: 1, changeSets: [{ entries: [{ path: "one.txt" }] }] });
+  });
+});


### PR DESCRIPTION
Parent: #206

Relates to #212.

## Summary

- add change-set and staged-entry persistence with create-time head validation
- implement create, list, get, and diff APIs with storage-aware staging
- enforce whole-set staleness, cursor binding, source validation, and error classification

## Validation

- 581 Stash tests passed at topic completion
- focused storage, route, RPC, typecheck, lint, and formatting gates passed
- blocking topic review completed before integration
