### PR TITLE
Harden commit races and publish commit events

### DIFF
--- a/workers/stash/src/d1/commits.ts
+++ b/workers/stash/src/d1/commits.ts
@@ -638,6 +638,7 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
       created_at: createdAt,
     };
 
+    let results: D1Result<unknown>[] | null = null;
     try {
       let statements = commitBatch(db, {
         row,
@@ -647,19 +648,19 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
           : { expectedLastChangeId: value.expectedLastChangeId }),
       });
       statements = deps.alterCommitStatementsForTest?.(statements) ?? statements;
-      const results = await db.batch(statements);
-      if (results.at(-1)?.meta.changes === 1) {
-        const persisted = await db
-          .prepare("SELECT * FROM commits WHERE stash_name = ? AND id = ? AND sealed = 1")
-          .bind(stash, commitId)
-          .first<CommitRow>();
-        const result = persisted ? await resultFromCommit(db, persisted, value.entries) : null;
-        if (!result) return failure("internal", 500, "Missing committed changes");
-        await options.onCommitted?.(result);
-        return { ok: true, value: result, statusCode: 201 };
-      }
+      results = await db.batch(statements);
     } catch {
       // UNIQUE idempotency races and CHECK rollbacks are classified by the same durable re-read.
+    }
+    if (results?.at(-1)?.meta.changes === 1) {
+      const persisted = await db
+        .prepare("SELECT * FROM commits WHERE stash_name = ? AND id = ? AND sealed = 1")
+        .bind(stash, commitId)
+        .first<CommitRow>();
+      const result = persisted ? await resultFromCommit(db, persisted, value.entries) : null;
+      if (!result) return failure("internal", 500, "Missing committed changes");
+      await options.onCommitted?.(result);
+      return { ok: true, value: result, statusCode: 201 };
     }
 
     if (!(await stashIsLive(db, stash))) return failure("not-found", 404, "Stash not found");

--- a/workers/stash/src/d1/commits.ts
+++ b/workers/stash/src/d1/commits.ts
@@ -71,6 +71,7 @@ export type StoreCommitResult =
 export interface CommitOptions {
   principal: string | Principal;
   idempotencyKey?: string;
+  onCommitted?: (result: CommitResult) => void | Promise<void>;
 }
 
 export interface StashCommits {
@@ -84,6 +85,7 @@ export interface StashCommits {
 export interface CommitDependencies extends StoreDependencies {
   onBeforeCommit?: () => void | Promise<void>;
   createBlobGeneration?: BlobGenerationFactory;
+  alterCommitStatementsForTest?: (statements: D1PreparedStatement[]) => D1PreparedStatement[];
 }
 
 function failure(
@@ -486,24 +488,24 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
     };
 
     try {
-      const results = await db.batch(
-        commitBatch(db, {
-          row,
-          entries: prepared,
-          ...(value.expectedLastChangeId === undefined
-            ? {}
-            : { expectedLastChangeId: value.expectedLastChangeId }),
-        }),
-      );
+      let statements = commitBatch(db, {
+        row,
+        entries: prepared,
+        ...(value.expectedLastChangeId === undefined
+          ? {}
+          : { expectedLastChangeId: value.expectedLastChangeId }),
+      });
+      statements = deps.alterCommitStatementsForTest?.(statements) ?? statements;
+      const results = await db.batch(statements);
       if (results.at(-1)?.meta.changes === 1) {
         const persisted = await db
           .prepare("SELECT * FROM commits WHERE stash_name = ? AND id = ? AND sealed = 1")
           .bind(stash, commitId)
           .first<CommitRow>();
         const result = persisted ? await resultFromCommit(db, persisted, value.entries) : null;
-        return result
-          ? { ok: true, value: result, statusCode: 201 }
-          : failure("internal", 500, "Missing committed changes");
+        if (!result) return failure("internal", 500, "Missing committed changes");
+        await options.onCommitted?.(result);
+        return { ok: true, value: result, statusCode: 201 };
       }
     } catch {
       // UNIQUE idempotency races and CHECK rollbacks are classified by the same durable re-read.

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -404,6 +404,12 @@ function commitSealStatement(db: Preparer, input: CommitBatchInput): D1PreparedS
                WHERE f.path IS NULL
                  OR f.head_version <> json_extract(expected.value, '$.version')
                  OR f.deleted <> json_extract(expected.value, '$.deleted')
+                 OR f.head_hash IS NOT (
+                   SELECT committed.blob_hash FROM versions AS committed
+                   WHERE committed.stash_name = commits.stash_name
+                     AND committed.path = json_extract(expected.value, '$.path')
+                     AND committed.version = json_extract(expected.value, '$.version')
+                 )
              )
            THEN (SELECT COUNT(*) FROM versions WHERE commit_id = commits.id)
            ELSE -1 END,

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -376,8 +376,43 @@ export function commitBatch(db: Preparer, input: CommitBatchInput): D1PreparedSt
     else statements.push(derivedEntryStatement(db, input, entry));
     statements.push(headStatement(db, input, entry));
   }
-  statements.push(sealStatement(db, { stash: input.row.stash_name, id: input.row.id }));
+  statements.push(commitSealStatement(db, input));
   return statements;
+}
+
+/**
+ * Sealing is the final aggregate invariant. Once the gate inserted the commit, every generated
+ * version and file-head write must be visible or the existing commits CHECK is intentionally
+ * violated so D1 rolls the whole batch back.
+ */
+function commitSealStatement(db: Preparer, input: CommitBatchInput): D1PreparedStatement {
+  const expectedHeads = input.entries.map((entry) => ({
+    path: entry.path,
+    version: entry.version,
+    deleted: entry.op === "delete" ? 1 : 0,
+  }));
+  return db
+    .prepare(
+      `UPDATE commits
+       SET change_count = CASE WHEN
+             entry_count = (SELECT COUNT(*) FROM versions WHERE commit_id = commits.id)
+             AND NOT EXISTS (
+               SELECT 1 FROM json_each(?) AS expected
+               LEFT JOIN files AS f
+                 ON f.stash_name = commits.stash_name
+                   AND f.path = json_extract(expected.value, '$.path')
+               WHERE f.path IS NULL
+                 OR f.head_version <> json_extract(expected.value, '$.version')
+                 OR f.deleted <> json_extract(expected.value, '$.deleted')
+             )
+           THEN (SELECT COUNT(*) FROM versions WHERE commit_id = commits.id)
+           ELSE -1 END,
+           first_change_id = (SELECT MIN(id) FROM versions WHERE commit_id = commits.id),
+           last_change_id = (SELECT MAX(id) FROM versions WHERE commit_id = commits.id),
+           sealed = 1
+       WHERE stash_name = ? AND id = ? AND sealed = 0`,
+    )
+    .bind(JSON.stringify(expectedHeads), input.row.stash_name, input.row.id);
 }
 
 export function sealStatement(

--- a/workers/stash/src/events/publish.ts
+++ b/workers/stash/src/events/publish.ts
@@ -1,6 +1,7 @@
 import {
   STASH_CLIENT_ID_HEADER,
   isStashClientId,
+  type CommitResult,
   type StashEvent,
 } from "@takazudo/zudo-history-stash-core";
 import type { Env } from "../env.js";
@@ -18,24 +19,49 @@ export function eventOrigin(request: Request): string | null {
   return isStashClientId(value) ? value : null;
 }
 
+/** Builds the ordered live-only frames for a newly persisted multi-entry commit. */
+export function commitEvents(result: CommitResult, origin: string | null): StashEvent[] {
+  return [
+    ...result.entries.map((entry): StashEvent => ({
+      type: "change",
+      changeId: entry.changeId,
+      commitId: result.id,
+      stash: result.stash,
+      path: entry.path,
+      version: entry.version,
+      kind: entry.kind,
+      origin,
+      createdAt: result.createdAt,
+    })),
+    {
+      type: "commit",
+      commitId: result.id,
+      stash: result.stash,
+      entryCount: result.entryCount,
+      firstChangeId: result.firstChangeId,
+      lastChangeId: result.lastChangeId,
+      origin,
+    },
+  ];
+}
+
 export async function deliverEvents(
   env: Env,
   stash: string,
   events: readonly StashEvent[],
 ): Promise<void> {
   const stub = env.STASH_EVENTS.getByName(stash);
-  for (const event of events) {
-    const response = await stub.fetch(
-      new Request(`${INTERNAL_EVENTS_ORIGIN}${STASH_EVENTS_PUBLISH_PATH}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(event),
-      }),
-    );
-    if (!response.ok) {
-      await response.body?.cancel();
-      throw new Error(`StashEvents publish returned ${response.status}`);
-    }
+  if (events.length === 0) return;
+  const response = await stub.fetch(
+    new Request(`${INTERNAL_EVENTS_ORIGIN}${STASH_EVENTS_PUBLISH_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(events),
+    }),
+  );
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(`StashEvents publish returned ${response.status}`);
   }
 }
 

--- a/workers/stash/src/events/stash-events.ts
+++ b/workers/stash/src/events/stash-events.ts
@@ -208,11 +208,13 @@ export class StashEvents extends DurableObject<Env> {
     } catch {
       return errorResponse(400, "Invalid event.");
     }
-    const event = StashEventSchema.safeParse(value);
-    if (!event.success) return errorResponse(400, "Invalid event.");
+    const events = StashEventSchema.array().min(1).safeParse(value);
+    if (!events.success) return errorResponse(400, "Invalid event batch.");
 
-    const frame = encodeEvent(event.data);
-    for (const subscriber of this.subscribers.values()) subscriber.offer(frame);
+    for (const event of events.data) {
+      const frame = encodeEvent(event);
+      for (const subscriber of this.subscribers.values()) subscriber.offer(frame);
+    }
     return new Response(null, { status: 204 });
   }
 

--- a/workers/stash/test/events/do.test.ts
+++ b/workers/stash/test/events/do.test.ts
@@ -45,7 +45,7 @@ async function publish(instance: StashEvents, event: StashEvent): Promise<Respon
     request(STASH_EVENTS_PUBLISH_PATH, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(event),
+      body: JSON.stringify([event]),
     }),
   );
 }
@@ -107,6 +107,48 @@ describe("StashEvents Durable Object", () => {
       }
       expect(inspect(instance).activeSubscriberCount).toBe(0);
       expect(inspect(instance).heartbeatActive).toBe(false);
+    });
+  });
+
+  it("validates and publishes an ordered event array while commit frames remain live-only", async () => {
+    await runInDurableObject(stub(), async (instance: StashEvents) => {
+      const reader = readerFor(await subscribe(instance));
+      const change: StashEvent = {
+        type: "change",
+        changeId: 50,
+        commitId: "cmt_batch",
+        stash: "docs",
+        path: "one.txt",
+        version: 1,
+        kind: "put",
+        origin: null,
+        createdAt: "2026-08-28T00:00:00.000Z",
+      };
+      const commit: StashEvent = {
+        type: "commit",
+        commitId: "cmt_batch",
+        stash: "docs",
+        entryCount: 1,
+        firstChangeId: 50,
+        lastChangeId: 50,
+        origin: null,
+      };
+      try {
+        const response = await instance.fetch(
+          request(STASH_EVENTS_PUBLISH_PATH, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify([change, commit]),
+          }),
+        );
+        expect(response.status).toBe(204);
+        expect(await readText(reader)).toEqual({ text: eventFrame(change), done: false });
+        expect(await readText(reader)).toEqual({ text: eventFrame(commit), done: false });
+        expect(eventFrame(change)).toContain("id: 50\n");
+        expect(eventFrame(commit)).not.toContain("id:");
+      } finally {
+        await cancelReader(reader);
+      }
     });
   });
 
@@ -315,6 +357,14 @@ describe("StashEvents Durable Object", () => {
           request(STASH_EVENTS_PUBLISH_PATH, { method: "POST", body: "{" }),
         );
         expect(malformed.status).toBe(400);
+        const singleton = await instance.fetch(
+          request(STASH_EVENTS_PUBLISH_PATH, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(event),
+          }),
+        );
+        expect(singleton.status).toBe(400);
         expect((await instance.fetch(request("/unknown"))).status).toBe(404);
         expect(inspect(instance).activeSubscriberCount).toBe(1);
 

--- a/workers/stash/test/events/do.test.ts
+++ b/workers/stash/test/events/do.test.ts
@@ -124,13 +124,18 @@ describe("StashEvents Durable Object", () => {
         origin: null,
         createdAt: "2026-08-28T00:00:00.000Z",
       };
+      const secondChange: StashEvent = {
+        ...change,
+        changeId: 51,
+        path: "two.txt",
+      };
       const commit: StashEvent = {
         type: "commit",
         commitId: "cmt_batch",
         stash: "docs",
-        entryCount: 1,
+        entryCount: 2,
         firstChangeId: 50,
-        lastChangeId: 50,
+        lastChangeId: 51,
         origin: null,
       };
       try {
@@ -138,13 +143,18 @@ describe("StashEvents Durable Object", () => {
           request(STASH_EVENTS_PUBLISH_PATH, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify([change, commit]),
+            body: JSON.stringify([change, secondChange, commit]),
           }),
         );
         expect(response.status).toBe(204);
         expect(await readText(reader)).toEqual({ text: eventFrame(change), done: false });
+        expect(await readText(reader)).toEqual({ text: eventFrame(secondChange), done: false });
         expect(await readText(reader)).toEqual({ text: eventFrame(commit), done: false });
         expect(eventFrame(change)).toContain("id: 50\n");
+        expect(eventFrame(secondChange)).toContain("id: 51\n");
+        expect([change, secondChange].every((event) => event.commitId === commit.commitId)).toBe(
+          true,
+        );
         expect(eventFrame(commit)).not.toContain("id:");
       } finally {
         await cancelReader(reader);

--- a/workers/stash/test/events/publish.test.ts
+++ b/workers/stash/test/events/publish.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@takazudo/zudo-history-stash-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { app } from "../../src/app.js";
+import { createStashStore } from "../../src/d1/store.js";
 import type { Env } from "../../src/env.js";
 import { commitEvents, deliverEvents, eventOrigin } from "../../src/events/publish.js";
 import { bearer, request, resetDatabase, seedStash } from "../helpers/app.js";
@@ -120,39 +121,27 @@ beforeEach(async () => {
 describe("event publication", () => {
   it("delivers a 20-entry commit as one ordered Durable Object POST", async () => {
     const { bindings, events, batches, names } = recordingEnv();
-    const entries = Array.from({ length: 20 }, (_, index) => ({
-      path: `file-${index}.txt`,
-      op: "put" as const,
-      version: 1,
-      kind: "put" as const,
-      changeId: index + 1,
-      hash: `sha256-${index}`,
-      size: 1,
-      contentType: "text/plain",
-      representation: "text" as const,
-      rollbackOf: null,
-    }));
-    const batch = commitEvents(
+    const result = await createStashStore(bindings, {
+      now: () => 1_800_000_000_000,
+      createId: () => "twenty-entry-commit",
+    }).commits.createCommit(
+      STASH,
       {
-        id: "cmt_twenty",
-        stash: STASH,
-        source: "commit",
-        sourceId: null,
-        author: "",
-        message: "",
-        meta: {},
-        entryCount: 20,
-        firstChangeId: 1,
-        lastChangeId: 20,
-        revertsCommitId: null,
-        createdBy: "test",
-        createdAt: "2026-08-29T00:00:00.000Z",
-        entries,
+        entries: Array.from({ length: 20 }, (_, index) => ({
+          op: "put" as const,
+          path: `file-${index}.txt`,
+          expectedVersion: null,
+          body: String(index),
+        })),
       },
-      "tab-twenty",
+      {
+        principal: "test",
+        onCommitted: (committed) =>
+          deliverEvents(bindings, STASH, commitEvents(committed, "tab-twenty")),
+      },
     );
-
-    await deliverEvents(bindings, STASH, batch);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected 20-entry commit");
 
     expect(names).toEqual([STASH]);
     expect(batches).toHaveLength(1);
@@ -161,17 +150,17 @@ describe("event publication", () => {
       value.every(
         (event, index) =>
           event.type === "change" &&
-          event.commitId === "cmt_twenty" &&
-          event.changeId === index + 1,
+          event.commitId === result.value.id &&
+          event.changeId === result.value.entries[index]?.changeId,
       ),
     );
     expect(events.at(-1)).toEqual({
       type: "commit",
-      commitId: "cmt_twenty",
+      commitId: result.value.id,
       stash: STASH,
       entryCount: 20,
-      firstChangeId: 1,
-      lastChangeId: 20,
+      firstChangeId: result.value.firstChangeId,
+      lastChangeId: result.value.lastChangeId,
       origin: "tab-twenty",
     });
   });

--- a/workers/stash/test/events/publish.test.ts
+++ b/workers/stash/test/events/publish.test.ts
@@ -6,7 +6,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { app } from "../../src/app.js";
 import type { Env } from "../../src/env.js";
-import { eventOrigin } from "../../src/events/publish.js";
+import { commitEvents, deliverEvents, eventOrigin } from "../../src/events/publish.js";
 import { bearer, request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv } from "../helpers/env.js";
 
@@ -22,10 +22,12 @@ function recordingEnv(
   bindings: Env;
   events: StashEvent[];
   names: string[];
+  batches: StashEvent[][];
 } {
   const base = createTestEnv().env;
   const events: StashEvent[] = [];
   const names: string[] = [];
+  const batches: StashEvent[][] = [];
   const namespace = new Proxy(base.STASH_EVENTS, {
     get(target, property, receiver) {
       if (property === "getByName") {
@@ -40,7 +42,9 @@ function recordingEnv(
                   if (options.failure === "throw") throw error;
                   if (options.failure === "reject") return Promise.reject(error);
                   return input.json().then((value) => {
-                    events.push(StashEventSchema.parse(value));
+                    const batch = StashEventSchema.array().parse(value);
+                    batches.push(batch);
+                    events.push(...batch);
                     return new Response(null, { status: 204 });
                   });
                 };
@@ -88,7 +92,7 @@ function recordingEnv(
             };
           },
         });
-  return { bindings: { ...base, DB: database, STASH_EVENTS: namespace }, events, names };
+  return { bindings: { ...base, DB: database, STASH_EVENTS: namespace }, events, names, batches };
 }
 
 async function mutation(
@@ -114,6 +118,63 @@ beforeEach(async () => {
 });
 
 describe("event publication", () => {
+  it("delivers a 20-entry commit as one ordered Durable Object POST", async () => {
+    const { bindings, events, batches, names } = recordingEnv();
+    const entries = Array.from({ length: 20 }, (_, index) => ({
+      path: `file-${index}.txt`,
+      op: "put" as const,
+      version: 1,
+      kind: "put" as const,
+      changeId: index + 1,
+      hash: `sha256-${index}`,
+      size: 1,
+      contentType: "text/plain",
+      representation: "text" as const,
+      rollbackOf: null,
+    }));
+    const batch = commitEvents(
+      {
+        id: "cmt_twenty",
+        stash: STASH,
+        source: "commit",
+        sourceId: null,
+        author: "",
+        message: "",
+        meta: {},
+        entryCount: 20,
+        firstChangeId: 1,
+        lastChangeId: 20,
+        revertsCommitId: null,
+        createdBy: "test",
+        createdAt: "2026-08-29T00:00:00.000Z",
+        entries,
+      },
+      "tab-twenty",
+    );
+
+    await deliverEvents(bindings, STASH, batch);
+
+    expect(names).toEqual([STASH]);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(21);
+    expect(events.slice(0, 20)).toSatisfy((value: StashEvent[]) =>
+      value.every(
+        (event, index) =>
+          event.type === "change" &&
+          event.commitId === "cmt_twenty" &&
+          event.changeId === index + 1,
+      ),
+    );
+    expect(events.at(-1)).toEqual({
+      type: "commit",
+      commitId: "cmt_twenty",
+      stash: STASH,
+      entryCount: 20,
+      firstChangeId: 1,
+      lastChangeId: 20,
+      origin: "tab-twenty",
+    });
+  });
   it("accepts only canonical client origins after the actual Request boundary", () => {
     expect(
       eventOrigin(new Request("https://x", { headers: { [STASH_CLIENT_ID_HEADER]: "tab A!~" } })),

--- a/workers/stash/test/routes/change-sets.test.ts
+++ b/workers/stash/test/routes/change-sets.test.ts
@@ -34,7 +34,7 @@ describe("change-set routes", () => {
           if (property === "getByName") {
             return () => ({
               fetch: async (eventRequest: Request) => {
-                events.push(StashEventSchema.parse(await eventRequest.json()));
+                events.push(...StashEventSchema.array().parse(await eventRequest.json()));
                 return new Response(null, { status: 204 });
               },
             });

--- a/workers/stash/test/routes/events.test.ts
+++ b/workers/stash/test/routes/events.test.ts
@@ -122,7 +122,7 @@ async function publish(bindings: Env, stash: string, event: StashEvent): Promise
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(event),
+      body: JSON.stringify([event]),
     },
   );
   expect(response.status).toBe(204);

--- a/workers/stash/test/routes/uploads.test.ts
+++ b/workers/stash/test/routes/uploads.test.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:workers";
-import { sha256Hex, type StashEvent } from "@takazudo/zudo-history-stash-core";
+import { sha256Hex, StashEventSchema, type StashEvent } from "@takazudo/zudo-history-stash-core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../../src/app.js";
 import { GC_ORPHAN_MIN_AGE_MS, createGcEngine } from "../../src/gc.js";
@@ -539,7 +539,7 @@ describe("single raw upload lifecycle", () => {
               eventFault = false;
               throw new Error("event delivery");
             }
-            events.push((await input.json()) as StashEvent);
+            events.push(...StashEventSchema.array().parse(await input.json()));
             return new Response(null, { status: 204 });
           },
         });

--- a/workers/stash/test/store/commits-races.test.ts
+++ b/workers/stash/test/store/commits-races.test.ts
@@ -1,0 +1,440 @@
+import { env } from "cloudflare:workers";
+import { R2_SPILL_BYTES, type CreateCommitBody } from "@takazudo/zudo-history-stash-core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createCommits, type CommitDependencies } from "../../src/d1/commits.js";
+import { createStashStore } from "../../src/d1/store.js";
+import { createGcEngine, GC_ORPHAN_MIN_AGE_MS } from "../../src/gc.js";
+import type { Env } from "../../src/env.js";
+import { commitEvents } from "../../src/events/publish.js";
+import { resetDatabase, seedStash } from "../helpers/app.js";
+
+const workerEnv = env as Env;
+let sequence = 0;
+
+function deps(overrides: Partial<CommitDependencies> = {}): CommitDependencies {
+  return {
+    now: () => 10_000 + sequence,
+    createId: () => `race-${++sequence}`,
+    ...overrides,
+  };
+}
+
+function store(now = 1_000) {
+  return createStashStore(workerEnv, {
+    now: () => now,
+    createId: () => `seed-${++sequence}`,
+  });
+}
+
+async function seedFile(stash: string, path: string, body = "seed") {
+  const result = await store().writes.put(stash, path, { body, expectedVersion: null });
+  if (!result.ok || "unchanged" in result.value) throw new Error("Failed to seed file");
+  return result.value;
+}
+
+async function counts(stash: string) {
+  const result = { commits: -1, versions: -1, files: -1, blobs: -1 };
+  for (const table of ["commits", "versions", "files", "blobs"] as const) {
+    result[table] =
+      (await workerEnv.DB.prepare(`SELECT COUNT(*) AS count FROM ${table} WHERE stash_name = ?`)
+        .bind(stash)
+        .first<number>("count")) ?? -1;
+  }
+  return result;
+}
+
+async function idempotencyRows(stash: string, key: string): Promise<number> {
+  return (
+    (await workerEnv.DB.prepare(
+      "SELECT COUNT(*) AS count FROM commits WHERE stash_name = ? AND idempotency_key = ?",
+    )
+      .bind(stash, key)
+      .first<number>("count")) ?? -1
+  );
+}
+
+beforeEach(async () => {
+  sequence = 0;
+  await resetDatabase();
+});
+
+describe("controlled commit races and invariants", () => {
+  it("names exactly the raced path and leaks no loser rows when one of N heads moves", async () => {
+    const stash = "race-one-head";
+    await seedStash(stash);
+    await seedFile(stash, "raced.txt");
+    const before = await counts(stash);
+    const winnerStore = store(9_000);
+    const commits = createCommits(
+      workerEnv,
+      deps({
+        onBeforeCommit: async () => {
+          const winner = await winnerStore.writes.put(stash, "raced.txt", {
+            body: "winner",
+            expectedVersion: 1,
+          });
+          if (!winner.ok) throw new Error("Race winner failed");
+        },
+      }),
+    );
+
+    const refused = await commits.createCommit(
+      stash,
+      {
+        entries: [
+          { op: "put", path: "new-a.txt", expectedVersion: null, body: "a" },
+          { op: "put", path: "raced.txt", expectedVersion: 1, body: "loser" },
+          { op: "put", path: "new-b.txt", expectedVersion: null, body: "b" },
+        ],
+      },
+      { principal: "test", idempotencyKey: "loser" },
+    );
+
+    expect(refused).toMatchObject({
+      ok: false,
+      error: { code: "commit-conflict", status: 409 },
+      conflicts: [{ path: "raced.txt", current: { version: 2 } }],
+    });
+    expect(refused.ok ? [] : refused.conflicts?.map(({ path }) => path)).toEqual(["raced.txt"]);
+    expect(await counts(stash)).toEqual({
+      commits: before.commits + 1,
+      versions: before.versions + 1,
+      files: before.files,
+      blobs: before.blobs + 1,
+    });
+    expect(await idempotencyRows(stash, "loser")).toBe(0);
+  });
+
+  it("serializes simultaneous identical idempotency keys into one winner and one replay", async () => {
+    const stash = "race-idempotency";
+    await seedStash(stash);
+    let arrivals = 0;
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const commits = createCommits(
+      workerEnv,
+      deps({
+        onBeforeCommit: async () => {
+          arrivals += 1;
+          if (arrivals === 2) release();
+          await barrier;
+        },
+      }),
+    );
+    const input: CreateCommitBody = {
+      entries: [{ op: "put", path: "same.txt", expectedVersion: null, body: "same" }],
+    };
+
+    const results = await Promise.all([
+      commits.createCommit(stash, input, { principal: "a", idempotencyKey: "same" }),
+      commits.createCommit(stash, input, { principal: "a", idempotencyKey: "same" }),
+    ]);
+
+    expect(results.every(({ ok }) => ok)).toBe(true);
+    expect(results.filter((result) => result.ok && result.replayed)).toHaveLength(1);
+    expect(results.filter((result) => result.ok && !result.replayed)).toHaveLength(1);
+    if (!results[0]?.ok || !results[1]?.ok) throw new Error("Expected two successful results");
+    expect(results[0].value).toEqual(results[1].value);
+    expect(await counts(stash)).toEqual({ commits: 1, versions: 1, files: 1, blobs: 1 });
+    expect(await idempotencyRows(stash, "same")).toBe(1);
+  });
+
+  it.each([
+    [
+      "duplicate path",
+      {
+        entries: [
+          { op: "put", path: "same.txt", expectedVersion: null, body: "a" },
+          { op: "put", path: "same.txt", expectedVersion: null, body: "b" },
+        ],
+      },
+    ],
+    [
+      "intra-commit copy source",
+      {
+        entries: [
+          { op: "put", path: "source.txt", expectedVersion: null, body: "a" },
+          {
+            op: "copy",
+            path: "copy.txt",
+            expectedVersion: null,
+            from: { path: "source.txt", version: 1 },
+          },
+        ],
+      },
+    ],
+  ] satisfies Array<[string, CreateCommitBody]>)(
+    "rejects %s before creating a batch",
+    async (_label, input) => {
+      const stash = `race-validation-${sequence++}`;
+      await seedStash(stash);
+      let beforeBatch = false;
+      const result = await createCommits(
+        workerEnv,
+        deps({
+          onBeforeCommit: () => {
+            beforeBatch = true;
+          },
+        }),
+      ).createCommit(stash, input, { principal: "test" });
+
+      expect(result).toMatchObject({ ok: false, error: { code: "validation", status: 400 } });
+      expect(beforeBatch).toBe(false);
+      expect(await counts(stash)).toEqual({ commits: 0, versions: 0, files: 0, blobs: 0 });
+    },
+  );
+
+  it("reports the newest offending change id for whole-stash stale CAS without rows", async () => {
+    const stash = "race-last-change";
+    await seedStash(stash);
+    const seeded = await seedFile(stash, "existing.txt");
+    const before = await counts(stash);
+    const result = await createCommits(workerEnv, deps()).createCommit(
+      stash,
+      {
+        entries: [{ op: "put", path: "new.txt", expectedVersion: null, body: "new" }],
+        expectedLastChangeId: seeded.changeId - 1,
+      },
+      { principal: "test", idempotencyKey: "stale" },
+    );
+
+    expect(result).toMatchObject({ ok: false, error: { code: "stale", status: 409 } });
+    if (result.ok) throw new Error("Expected stale result");
+    expect(result.error.message).toContain(`newest change is ${seeded.changeId}`);
+    expect(await counts(stash)).toEqual(before);
+    expect(await idempotencyRows(stash, "stale")).toBe(0);
+  });
+
+  it("rolls back a forced missing head write and classifies the durable re-read as internal", async () => {
+    const stash = "race-seal-check";
+    await seedStash(stash);
+    let batchRejected = false;
+    const database = new Proxy(workerEnv.DB, {
+      get(target, property, receiver) {
+        if (property !== "withSession") return Reflect.get(target, property, receiver);
+        return (...args: Parameters<D1Database["withSession"]>) => {
+          const session = target.withSession(...args);
+          return new Proxy(session, {
+            get(sessionTarget, sessionProperty, sessionReceiver) {
+              if (sessionProperty !== "batch") {
+                return Reflect.get(sessionTarget, sessionProperty, sessionReceiver);
+              }
+              return async (statements: D1PreparedStatement[]) => {
+                try {
+                  return await sessionTarget.batch(statements);
+                } catch (error) {
+                  batchRejected = true;
+                  throw error;
+                }
+              };
+            },
+          });
+        };
+      },
+    });
+    const commits = createCommits(
+      { ...workerEnv, DB: database },
+      deps({
+        alterCommitStatementsForTest: (statements) =>
+          statements.filter((_, index) => index !== statements.length - 2),
+      }),
+    );
+    const result = await commits.createCommit(
+      stash,
+      {
+        entries: [
+          { op: "put", path: "one.txt", expectedVersion: null, body: "one" },
+          { op: "put", path: "two.txt", expectedVersion: null, body: "two" },
+        ],
+      },
+      { principal: "test", idempotencyKey: "forced-seal" },
+    );
+
+    expect(batchRejected).toBe(true);
+    expect(result).toMatchObject({ ok: false, error: { code: "internal", status: 500 } });
+    expect(await counts(stash)).toEqual({ commits: 0, versions: 0, files: 0, blobs: 0 });
+    expect(await idempotencyRows(stash, "forced-seal")).toBe(0);
+    await expect(
+      workerEnv.DB.prepare(
+        "SELECT path, head_version FROM files WHERE stash_name = ? ORDER BY path",
+      )
+        .bind(stash)
+        .all(),
+    ).resolves.toMatchObject({ results: [] });
+  });
+
+  it("garbage-collects exactly N spilled objects from a refused commit", async () => {
+    const stash = "race-r2-orphans";
+    await seedStash(stash);
+    await seedFile(stash, "raced.txt");
+    const spillA = "a".repeat(R2_SPILL_BYTES + 1);
+    const spillB = "b".repeat(R2_SPILL_BYTES + 1);
+    let generation = 0;
+    const commits = createCommits(
+      workerEnv,
+      deps({
+        createBlobGeneration: () =>
+          `11111111-1111-4111-8111-${String(++generation).padStart(12, "0")}`,
+        onBeforeCommit: async () => {
+          const winner = await store(9_000).writes.put(stash, "raced.txt", {
+            body: "winner",
+            expectedVersion: 1,
+          });
+          if (!winner.ok) throw new Error("Race winner failed");
+        },
+      }),
+    );
+    const result = await commits.createCommit(
+      stash,
+      {
+        entries: [
+          { op: "put", path: "raced.txt", expectedVersion: 1, body: spillA },
+          { op: "put", path: "new.txt", expectedVersion: null, body: spillB },
+        ],
+      },
+      { principal: "test", idempotencyKey: "spilled-loser" },
+    );
+
+    expect(result).toMatchObject({ ok: false, error: { code: "commit-conflict" } });
+    expect(await idempotencyRows(stash, "spilled-loser")).toBe(0);
+    const beforeGc = await workerEnv.BLOBS.list();
+    expect(beforeGc.objects).toHaveLength(2);
+    const newestUpload = Math.max(...beforeGc.objects.map(({ uploaded }) => uploaded.getTime()));
+    const gc = await createGcEngine(workerEnv, {
+      now: () => newestUpload + GC_ORPHAN_MIN_AGE_MS + 1,
+    }).run({ kind: "r2-orphans", dryRun: false, maxObjects: 10 });
+    expect(gc).toMatchObject({ scanned: 2, eligible: 2, deleted: 2 });
+    expect((await workerEnv.BLOBS.list()).objects).toHaveLength(0);
+  });
+
+  it("keeps a multi-entry commit contiguous around an injected unrelated write", async () => {
+    const stash = "race-contiguous";
+    await seedStash(stash);
+    const first = await seedFile(stash, "before.txt");
+    let competitorId = -1;
+    const commits = createCommits(
+      workerEnv,
+      deps({
+        onBeforeCommit: async () => {
+          const competitor = await store(9_000).writes.put(stash, "competitor.txt", {
+            body: "between",
+            expectedVersion: null,
+          });
+          if (!competitor.ok || "unchanged" in competitor.value) {
+            throw new Error("Competitor failed");
+          }
+          competitorId = competitor.value.changeId;
+        },
+      }),
+    );
+    const result = await commits.createCommit(
+      stash,
+      {
+        entries: [
+          { op: "put", path: "one.txt", expectedVersion: null, body: "one" },
+          { op: "put", path: "two.txt", expectedVersion: null, body: "two" },
+          { op: "put", path: "three.txt", expectedVersion: null, body: "three" },
+        ],
+      },
+      { principal: "test" },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected successful commit");
+    expect(competitorId).toBe(first.changeId + 1);
+    expect(result.value.entries.map(({ changeId }) => changeId)).toEqual([
+      competitorId + 1,
+      competitorId + 2,
+      competitorId + 3,
+    ]);
+    expect(result.value.firstChangeId).toBe(competitorId + 1);
+    expect(result.value.lastChangeId).toBe(competitorId + 3);
+  });
+
+  it("calls onCommitted once for a new commit and never for its replay", async () => {
+    const stash = "race-on-committed";
+    await seedStash(stash);
+    const published: string[] = [];
+    const input: CreateCommitBody = {
+      entries: [{ op: "put", path: "event.txt", expectedVersion: null, body: "event" }],
+    };
+    const commits = createCommits(workerEnv, deps());
+    const options = {
+      principal: "test",
+      idempotencyKey: "event",
+      onCommitted: (result: { id: string }) => {
+        published.push(result.id);
+      },
+    };
+
+    const created = await commits.createCommit(stash, input, options);
+    const replayed = await commits.createCommit(stash, input, options);
+
+    expect(created.ok).toBe(true);
+    expect(replayed).toMatchObject({ ok: true, replayed: true });
+    expect(published).toEqual(created.ok ? [created.value.id] : []);
+    expect(await counts(stash)).toEqual({ commits: 1, versions: 1, files: 1, blobs: 1 });
+  });
+
+  it("publishes only the new change when copying a version created by an upload", async () => {
+    const stash = "race-copy-upload";
+    await seedStash(stash);
+    await workerEnv.DB.batch([
+      workerEnv.DB.prepare(
+        `INSERT INTO commits
+            (id, stash_name, source, source_id, entry_count, change_count, sealed,
+             first_change_id, last_change_id, created_by, created_at)
+           VALUES ('cmt_uploaded', ?, 'upload', 'upl_source', 1, 1, 1, 1, 1, 'test', 1)`,
+      ).bind(stash),
+      workerEnv.DB.prepare(
+        `INSERT INTO versions
+            (id, stash_name, path, version, kind, blob_hash, size_bytes, content_type,
+             created_at, representation, application_etag, content_storage, commit_id)
+           VALUES (1, ?, 'uploaded.bin', 1, 'put', 'sha256-uploaded', 2,
+             'application/octet-stream', 1, 'binary', 'etag-uploaded', 'bytes', 'cmt_uploaded')`,
+      ).bind(stash),
+      workerEnv.DB.prepare(
+        `INSERT INTO files
+            (stash_name, path, head_version, head_hash, deleted, created_at, updated_at)
+           VALUES (?, 'uploaded.bin', 1, 'sha256-uploaded', 0, 1, 1)`,
+      ).bind(stash),
+    ]);
+    const published = [] as ReturnType<typeof commitEvents>;
+    const result = await createCommits(workerEnv, deps()).createCommit(
+      stash,
+      {
+        entries: [
+          {
+            op: "copy",
+            path: "copied.bin",
+            expectedVersion: null,
+            from: { path: "uploaded.bin", version: 1 },
+          },
+        ],
+      },
+      {
+        principal: "test",
+        onCommitted: (committed) => {
+          published.push(...commitEvents(committed, null));
+        },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected copy commit");
+    expect(published.filter(({ type }) => type === "change")).toEqual([
+      expect.objectContaining({
+        type: "change",
+        changeId: result.value.entries[0]?.changeId,
+        commitId: result.value.id,
+        path: "copied.bin",
+      }),
+    ]);
+    expect(published.map(({ type }) => type)).toEqual(["change", "commit"]);
+    expect(published).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ changeId: 1 })]),
+    );
+  });
+});


### PR DESCRIPTION
Parent: #206

Relates to #213.

## Summary

- harden atomic commit invariants with controlled race coverage
- publish ordered arrays of live change frames from one committed batch
- add the live-only commit event after all change frames

## Validation

- 80 focused commit race and event tests passed during integration
- typecheck, lint, and formatting passed
- blocking topic review completed before integration
