### PR TITLE
Support binary and copy commit entries

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -89,14 +89,15 @@ An `already-rotated` error carries the winning successor token ID as
 
 ## Limits and storage tiers
 
-The compatibility JSON API is text-only. Its core `MAX_BODY_BYTES` schema limit is **5,000,000
-UTF-8 bytes**, inclusive, for a JSON file PUT and for each inline `put` entry in a commit,
-change set, or history
-import. The default `JSON_INLINE_MAX_BYTES` setting has the same value and controls when text content
-can be returned inline; changing that setting does not change the fixed change set/import schema.
-Change set candidates and imports remain JSON/text-only even when raw uploads support binary, so their
-5 MB rule is not a universal file-size or representation rule. A valid UTF-8 body larger than
-5,000,000 bytes is still `text` when sent through the raw upload API.
+The compatibility file JSON API is text-only. Its core `MAX_BODY_BYTES` schema limit is **5,000,000
+UTF-8 bytes**, inclusive, for a JSON file PUT and each history-import body. Commit and change-set
+requests also accept canonical padded base64 binary `put` entries and stored-version `copy` entries.
+Their fixed `MAX_COMMIT_INLINE_BYTES` limit is 5,000,000 exact content bytes in aggregate across all
+inline text and decoded binary entries; base64 and JSON framing do not count toward that content
+limit. The 32 MiB request-body limit leaves room for base64 inflation. The default
+`JSON_INLINE_MAX_BYTES` setting controls when text content can be returned inline; changing it does
+not change these fixed request-schema limits. A valid UTF-8 body larger than 5,000,000 bytes is still
+`text` when sent through the raw upload API.
 
 Raw uploads preserve exact bytes and choose `single` or `multipart` transfer from capabilities.
 The default `HTTP_REQUEST_MAX_BYTES` and `MAX_FILE_BYTES` are each 100,000,000 content bytes; a
@@ -276,8 +277,9 @@ Cloudflare RPC serialisation for the outer structured value payload is capped at
 the envelope. The flow-controlled `StashRpc.requestStream()` bridge instead passes RPC-aware
 `Request`/`Response` body streams without serialising their bytes into that value payload, and the
 client selects it for raw and upload routes when available. Independently, the raw API's default
-`HTTP_REQUEST_MAX_BYTES` is 100,000,000 and its single-upload default is 32 MiB; the compatibility
-JSON/change set/import limit remains 5,000,000 UTF-8 bytes. The existing `env.STASH.fetch()` service
+`HTTP_REQUEST_MAX_BYTES` is 100,000,000 and its single-upload default is 32 MiB; compatibility JSON
+file/import text bodies and aggregate decoded commit/change-set content remain capped at 5,000,000
+bytes. The existing `env.STASH.fetch()` service
 binding remains supported for HTTP-compatible consumers. These are independent transport and
 content contracts, not a claim that a deployment can discover its Cloudflare plan at runtime.
 
@@ -286,9 +288,9 @@ content contracts, not a claim that a deployment can discover its Cloudflare pla
 Binary metadata keeps representation (`text | binary`), content access (`inline | raw | deleted`),
 transfer mode, and physical storage tier independent. Legacy rows default to text and resolve from
 the legacy TEXT table; new versions carry an explicit storage discriminator so an identical SHA-256
-may coexist in the legacy and byte tables without ambiguous reads. Binary bytes are never base64 in
-JSON. Change set candidates and history import remain JSON/text-only and reject raw/binary usage with
-`422 unsupported-representation`.
+may coexist in the legacy and byte tables without ambiguous reads. Raw response bytes are never
+base64 in JSON. Commit and change-set inputs use strict canonical base64 for inline binary
+candidates; history import remains JSON/text-only.
 
 Published defaults are `JSON_INLINE_MAX_BYTES=5000000`, `D1_INLINE_MAX_BYTES=524288`,
 `HTTP_REQUEST_MAX_BYTES=100000000`, `SINGLE_UPLOAD_MAX_BYTES=33554432`, `MAX_FILE_BYTES=100000000`,
@@ -315,7 +317,7 @@ protocol framing. The settings must also satisfy the relationships described in
 - **Principal/capability:** `open`; no capability or token is required.
 - **Request:** No body or query.
 - **Response:** `200` with representations, content-access modes, transfer modes, storage tiers,
-  and the authoritative exact-content byte limits.
+  supported commit entry kinds, and the authoritative exact-content byte limits.
 - **Errors:** `500 internal`.
 
 ### `GET /v1/me`
@@ -513,6 +515,10 @@ Commits apply up to 20 entries atomically: the gate checks every expected versio
 records one verdict, so either every entry lands or none does. Conflicts return root-level
 `conflicts[]`. Reverts create a new commit, never erase history. Change feeds group every written
 version by required `commitId`; change sets hold expiring candidates and approval never rebases.
+Entry kinds are text `put`, binary `put` (`representation: "binary"`, `contentType`, and canonical
+`bytesBase64`), `copy` from a stored `{ path, version }` in the same stash, `delete`, and `rollback`.
+Copy sources cannot name another entry path in the same request. Binary candidates are decoded and
+staged when a change set is created; binary review diffs report base/candidate hashes and sizes.
 
 ### `POST /v1/stashes/:stash/commits`
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -102,11 +102,7 @@
           "commitEntryKinds": {
             "prefixItems": [
               {
-                "const": "put-text",
-                "type": "string"
-              },
-              {
-                "const": "put-binary",
+                "const": "put",
                 "type": "string"
               },
               {
@@ -1309,6 +1305,10 @@
                 "maximum": 9007199254740991,
                 "minimum": 0,
                 "type": "integer"
+              },
+              "storageTier": {
+                "enum": ["d1", "r2"],
+                "type": "string"
               },
               "version": {
                 "exclusiveMinimum": 0,
@@ -4514,7 +4514,7 @@
             "content": {
               "application/json": {
                 "example": {
-                  "commitEntryKinds": ["put-text", "put-binary", "copy", "delete", "rollback"],
+                  "commitEntryKinds": ["put", "copy", "delete", "rollback"],
                   "contentAccess": ["inline", "raw", "deleted"],
                   "limits": {
                     "d1InlineMaxBytes": 524288,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -99,6 +99,31 @@
       "CapabilitiesResponse": {
         "additionalProperties": false,
         "properties": {
+          "commitEntryKinds": {
+            "prefixItems": [
+              {
+                "const": "put-text",
+                "type": "string"
+              },
+              {
+                "const": "put-binary",
+                "type": "string"
+              },
+              {
+                "const": "copy",
+                "type": "string"
+              },
+              {
+                "const": "delete",
+                "type": "string"
+              },
+              {
+                "const": "rollback",
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
           "contentAccess": {
             "prefixItems": [
               {
@@ -233,7 +258,14 @@
             "type": "array"
           }
         },
-        "required": ["representations", "contentAccess", "transferModes", "storageTiers", "limits"],
+        "required": [
+          "representations",
+          "contentAccess",
+          "transferModes",
+          "storageTiers",
+          "commitEntryKinds",
+          "limits"
+        ],
         "type": "object"
       },
       "ChangeItem": {
@@ -360,17 +392,112 @@
                 "diff": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/CandidateDiffResult"
-                    },
-                    {
                       "additionalProperties": false,
                       "properties": {
                         "state": {
-                          "enum": ["binary", "oversized"],
+                          "const": "same",
                           "type": "string"
                         }
                       },
                       "required": ["state"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "reason": {
+                          "enum": ["bytes", "complexity"],
+                          "type": "string"
+                        },
+                        "state": {
+                          "const": "oversized",
+                          "type": "string"
+                        }
+                      },
+                      "required": ["state"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "hunks": {
+                          "items": {
+                            "$ref": "#/components/schemas/DiffHunk"
+                          },
+                          "type": "array"
+                        },
+                        "state": {
+                          "const": "ready",
+                          "type": "string"
+                        },
+                        "stats": {
+                          "$ref": "#/components/schemas/DiffStats"
+                        },
+                        "truncated": {
+                          "type": "boolean"
+                        },
+                        "unified": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["state", "unified", "truncated", "hunks", "stats"],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "base": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "hash": {
+                                  "pattern": "^sha256-[0-9a-f]{64}$",
+                                  "type": "string"
+                                },
+                                "size": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": ["hash", "size"],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "candidate": {
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "hash": {
+                                  "pattern": "^sha256-[0-9a-f]{64}$",
+                                  "type": "string"
+                                },
+                                "size": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": 0,
+                                  "type": "integer"
+                                }
+                              },
+                              "required": ["hash", "size"],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "state": {
+                          "const": "binary",
+                          "type": "string"
+                        }
+                      },
+                      "required": ["state", "base", "candidate"],
                       "type": "object"
                     }
                   ]
@@ -4387,6 +4514,7 @@
             "content": {
               "application/json": {
                 "example": {
+                  "commitEntryKinds": ["put-text", "put-binary", "copy", "delete", "rollback"],
                   "contentAccess": ["inline", "raw", "deleted"],
                   "limits": {
                     "d1InlineMaxBytes": 524288,

--- a/packages/client/src/binary.test.ts
+++ b/packages/client/src/binary.test.ts
@@ -12,6 +12,7 @@ function capabilities(
     contentAccess: ["inline", "raw", "deleted"],
     transferModes: ["json", "single", "multipart"],
     storageTiers: ["d1", "r2"],
+    commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
     limits: {
       jsonInlineMaxBytes: 3,
       d1InlineMaxBytes: 8,

--- a/packages/client/src/binary.test.ts
+++ b/packages/client/src/binary.test.ts
@@ -12,7 +12,7 @@ function capabilities(
     contentAccess: ["inline", "raw", "deleted"],
     transferModes: ["json", "single", "multipart"],
     storageTiers: ["d1", "r2"],
-    commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
+    commitEntryKinds: ["put", "copy", "delete", "rollback"],
     limits: {
       jsonInlineMaxBytes: 3,
       d1InlineMaxBytes: 8,

--- a/packages/client/src/testing/fake.ts
+++ b/packages/client/src/testing/fake.ts
@@ -85,7 +85,7 @@ const DEFAULT_CAPABILITIES: CapabilitiesResponse = {
   contentAccess: ["inline", "raw", "deleted"],
   transferModes: ["json", "single", "multipart"],
   storageTiers: ["d1", "r2"],
-  commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
+  commitEntryKinds: ["put", "copy", "delete", "rollback"],
   limits: {
     jsonInlineMaxBytes: MAX_BODY_BYTES,
     d1InlineMaxBytes: 1_000_000,

--- a/packages/client/src/testing/fake.ts
+++ b/packages/client/src/testing/fake.ts
@@ -85,6 +85,7 @@ const DEFAULT_CAPABILITIES: CapabilitiesResponse = {
   contentAccess: ["inline", "raw", "deleted"],
   transferModes: ["json", "single", "multipart"],
   storageTiers: ["d1", "r2"],
+  commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
   limits: {
     jsonInlineMaxBytes: MAX_BODY_BYTES,
     d1InlineMaxBytes: 1_000_000,

--- a/packages/core/src/binary.test.ts
+++ b/packages/core/src/binary.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { decodeCanonicalBase64, isCanonicalBase64 } from "./binary.js";
+
+describe("canonical base64", () => {
+  it.each([
+    ["", []],
+    ["AA==", [0]],
+    ["AAEC/w==", [0, 1, 2, 255]],
+  ])("decodes %j without Node runtime APIs", (value, expected) => {
+    expect([...decodeCanonicalBase64(value)]).toEqual(expected);
+    expect(isCanonicalBase64(value)).toBe(true);
+  });
+
+  it.each(["A", "AAA", "AB==", "AA=", "AA===", "AA==\n", "_A==", " /8="])(
+    "rejects non-canonical input %j",
+    (value) => {
+      expect(() => decodeCanonicalBase64(value)).toThrow(TypeError);
+      expect(isCanonicalBase64(value)).toBe(false);
+    },
+  );
+});

--- a/packages/core/src/binary.ts
+++ b/packages/core/src/binary.ts
@@ -5,6 +5,31 @@ export type StorageTier = "d1" | "r2";
 export type ContentStorage = "legacy" | "bytes";
 export type UploadMode = "single" | "multipart";
 
+const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+/** Decodes padded RFC 4648 base64 while rejecting whitespace and non-canonical spellings. */
+export function decodeCanonicalBase64(value: string): Uint8Array<ArrayBuffer> {
+  if (!CANONICAL_BASE64.test(value)) throw new TypeError("Invalid canonical base64");
+  try {
+    const decoded = atob(value);
+    const bytes = new Uint8Array(decoded.length);
+    for (let index = 0; index < decoded.length; index++) bytes[index] = decoded.charCodeAt(index);
+    if (btoa(decoded) !== value) throw new TypeError("Invalid canonical base64");
+    return bytes;
+  } catch {
+    throw new TypeError("Invalid canonical base64");
+  }
+}
+
+export function isCanonicalBase64(value: string): boolean {
+  try {
+    decodeCanonicalBase64(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export interface ContentMetadata {
   representation: Representation;
   contentAccess: ContentAccess;

--- a/packages/core/src/openapi/responses.ts
+++ b/packages/core/src/openapi/responses.ts
@@ -504,7 +504,7 @@ export const CurrentSchema = z.strictObject({
 });
 
 const CommitOperationSchema = z.enum(["put", "copy", "delete", "rollback"]);
-export const CommitEntryRecordSchema = z.strictObject({
+export const CommitEntryRecordSchema: z.ZodType<CommitEntryRecord> = z.strictObject({
   path: z.string(),
   op: CommitOperationSchema,
   version: IntegerSchema,
@@ -596,7 +596,7 @@ export const ChangeSetListResponseSchema = z.strictObject({
   nextAfter: z.string().nullable(),
   total: NonNegativeIntegerSchema,
 });
-export const ChangeSetDiffResultSchema = z.strictObject({
+export const ChangeSetDiffResultSchema: z.ZodType<ChangeSetDiffResult> = z.strictObject({
   entries: z.array(
     z.strictObject({
       path: z.string(),

--- a/packages/core/src/openapi/responses.ts
+++ b/packages/core/src/openapi/responses.ts
@@ -106,6 +106,13 @@ export const CapabilitiesResponseSchema: z.ZodType<CapabilitiesResponse> = z.str
   contentAccess: z.tuple([z.literal("inline"), z.literal("raw"), z.literal("deleted")]),
   transferModes: z.tuple([z.literal("json"), z.literal("single"), z.literal("multipart")]),
   storageTiers: z.tuple([z.literal("d1"), z.literal("r2")]),
+  commitEntryKinds: z.tuple([
+    z.literal("put-text"),
+    z.literal("put-binary"),
+    z.literal("copy"),
+    z.literal("delete"),
+    z.literal("rollback"),
+  ]),
   limits: z.strictObject({
     jsonInlineMaxBytes: z.number().int().positive(),
     d1InlineMaxBytes: z.number().int().positive(),
@@ -598,7 +605,27 @@ export const ChangeSetDiffResultSchema = z.strictObject({
       candidate: CurrentSchema.nullable(),
       current: CurrentSchema.nullable(),
       stale: z.boolean(),
-      diff: DiffEnvelopeSchema,
+      diff: z.union([
+        z.strictObject({ state: z.literal("same") }),
+        z.strictObject({
+          state: z.literal("oversized"),
+          reason: z.enum(["bytes", "complexity"]).optional(),
+        }),
+        z.strictObject({
+          state: z.literal("ready"),
+          unified: z.string(),
+          truncated: z.boolean(),
+          hunks: z.array(DiffHunkSchema),
+          stats: DiffStatsSchema,
+        }),
+        z.strictObject({
+          state: z.literal("binary"),
+          base: z.strictObject({ hash: HashSchema, size: NonNegativeIntegerSchema }).nullable(),
+          candidate: z
+            .strictObject({ hash: HashSchema, size: NonNegativeIntegerSchema })
+            .nullable(),
+        }),
+      ]),
     }),
   ),
   stale: z.boolean(),

--- a/packages/core/src/openapi/responses.ts
+++ b/packages/core/src/openapi/responses.ts
@@ -107,8 +107,7 @@ export const CapabilitiesResponseSchema: z.ZodType<CapabilitiesResponse> = z.str
   transferModes: z.tuple([z.literal("json"), z.literal("single"), z.literal("multipart")]),
   storageTiers: z.tuple([z.literal("d1"), z.literal("r2")]),
   commitEntryKinds: z.tuple([
-    z.literal("put-text"),
-    z.literal("put-binary"),
+    z.literal("put"),
     z.literal("copy"),
     z.literal("delete"),
     z.literal("rollback"),
@@ -372,6 +371,7 @@ export const UploadCommitResultSchema = z.strictObject({
   hash: HashSchema,
   size: NonNegativeIntegerSchema,
   representation: RepresentationSchema,
+  storageTier: z.enum(["d1", "r2"]).optional(),
   contentType: z.string(),
   changeId: z.number().int().positive(),
   createdAt: TimestampSchema,

--- a/packages/core/src/openapi/samples.ts
+++ b/packages/core/src/openapi/samples.ts
@@ -341,7 +341,7 @@ const responseSamples = {
     contentAccess: ["inline", "raw", "deleted"],
     transferModes: ["json", "single", "multipart"],
     storageTiers: ["d1", "r2"],
-    commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
+    commitEntryKinds: ["put", "copy", "delete", "rollback"],
     limits: {
       jsonInlineMaxBytes: 5_000_000,
       d1InlineMaxBytes: 524_288,

--- a/packages/core/src/openapi/samples.ts
+++ b/packages/core/src/openapi/samples.ts
@@ -341,6 +341,7 @@ const responseSamples = {
     contentAccess: ["inline", "raw", "deleted"],
     transferModes: ["json", "single", "multipart"],
     storageTiers: ["d1", "r2"],
+    commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
     limits: {
       jsonInlineMaxBytes: 5_000_000,
       d1InlineMaxBytes: 524_288,

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -272,6 +272,34 @@ describe("commit and change-set request schemas", () => {
       CreateCommitBody.safeParse({ entries: [{ ...put, expectedVersion: 1.5 }] }).success,
     ).toBe(false);
   });
+  it.each(["AB==", "AA=", "AA==\n", "_A=="])(
+    "rejects non-canonical binary input %j",
+    (bytesBase64) => {
+      const binary = {
+        op: "put" as const,
+        path: "bin/a",
+        expectedVersion: null,
+        representation: "binary" as const,
+        contentType: "application/octet-stream",
+        bytesBase64,
+      };
+      expect(CreateCommitBody.safeParse({ entries: [binary] }).success).toBe(false);
+      expect(
+        CreateChangeSetBody.safeParse({
+          entries: [
+            {
+              op: binary.op,
+              path: binary.path,
+              baseVersion: null,
+              representation: binary.representation,
+              contentType: binary.contentType,
+              bytesBase64: binary.bytesBase64,
+            },
+          ],
+        }).success,
+      ).toBe(false);
+    },
+  );
   it("enforces entry count, unique paths, copy isolation, and platform metadata", () => {
     expect(CreateCommitBody.safeParse({ entries: [] }).success).toBe(false);
     expect(

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -9,6 +9,7 @@ import {
   MAX_MESSAGE_BYTES,
   MAX_META_BYTES,
 } from "./limits.js";
+import { isCanonicalBase64 } from "./binary.js";
 import { isWellFormedString, utf8ByteLength } from "./hash.js";
 import { validatePath, validateStashName } from "./paths.js";
 import type { StashEvent } from "./types.js";
@@ -238,6 +239,7 @@ const entryPath = z.string().refine((value) => validatePath(value).ok, "Invalid 
 const strictInteger = z.number().int();
 const commitExpectedVersion = strictInteger.nullable();
 const entryCommon = { path: entryPath, expectedVersion: commitExpectedVersion };
+const canonicalBase64 = z.string().refine(isCanonicalBase64, "Invalid canonical base64");
 export const CommitEntryInput = z.union([
   z.strictObject({
     op: z.literal("put"),
@@ -250,7 +252,7 @@ export const CommitEntryInput = z.union([
     ...entryCommon,
     representation: z.literal("binary"),
     contentType: wellFormed,
-    bytesBase64: z.string(),
+    bytesBase64: canonicalBase64,
   }),
   z.strictObject({
     op: z.literal("copy"),
@@ -340,7 +342,7 @@ export const ChangeSetEntryInput = z.union([
     ...changeSetCommon,
     representation: z.literal("binary"),
     contentType: wellFormed,
-    bytesBase64: z.string(),
+    bytesBase64: canonicalBase64,
   }),
   z.strictObject({
     op: z.literal("copy"),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -110,6 +110,7 @@ export interface CapabilitiesResponse {
   contentAccess: readonly ContentAccess[];
   transferModes: readonly ["json", "single", "multipart"];
   storageTiers: readonly StorageTier[];
+  commitEntryKinds: readonly ["put-text", "put-binary", "copy", "delete", "rollback"];
   limits: {
     jsonInlineMaxBytes: number;
     d1InlineMaxBytes: number;
@@ -301,7 +302,14 @@ export interface ChangeSetDiffResult {
     candidate: Current | null;
     current: Current | null;
     stale: boolean;
-    diff: DiffResult | { state: "binary" | "oversized" };
+    diff:
+      | Exclude<DiffResult, { state: "binary" }>
+      | {
+          state: "binary";
+          base: { hash: string; size: number } | null;
+          candidate: { hash: string; size: number } | null;
+        }
+      | { state: "oversized" };
   }>;
   stale: boolean;
   status: ChangeSetStatus;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -110,7 +110,7 @@ export interface CapabilitiesResponse {
   contentAccess: readonly ContentAccess[];
   transferModes: readonly ["json", "single", "multipart"];
   storageTiers: readonly StorageTier[];
-  commitEntryKinds: readonly ["put-text", "put-binary", "copy", "delete", "rollback"];
+  commitEntryKinds: readonly ["put", "copy", "delete", "rollback"];
   limits: {
     jsonInlineMaxBytes: number;
     d1InlineMaxBytes: number;
@@ -222,6 +222,7 @@ export interface CommitEntryRecord {
   size: number;
   contentType: string;
   representation: Representation;
+  storageTier?: StorageTier;
   rollbackOf: number | null;
   copiedFrom?: { path: string; version: number };
   identicalToHead?: boolean;

--- a/packages/ui/src/components/binary-upload-form.test.tsx
+++ b/packages/ui/src/components/binary-upload-form.test.tsx
@@ -20,6 +20,7 @@ function capabilities(
     contentAccess: ["inline", "raw", "deleted"],
     transferModes: ["json", "single", "multipart"],
     storageTiers: ["d1", "r2"],
+    commitEntryKinds: ["put", "copy", "delete", "rollback"],
     limits: {
       jsonInlineMaxBytes: 16,
       d1InlineMaxBytes: 16,

--- a/packages/ui/src/components/file-content.test.tsx
+++ b/packages/ui/src/components/file-content.test.tsx
@@ -35,6 +35,7 @@ async function uploadedFile(
       contentAccess: ["inline", "raw", "deleted"],
       transferModes: ["json", "single", "multipart"],
       storageTiers: ["d1", "r2"],
+      commitEntryKinds: ["put", "copy", "delete", "rollback"],
       limits: {
         jsonInlineMaxBytes: 2,
         d1InlineMaxBytes: 2,

--- a/workers/stash/migrations/0011_commit_copy_sources.sql
+++ b/workers/stash/migrations/0011_commit_copy_sources.sql
@@ -1,0 +1,3 @@
+ALTER TABLE versions ADD COLUMN copied_from_path TEXT;
+ALTER TABLE versions ADD COLUMN copied_from_version INTEGER;
+ALTER TABLE change_set_entries ADD COLUMN application_etag TEXT;

--- a/workers/stash/src/binary-config.ts
+++ b/workers/stash/src/binary-config.ts
@@ -157,6 +157,7 @@ export function capabilitiesFor(settings: BinarySettings): CapabilitiesResponse 
     contentAccess: ["inline", "raw", "deleted"],
     transferModes: ["json", "single", "multipart"],
     storageTiers: ["d1", "r2"],
+    commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
     limits: {
       jsonInlineMaxBytes: settings.jsonInlineMaxBytes,
       d1InlineMaxBytes: settings.d1InlineMaxBytes,

--- a/workers/stash/src/binary-config.ts
+++ b/workers/stash/src/binary-config.ts
@@ -157,7 +157,7 @@ export function capabilitiesFor(settings: BinarySettings): CapabilitiesResponse 
     contentAccess: ["inline", "raw", "deleted"],
     transferModes: ["json", "single", "multipart"],
     storageTiers: ["d1", "r2"],
-    commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
+    commitEntryKinds: ["put", "copy", "delete", "rollback"],
     limits: {
       jsonInlineMaxBytes: settings.jsonInlineMaxBytes,
       d1InlineMaxBytes: settings.d1InlineMaxBytes,

--- a/workers/stash/src/d1/byte-writes.ts
+++ b/workers/stash/src/d1/byte-writes.ts
@@ -1,0 +1,63 @@
+import { sha256Hex } from "@takazudo/zudo-history-stash-core";
+import { parseBinarySettings } from "../binary-config.js";
+import type { Env } from "../env.js";
+import { blobKey, parseBlobKey, type BlobGenerationFactory } from "./blobs.js";
+
+const SHA256_HASH = /^sha256-([0-9a-f]{64})$/;
+
+export type PreparedByteWrite =
+  | { bodyBytes: ArrayBuffer; r2Key: null; storageGeneration: 0 }
+  | { bodyBytes: null; r2Key: string; storageGeneration: 0 };
+
+function invalidByteWrite(): Error {
+  return new Error("Binary content representation is unavailable or invalid");
+}
+
+export function assertPreparedByteWrite(
+  prepared: PreparedByteWrite,
+  size: number,
+): asserts prepared is PreparedByteWrite {
+  const inline = prepared.bodyBytes instanceof ArrayBuffer && prepared.r2Key === null;
+  const spilled = prepared.bodyBytes === null && typeof prepared.r2Key === "string";
+  if (
+    (!inline && !spilled) ||
+    prepared.storageGeneration !== 0 ||
+    (inline && prepared.bodyBytes.byteLength !== size)
+  ) {
+    throw invalidByteWrite();
+  }
+}
+
+export async function prepareByteWrite(
+  env: Env,
+  stash: string,
+  hash: string,
+  bytes: Uint8Array<ArrayBuffer>,
+  contentType: string,
+  createGeneration: BlobGenerationFactory = () => crypto.randomUUID(),
+): Promise<PreparedByteWrite> {
+  const match = SHA256_HASH.exec(hash);
+  if (match?.[1] === undefined || (await sha256Hex(bytes)) !== hash) throw invalidByteWrite();
+
+  let prepared: PreparedByteWrite;
+  if (bytes.byteLength <= parseBinarySettings(env).d1InlineMaxBytes) {
+    prepared = {
+      bodyBytes: bytes.slice().buffer as ArrayBuffer,
+      r2Key: null,
+      storageGeneration: 0,
+    };
+  } else {
+    const key = blobKey(stash, hash, createGeneration());
+    if (parseBlobKey(key) === null) throw invalidByteWrite();
+    const object = await env.BLOBS.put(key, bytes, {
+      onlyIf: { etagDoesNotMatch: "*" },
+      httpMetadata: { contentType },
+      customMetadata: { sha256: match[1] },
+      sha256: match[1],
+    });
+    if (object === null) throw invalidByteWrite();
+    prepared = { bodyBytes: null, r2Key: key, storageGeneration: 0 };
+  }
+  assertPreparedByteWrite(prepared, bytes.byteLength);
+  return prepared;
+}

--- a/workers/stash/src/d1/change-sets.ts
+++ b/workers/stash/src/d1/change-sets.ts
@@ -9,6 +9,7 @@ import {
   StashError,
   canonicalJson,
   computeDiff,
+  decodeCanonicalBase64,
   isWellFormedString,
   sha256Hex,
   utf8ByteLength,
@@ -24,7 +25,8 @@ import {
 } from "@takazudo/zudo-history-stash-core";
 import { parseBinarySettings } from "../binary-config.js";
 import type { Env } from "../env.js";
-import { blobKey, prepareBlob, readBlob, type PreparedBlob } from "./blobs.js";
+import { prepareBlob, readBlob, type PreparedBlob } from "./blobs.js";
+import { prepareByteWrite, type PreparedByteWrite } from "./byte-writes.js";
 import { createByteStorageReader } from "./byte-reader.js";
 import type { ChangeSetEntryRow, ChangeSetRow } from "./schema.js";
 import {
@@ -52,6 +54,7 @@ interface VersionMaterialRow {
   content_type: string;
   representation: "text" | "binary";
   content_storage: "legacy" | "bytes";
+  application_etag: string | null;
   author: string;
   created_at: number;
   blob_body: string | null;
@@ -67,8 +70,8 @@ interface HeadRow extends VersionMaterialRow {
 
 interface StagedEntry extends ChangeSetEntryRow {
   textBody?: string;
-  binaryBody?: ArrayBuffer;
-  binaryR2Key?: string;
+  binaryBody?: Uint8Array<ArrayBuffer>;
+  preparedBinary?: PreparedByteWrite;
 }
 
 export interface ChangeSetDependencies extends StoreDependencies {
@@ -169,12 +172,9 @@ function validateKey(key: string | undefined): string | undefined {
   return key;
 }
 
-function decodeBinary(value: string, path: string): ArrayBuffer {
+function decodeBinary(value: string, path: string): Uint8Array<ArrayBuffer> {
   try {
-    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
-      return validation(`Invalid binary body for ${path}.`);
-    }
-    return Uint8Array.from(atob(value), (character) => character.charCodeAt(0)).buffer;
+    return decodeCanonicalBase64(value);
   } catch {
     return validation(`Invalid binary body for ${path}.`);
   }
@@ -189,6 +189,7 @@ async function selectHead(
     .prepare(
       `SELECT v.stash_name, f.head_version, f.head_hash, f.deleted, v.version, v.kind, v.blob_hash,
          v.size_bytes, v.content_type, v.representation, v.content_storage, v.author, v.created_at,
+         v.application_etag,
          b.body AS blob_body, b.r2_key AS blob_r2_key, b.size_bytes AS blob_size
        FROM files f JOIN versions v
          ON v.stash_name = f.stash_name AND v.path = f.path AND v.version = f.head_version
@@ -209,6 +210,7 @@ async function selectVersion(
     .prepare(
       `SELECT v.stash_name, v.version, v.kind, v.blob_hash, v.size_bytes, v.content_type, v.representation,
          v.content_storage, v.author, v.created_at, b.body AS blob_body,
+         v.application_etag,
          b.r2_key AS blob_r2_key, b.size_bytes AS blob_size
        FROM versions v LEFT JOIN blobs b
          ON b.stash_name = v.stash_name AND b.hash = v.blob_hash
@@ -233,6 +235,7 @@ function sourceEntry(id: string, stash: string, input: ChangeSetEntryInput): Cha
     rollback_to: input.op === "rollback" ? input.toVersion : null,
     copied_from_path: input.op === "copy" ? input.from.path : null,
     copied_from_version: input.op === "copy" ? input.from.version : null,
+    application_etag: null,
   };
 }
 
@@ -269,6 +272,7 @@ async function stageEntry(
       entry.representation = "binary";
       entry.content_type = input.contentType;
       entry.size_bytes = bytes.byteLength;
+      entry.application_etag = entry.blob_hash;
     } else {
       entry.textBody = input.body;
       entry.blob_hash = await sha256Hex(input.body);
@@ -298,6 +302,7 @@ async function stageEntry(
   entry.representation = source.representation;
   entry.content_type = source.content_type;
   entry.size_bytes = source.size_bytes;
+  entry.application_etag = source.application_etag;
   return entry;
 }
 
@@ -491,7 +496,6 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
       const staged = await Promise.all(
         input.entries.map((entry) => stageEntry(db, id, stash, entry)),
       );
-      const d1InlineMaxBytes = parseBinarySettings(env).d1InlineMaxBytes;
       const prepared = new Map<string, PreparedBlob>();
       for (const entry of staged) {
         if (
@@ -510,25 +514,15 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
             ),
           );
         }
-        if (
-          entry.binaryBody !== undefined &&
-          entry.blob_hash !== null &&
-          entry.binaryBody.byteLength > d1InlineMaxBytes
-        ) {
-          const key = blobKey(
+        if (entry.binaryBody !== undefined && entry.blob_hash !== null) {
+          entry.preparedBinary = await prepareByteWrite(
+            env,
             stash,
             entry.blob_hash,
-            deps.createBlobGeneration?.() ?? crypto.randomUUID(),
+            entry.binaryBody,
+            entry.content_type ?? "application/octet-stream",
+            deps.createBlobGeneration,
           );
-          const object = await env.BLOBS.put(key, entry.binaryBody, {
-            onlyIf: { etagDoesNotMatch: "*" },
-            httpMetadata: { contentType: entry.content_type ?? "application/octet-stream" },
-            customMetadata: { sha256: entry.blob_hash.slice("sha256-".length) },
-            sha256: entry.blob_hash.slice("sha256-".length),
-          });
-          if (object === null) return internal("Binary change-set content could not be staged.");
-          entry.binaryR2Key = key;
-          entry.binaryBody = undefined;
         }
       }
       const row: ChangeSetRow = {
@@ -555,9 +549,7 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
       for (const entry of staged) {
         if (
           entry.blob_hash === null ||
-          (entry.textBody === undefined &&
-            entry.binaryBody === undefined &&
-            entry.binaryR2Key === undefined)
+          (entry.textBody === undefined && entry.preparedBinary === undefined)
         ) {
           continue;
         }
@@ -592,24 +584,22 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
                 ...expectedParams,
               ),
           );
-        } else if (
-          (entry.binaryBody !== undefined || entry.binaryR2Key !== undefined) &&
-          entry.blob_hash !== null
-        ) {
+        } else if (entry.preparedBinary !== undefined && entry.blob_hash !== null) {
           statements.push(
             db
               .prepare(
                 `INSERT INTO byte_blobs
                  (stash_name, hash, body_bytes, r2_key, storage_generation, size_bytes, created_at)
-                 SELECT ?, ?, ?, ?, 0, ?, ? WHERE EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
+                 SELECT ?, ?, ?, ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
                    AND ${expectedFence}
                  ON CONFLICT(stash_name, hash) DO NOTHING`,
               )
               .bind(
                 stash,
                 entry.blob_hash,
-                entry.binaryBody ?? null,
-                entry.binaryR2Key ?? null,
+                entry.preparedBinary.bodyBytes,
+                entry.preparedBinary.r2Key,
+                entry.preparedBinary.storageGeneration,
                 entry.size_bytes,
                 now,
                 stash,
@@ -762,11 +752,20 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
                 };
           let diff: ChangeSetDiffResult["entries"][number]["diff"];
           if (
-            entry.op === "copy" ||
             entry.representation === "binary" ||
             (baseRow !== null && baseRow.representation === "binary")
           ) {
-            diff = { state: "binary" };
+            diff = {
+              state: "binary",
+              base:
+                baseRow?.blob_hash === null || baseRow === null
+                  ? null
+                  : { hash: baseRow.blob_hash, size: baseRow.size_bytes },
+              candidate:
+                entry.blob_hash === null || entry.size_bytes === null
+                  ? null
+                  : { hash: entry.blob_hash, size: entry.size_bytes },
+            };
           } else if (
             (baseRow?.size_bytes ?? 0) > diffMaxBytes ||
             (entry.size_bytes ?? 0) > diffMaxBytes
@@ -779,7 +778,7 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
                 : textFor(env, baseRow),
               entry.op === "delete" ? Promise.resolve("") : textFor(env, entry),
             ]);
-            diff = computeDiff({
+            const computed = computeDiff({
               fromText,
               toText,
               fromLabel:
@@ -789,6 +788,8 @@ export function createChangeSets(env: Env, deps: ChangeSetDependencies) {
               toLabel: `b/${entry.path}@${id}`,
               context: options.context,
             });
+            if (computed.state === "binary") return internal();
+            diff = computed;
           }
           return {
             path: entry.path,

--- a/workers/stash/src/d1/commits.ts
+++ b/workers/stash/src/d1/commits.ts
@@ -9,6 +9,7 @@ import {
   StashError,
   canonicalJson,
   computeDiff,
+  decodeCanonicalBase64,
   isWellFormedString,
   sha256Hex,
   utf8ByteLength,
@@ -31,6 +32,7 @@ import type { Principal } from "../context.js";
 import type { Env } from "../env.js";
 import { parseBinarySettings } from "../binary-config.js";
 import { prepareBlob, type BlobGenerationFactory, type PreparedBlob } from "./blobs.js";
+import { prepareByteWrite, type PreparedByteWrite } from "./byte-writes.js";
 import { createReads } from "./reads.js";
 import type { CommitRow } from "./schema.js";
 import { commitBatch, mintCommitId, type PreparedCommitEntry } from "./sql/commits.js";
@@ -68,6 +70,8 @@ interface CommittedVersionRow {
   content_type: string;
   representation: "text" | "binary";
   rollback_of: number | null;
+  copied_from_path: string | null;
+  copied_from_version: number | null;
   previous_hash: string | null;
   previous_content_type: string | null;
   previous_representation: "text" | "binary" | null;
@@ -274,7 +278,7 @@ async function resultFromCommit(
   const rows = await db
     .prepare(
       `SELECT id, path, version, kind, blob_hash, size_bytes, content_type,
-         representation, rollback_of,
+         representation, rollback_of, copied_from_path, copied_from_version,
          (SELECT previous.blob_hash FROM versions AS previous
           WHERE previous.stash_name = versions.stash_name
             AND previous.path = versions.path AND previous.version = versions.version - 1
@@ -313,7 +317,9 @@ async function resultFromCommit(
       contentType: row.content_type,
       representation: row.representation,
       rollbackOf: row.rollback_of,
-      ...(requested.op === "copy" ? { copiedFrom: requested.from } : {}),
+      ...(row.copied_from_path !== null && row.copied_from_version !== null
+        ? { copiedFrom: { path: row.copied_from_path, version: row.copied_from_version } }
+        : {}),
       ...(requested.op === "rollback"
         ? {
             identicalToHead:
@@ -342,7 +348,10 @@ async function resultFromCommit(
   };
 }
 
-function operationFromVersion(row: Pick<CommittedVersionRow, "kind">): CommitEntryRecord["op"] {
+function operationFromVersion(
+  row: Pick<CommittedVersionRow, "kind" | "copied_from_path">,
+): CommitEntryRecord["op"] {
+  if (row.copied_from_path !== null) return "copy";
   return row.kind === "rollback" ? "rollback" : row.kind === "delete" ? "delete" : "put";
 }
 
@@ -355,6 +364,7 @@ async function commitVersions(
     .prepare(
       `SELECT current.id, current.path, current.version, current.kind, current.blob_hash,
          current.size_bytes, current.content_type, current.representation, current.rollback_of,
+         current.copied_from_path, current.copied_from_version,
          previous.version AS previous_version, previous.blob_hash AS previous_hash,
          previous.size_bytes AS previous_size,
          previous.content_type AS previous_content_type,
@@ -405,6 +415,9 @@ function commitRecord(commit: CommitRow, rows: CommittedVersionRow[]): CommitRec
       contentType: row.content_type,
       representation: row.representation,
       rollbackOf: row.rollback_of,
+      ...(row.copied_from_path !== null && row.copied_from_version !== null
+        ? { copiedFrom: { path: row.copied_from_path, version: row.copied_from_version } }
+        : {}),
       ...(row.kind === "rollback"
         ? {
             identicalToHead:
@@ -487,11 +500,19 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
     if (input && typeof input === "object" && Array.isArray(input.entries)) {
       let rawBodyBytes = 0;
       for (const entry of input.entries) {
-        if (entry.op !== "put" || !("body" in entry) || typeof entry.body !== "string") continue;
-        if (!isWellFormedString(entry.body)) {
-          return failure("body-not-well-formed", 400, "Body is not well-formed Unicode");
+        if (entry.op !== "put") continue;
+        if ("bytesBase64" in entry && typeof entry.bytesBase64 === "string") {
+          try {
+            rawBodyBytes += decodeCanonicalBase64(entry.bytesBase64).byteLength;
+          } catch {
+            return failure("validation", 400, "Invalid binary commit body");
+          }
+        } else if ("body" in entry && typeof entry.body === "string") {
+          if (!isWellFormedString(entry.body)) {
+            return failure("body-not-well-formed", 400, "Body is not well-formed Unicode");
+          }
+          rawBodyBytes += utf8ByteLength(entry.body);
         }
-        rawBodyBytes += utf8ByteLength(entry.body);
       }
       if (rawBodyBytes > MAX_COMMIT_INLINE_BYTES) {
         return failure("payload-too-large", 413, "Commit bodies are too large");
@@ -509,31 +530,51 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
     }
 
     let totalBytes = 0;
-    const putFacts = new Map<
-      number,
-      { body: string; hash: string; size: number; contentType: string }
-    >();
+    type PutFact =
+      | { representation: "text"; body: string; hash: string; size: number; contentType: string }
+      | {
+          representation: "binary";
+          bytes: Uint8Array<ArrayBuffer>;
+          hash: string;
+          size: number;
+          contentType: string;
+        };
+    const putFacts = new Map<number, PutFact>();
     const distinctPuts = new Map<string, { body: string; size: number }>();
+    const distinctBinaryPuts = new Map<
+      string,
+      { bytes: Uint8Array<ArrayBuffer>; size: number; contentType: string }
+    >();
     for (const [index, entry] of value.entries.entries()) {
-      if (entry.op === "put" && !("body" in entry)) {
-        return failure(
-          "unsupported-representation",
-          422,
-          "Binary commit entries are not supported by this store",
-        );
-      }
       if (entry.op !== "put") continue;
-      const size = utf8ByteLength(entry.body);
-      totalBytes += size;
-      const hash = await sha256Hex(entry.body);
-      const fact = {
-        body: entry.body,
-        hash,
-        size,
-        contentType: entry.contentType ?? DEFAULT_CONTENT_TYPE,
-      };
-      putFacts.set(index, fact);
-      if (!distinctPuts.has(hash)) distinctPuts.set(hash, { body: entry.body, size });
+      if ("bytesBase64" in entry) {
+        const bytes = decodeCanonicalBase64(entry.bytesBase64);
+        const size = bytes.byteLength;
+        totalBytes += size;
+        const hash = await sha256Hex(bytes);
+        putFacts.set(index, {
+          representation: "binary",
+          bytes,
+          hash,
+          size,
+          contentType: entry.contentType,
+        });
+        if (!distinctBinaryPuts.has(hash)) {
+          distinctBinaryPuts.set(hash, { bytes, size, contentType: entry.contentType });
+        }
+      } else {
+        const size = utf8ByteLength(entry.body);
+        totalBytes += size;
+        const hash = await sha256Hex(entry.body);
+        putFacts.set(index, {
+          representation: "text",
+          body: entry.body,
+          hash,
+          size,
+          contentType: entry.contentType ?? DEFAULT_CONTENT_TYPE,
+        });
+        if (!distinctPuts.has(hash)) distinctPuts.set(hash, { body: entry.body, size });
+      }
     }
     if (totalBytes > MAX_COMMIT_INLINE_BYTES)
       return failure("payload-too-large", 413, "Commit bodies are too large");
@@ -544,9 +585,13 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
         canonicalJson({
           entries: value.entries.map((entry, index) => {
             const fact = putFacts.get(index);
-            if (!fact || !("body" in entry)) return entry;
-            const { body: _body, ...rest } = entry;
-            return { ...rest, bodyHash: fact.hash };
+            if (!fact || entry.op !== "put") return entry;
+            if ("body" in entry) {
+              const { body: _body, ...rest } = entry;
+              return { ...rest, bodyHash: fact.hash };
+            }
+            const { bytesBase64: _bytesBase64, ...rest } = entry;
+            return { ...rest, bytesHash: fact.hash };
           }),
           author: value.author ?? "",
           message: value.message ?? "",
@@ -588,6 +633,20 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
         await prepareBlob(env, stash, hash, fact.body, deps.createBlobGeneration),
       );
     }
+    const binaryStorageByHash = new Map<string, PreparedByteWrite>();
+    for (const [hash, fact] of distinctBinaryPuts) {
+      binaryStorageByHash.set(
+        hash,
+        await prepareByteWrite(
+          env,
+          stash,
+          hash,
+          fact.bytes,
+          fact.contentType,
+          deps.createBlobGeneration,
+        ),
+      );
+    }
 
     await deps.onBeforeCommit?.();
     const prepared: PreparedCommitEntry[] = value.entries.map((entry, index) => {
@@ -602,19 +661,17 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
         metaJson,
         createdAt,
       };
-      if (entry.op === "put" && "body" in entry) {
+      if (entry.op === "put") {
         const fact = putFacts.get(index);
         if (!fact) throw new Error("Missing commit PUT fact");
+        if (fact.representation === "binary") {
+          const storage = binaryStorageByHash.get(fact.hash);
+          if (!storage) throw new Error("Missing prepared binary commit blob");
+          return { ...base, op: "put", ...fact, ...storage };
+        }
         const storage = storageByHash.get(fact.hash);
-        if (!storage) throw new Error("Missing prepared commit blob");
-        return {
-          ...base,
-          op: "put",
-          hash: fact.hash,
-          size: fact.size,
-          contentType: fact.contentType,
-          ...storage,
-        };
+        if (!storage) throw new Error("Missing prepared text commit blob");
+        return { ...base, op: "put", ...fact, ...storage };
       }
       if (entry.op === "copy") return { ...base, op: "copy", from: entry.from };
       if (entry.op === "rollback") return { ...base, op: "rollback", toVersion: entry.toVersion };

--- a/workers/stash/src/d1/commits.ts
+++ b/workers/stash/src/d1/commits.ts
@@ -27,6 +27,7 @@ import {
   type ListCommitsQuery as ListCommitsQueryType,
   type RevertCommitBody as RevertCommitBodyType,
   type Result,
+  type StorageTier,
 } from "@takazudo/zudo-history-stash-core";
 import type { Principal } from "../context.js";
 import type { Env } from "../env.js";
@@ -72,6 +73,7 @@ interface CommittedVersionRow {
   rollback_of: number | null;
   copied_from_path: string | null;
   copied_from_version: number | null;
+  storage_tier: StorageTier | null;
   previous_hash: string | null;
   previous_content_type: string | null;
   previous_representation: "text" | "binary" | null;
@@ -179,6 +181,33 @@ function snapshotPayload(entries: CommitEntryInput[]): string {
   );
 }
 
+function storageTierSql(alias: string): string {
+  return `CASE
+    WHEN ${alias}.blob_hash IS NULL THEN NULL
+    WHEN ${alias}.content_storage = 'bytes' AND EXISTS (
+      SELECT 1 FROM byte_blobs AS stored
+      WHERE stored.stash_name = ${alias}.stash_name AND stored.hash = ${alias}.blob_hash
+        AND stored.size_bytes = ${alias}.size_bytes AND stored.body_bytes IS NOT NULL
+    ) THEN 'd1'
+    WHEN ${alias}.content_storage = 'bytes' AND EXISTS (
+      SELECT 1 FROM byte_blobs AS stored
+      WHERE stored.stash_name = ${alias}.stash_name AND stored.hash = ${alias}.blob_hash
+        AND stored.size_bytes = ${alias}.size_bytes AND stored.r2_key IS NOT NULL
+    ) THEN 'r2'
+    WHEN ${alias}.content_storage = 'legacy' AND EXISTS (
+      SELECT 1 FROM blobs AS stored
+      WHERE stored.stash_name = ${alias}.stash_name AND stored.hash = ${alias}.blob_hash
+        AND stored.size_bytes = ${alias}.size_bytes AND stored.body IS NOT NULL
+    ) THEN 'd1'
+    WHEN ${alias}.content_storage = 'legacy' AND EXISTS (
+      SELECT 1 FROM blobs AS stored
+      WHERE stored.stash_name = ${alias}.stash_name AND stored.hash = ${alias}.blob_hash
+        AND stored.size_bytes = ${alias}.size_bytes AND stored.r2_key IS NOT NULL
+    ) THEN 'r2'
+    ELSE NULL
+  END`;
+}
+
 async function readSnapshot(
   db: D1DatabaseSession,
   stash: string,
@@ -281,6 +310,7 @@ async function resultFromCommit(
     .prepare(
       `SELECT id, path, version, kind, blob_hash, size_bytes, content_type,
          representation, rollback_of, copied_from_path, copied_from_version,
+         ${storageTierSql("versions")} AS storage_tier,
          (SELECT previous.blob_hash FROM versions AS previous
           WHERE previous.stash_name = versions.stash_name
             AND previous.path = versions.path AND previous.version = versions.version - 1
@@ -318,6 +348,7 @@ async function resultFromCommit(
       size: row.size_bytes,
       contentType: row.content_type,
       representation: row.representation,
+      ...(row.storage_tier === null ? {} : { storageTier: row.storage_tier }),
       rollbackOf: row.rollback_of,
       ...(row.copied_from_path !== null && row.copied_from_version !== null
         ? { copiedFrom: { path: row.copied_from_path, version: row.copied_from_version } }
@@ -367,6 +398,7 @@ async function commitVersions(
       `SELECT current.id, current.path, current.version, current.kind, current.blob_hash,
          current.size_bytes, current.content_type, current.representation, current.rollback_of,
          current.copied_from_path, current.copied_from_version,
+         ${storageTierSql("current")} AS storage_tier,
          previous.version AS previous_version, previous.blob_hash AS previous_hash,
          previous.size_bytes AS previous_size,
          previous.content_type AS previous_content_type,
@@ -416,6 +448,7 @@ function commitRecord(commit: CommitRow, rows: CommittedVersionRow[]): CommitRec
       size: row.size_bytes,
       contentType: row.content_type,
       representation: row.representation,
+      ...(row.storage_tier === null ? {} : { storageTier: row.storage_tier }),
       rollbackOf: row.rollback_of,
       ...(row.copied_from_path !== null && row.copied_from_version !== null
         ? { copiedFrom: { path: row.copied_from_path, version: row.copied_from_version } }

--- a/workers/stash/src/d1/schema.ts
+++ b/workers/stash/src/d1/schema.ts
@@ -67,6 +67,8 @@ export interface VersionRow {
   application_etag: string | null;
   content_storage: "legacy" | "bytes";
   commit_id: string;
+  copied_from_path: string | null;
+  copied_from_version: number | null;
 }
 
 export interface CommitRow {
@@ -123,6 +125,7 @@ export interface ChangeSetEntryRow {
   rollback_to: number | null;
   copied_from_path: string | null;
   copied_from_version: number | null;
+  application_etag: string | null;
 }
 
 export type UploadSessionState =
@@ -295,6 +298,8 @@ export const TABLE_COLUMNS = {
     "application_etag",
     "content_storage",
     "commit_id",
+    "copied_from_path",
+    "copied_from_version",
   ],
   change_set_entries: [
     "change_set_id",
@@ -310,6 +315,7 @@ export const TABLE_COLUMNS = {
     "rollback_to",
     "copied_from_path",
     "copied_from_version",
+    "application_etag",
   ],
   change_sets: [
     "id",

--- a/workers/stash/src/d1/sql/change-sets.ts
+++ b/workers/stash/src/d1/sql/change-sets.ts
@@ -136,8 +136,8 @@ export function insertEntryStatement(db: Preparer, row: ChangeSetEntryRow): D1Pr
       `INSERT INTO change_set_entries
        (change_set_id, stash_name, path, op, base_version, blob_hash, content_storage,
         representation, content_type, size_bytes, rollback_to, copied_from_path,
-        copied_from_version)
-       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        copied_from_version, application_etag)
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
        WHERE EXISTS (SELECT 1 FROM change_sets WHERE id = ? AND stash_name = ?)`,
     )
     .bind(
@@ -154,6 +154,7 @@ export function insertEntryStatement(db: Preparer, row: ChangeSetEntryRow): D1Pr
       row.rollback_to,
       row.copied_from_path,
       row.copied_from_version,
+      row.application_etag,
       row.change_set_id,
       row.stash_name,
     );

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -195,6 +195,16 @@ function putEntryStatements(
   entry: Extract<PreparedCommitEntry, { op: "put" }>,
 ): D1PreparedStatement[] {
   const fence = entryFence(input);
+  const storedBlob =
+    entry.representation === "text"
+      ? `EXISTS (SELECT 1 FROM blobs
+          WHERE stash_name = ? AND hash = ? AND size_bytes = ?
+            AND ((body IS NOT NULL AND r2_key IS NULL)
+              OR (body IS NULL AND r2_key IS NOT NULL)))`
+      : `EXISTS (SELECT 1 FROM byte_blobs
+          WHERE stash_name = ? AND hash = ? AND size_bytes = ?
+            AND ((body_bytes IS NOT NULL AND r2_key IS NULL)
+              OR (body_bytes IS NULL AND r2_key IS NOT NULL)))`;
   const blobStatement =
     entry.representation === "text"
       ? db
@@ -238,7 +248,7 @@ function putEntryStatements(
            rollback_of, author, message, meta_json, created_at, representation,
            application_etag, content_storage, commit_id, copied_from_path, copied_from_version)
          SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL
-         WHERE ${fence.sql}`,
+         WHERE ${fence.sql} AND ${storedBlob}`,
       )
       .bind(
         input.row.stash_name,
@@ -256,6 +266,9 @@ function putEntryStatements(
         entry.representation === "binary" ? "bytes" : "legacy",
         input.row.id,
         ...fence.params,
+        input.row.stash_name,
+        entry.hash,
+        entry.size,
       ),
   ];
 }

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -1,5 +1,6 @@
 import type { CommitRow } from "../schema.js";
 import type { PreparedBlob } from "../blobs.js";
+import type { PreparedByteWrite } from "../byte-writes.js";
 import type { SqlFragment } from "./writes.js";
 
 type Preparer = Pick<D1DatabaseSession, "prepare">;
@@ -161,6 +162,15 @@ export type PreparedCommitEntry =
   | (PreparedCommitBase &
       PreparedBlob & {
         op: "put";
+        representation: "text";
+        hash: string;
+        size: number;
+        contentType: string;
+      })
+  | (PreparedCommitBase &
+      PreparedByteWrite & {
+        op: "put";
+        representation: "binary";
         hash: string;
         size: number;
         contentType: string;
@@ -185,28 +195,50 @@ function putEntryStatements(
   entry: Extract<PreparedCommitEntry, { op: "put" }>,
 ): D1PreparedStatement[] {
   const fence = entryFence(input);
+  const blobStatement =
+    entry.representation === "text"
+      ? db
+          .prepare(
+            `INSERT INTO blobs (stash_name, hash, body, r2_key, size_bytes, created_at)
+             SELECT ?, ?, ?, ?, ?, ? WHERE ${fence.sql}
+             ON CONFLICT(stash_name, hash) DO NOTHING`,
+          )
+          .bind(
+            input.row.stash_name,
+            entry.hash,
+            entry.body,
+            entry.r2_key,
+            entry.size,
+            entry.createdAt,
+            ...fence.params,
+          )
+      : db
+          .prepare(
+            `INSERT INTO byte_blobs
+              (stash_name, hash, body_bytes, r2_key, storage_generation, size_bytes, created_at)
+             SELECT ?, ?, ?, ?, ?, ?, ? WHERE ${fence.sql}
+             ON CONFLICT(stash_name, hash) DO NOTHING`,
+          )
+          .bind(
+            input.row.stash_name,
+            entry.hash,
+            entry.bodyBytes,
+            entry.r2Key,
+            entry.storageGeneration,
+            entry.size,
+            entry.createdAt,
+            ...fence.params,
+          );
   return [
-    db
-      .prepare(
-        `INSERT INTO blobs (stash_name, hash, body, r2_key, size_bytes, created_at)
-         SELECT ?, ?, ?, ?, ?, ? WHERE ${fence.sql}
-         ON CONFLICT(stash_name, hash) DO NOTHING`,
-      )
-      .bind(
-        input.row.stash_name,
-        entry.hash,
-        entry.body,
-        entry.r2_key,
-        entry.size,
-        entry.createdAt,
-        ...fence.params,
-      ),
+    blobStatement,
     db
       .prepare(
         `INSERT INTO versions
           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-           rollback_of, author, message, meta_json, created_at, commit_id)
-         SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ?, ? WHERE ${fence.sql}`,
+           rollback_of, author, message, meta_json, created_at, representation,
+           application_etag, content_storage, commit_id, copied_from_path, copied_from_version)
+         SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL
+         WHERE ${fence.sql}`,
       )
       .bind(
         input.row.stash_name,
@@ -219,6 +251,9 @@ function putEntryStatements(
         entry.message,
         entry.metaJson,
         entry.createdAt,
+        entry.representation,
+        entry.representation === "binary" ? entry.hash : null,
+        entry.representation === "binary" ? "bytes" : "legacy",
         input.row.id,
         ...fence.params,
       ),
@@ -236,10 +271,10 @@ function derivedEntryStatement(
       .prepare(
         `INSERT INTO versions
           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-           rollback_of, author, message, meta_json, created_at, representation,
-           application_etag, content_storage, commit_id)
+         rollback_of, author, message, meta_json, created_at, representation,
+           application_etag, content_storage, commit_id, copied_from_path, copied_from_version)
          SELECT ?, ?, ?, 'delete', NULL, 0, current.content_type, NULL, ?, ?, ?, ?,
-           current.representation, NULL, current.content_storage, ?
+           current.representation, NULL, current.content_storage, ?, NULL, NULL
          FROM versions AS current
          WHERE current.stash_name = ? AND current.path = ? AND current.version = ?
            AND ${fence.sql}`,
@@ -262,15 +297,17 @@ function derivedEntryStatement(
   const source = entry.op === "copy" ? entry.from : { path: entry.path, version: entry.toVersion };
   const kind = entry.op === "rollback" ? "rollback" : "put";
   const rollbackOf = entry.op === "rollback" ? "source.version" : "NULL";
+  const copiedFromPath = entry.op === "copy" ? "source.path" : "NULL";
+  const copiedFromVersion = entry.op === "copy" ? "source.version" : "NULL";
   return db
     .prepare(
       `INSERT INTO versions
         (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
          rollback_of, author, message, meta_json, created_at, representation,
-         application_etag, content_storage, commit_id)
+         application_etag, content_storage, commit_id, copied_from_path, copied_from_version)
        SELECT ?, ?, ?, '${kind}', source.blob_hash, source.size_bytes, source.content_type,
          ${rollbackOf}, ?, ?, ?, ?, source.representation, source.application_etag,
-         source.content_storage, ?
+         source.content_storage, ?, ${copiedFromPath}, ${copiedFromVersion}
        FROM versions AS source
        WHERE source.stash_name = ? AND source.path = ? AND source.version = ?
          AND source.blob_hash IS NOT NULL AND ${fence.sql}`,

--- a/workers/stash/test/binary-config.test.ts
+++ b/workers/stash/test/binary-config.test.ts
@@ -25,6 +25,7 @@ describe("binary object settings", () => {
       contentAccess: ["inline", "raw", "deleted"],
       transferModes: ["json", "single", "multipart"],
       storageTiers: ["d1", "r2"],
+      commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
       limits: { maxMultipartParts: MAX_MULTIPART_PARTS },
     });
   });
@@ -39,6 +40,7 @@ describe("binary object settings", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       representations: ["text", "binary"],
+      commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
       limits: { maxFileBytes: 100_000_000, multipartPartBytes: 8_388_608 },
     });
   });

--- a/workers/stash/test/binary-config.test.ts
+++ b/workers/stash/test/binary-config.test.ts
@@ -25,7 +25,7 @@ describe("binary object settings", () => {
       contentAccess: ["inline", "raw", "deleted"],
       transferModes: ["json", "single", "multipart"],
       storageTiers: ["d1", "r2"],
-      commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
+      commitEntryKinds: ["put", "copy", "delete", "rollback"],
       limits: { maxMultipartParts: MAX_MULTIPART_PARTS },
     });
   });
@@ -40,7 +40,7 @@ describe("binary object settings", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       representations: ["text", "binary"],
-      commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
+      commitEntryKinds: ["put", "copy", "delete", "rollback"],
       limits: { maxFileBytes: 100_000_000, multipartPartBytes: 8_388_608 },
     });
   });

--- a/workers/stash/test/routes/commits.test.ts
+++ b/workers/stash/test/routes/commits.test.ts
@@ -111,7 +111,7 @@ describe("commit routes", () => {
     });
     expect(binary.status).toBe(201);
     await expect(binary.json()).resolves.toMatchObject({
-      entries: [{ path: "binary.dat", representation: "binary", size: 1 }],
+      entries: [{ path: "binary.dat", representation: "binary", storageTier: "d1", size: 1 }],
     });
   });
 
@@ -154,7 +154,13 @@ describe("commit routes", () => {
       entries: [
         { path: "index.html", op: "put", representation: "text" },
         { path: "style.css", op: "put", representation: "text" },
-        { path: "hero.png", op: "put", representation: "binary", contentType: "image/png" },
+        {
+          path: "hero.png",
+          op: "put",
+          representation: "binary",
+          storageTier: "d1",
+          contentType: "image/png",
+        },
         {
           path: "logo-old.png",
           op: "copy",

--- a/workers/stash/test/routes/commits.test.ts
+++ b/workers/stash/test/routes/commits.test.ts
@@ -40,7 +40,7 @@ async function put(stash: string, path: string, body: string, expectedVersion: n
 }
 
 describe("commit routes", () => {
-  it("creates and replays a commit while classifying validation, conflict, size, and binary errors", async () => {
+  it("creates and replays a commit while classifying validation, conflict, and size errors", async () => {
     const stash = "commit-errors";
     await seedStash(stash);
     await put(stash, "existing.txt", "before\n", null);
@@ -109,10 +109,66 @@ describe("commit routes", () => {
         ],
       },
     });
-    expect(binary.status).toBe(422);
+    expect(binary.status).toBe(201);
     await expect(binary.json()).resolves.toMatchObject({
-      error: { code: "unsupported-representation" },
+      entries: [{ path: "binary.dat", representation: "binary", size: 1 }],
     });
+  });
+
+  it("atomically commits mixed text, binary bytes, and a persisted copy source", async () => {
+    const stash = "commit-mixed-binary";
+    await seedStash(stash);
+    await put(stash, "logo.png", "old-logo", null);
+    const hero = Uint8Array.from({ length: 40 * 1024 }, (_, index) => index % 251);
+    let binary = "";
+    for (const byte of hero) binary += String.fromCharCode(byte);
+
+    const response = await api(stash, "", {
+      method: "POST",
+      body: {
+        entries: [
+          { op: "put", path: "index.html", expectedVersion: null, body: "<main />" },
+          { op: "put", path: "style.css", expectedVersion: null, body: "main{}" },
+          {
+            op: "put",
+            path: "hero.png",
+            expectedVersion: null,
+            representation: "binary",
+            contentType: "image/png",
+            bytesBase64: btoa(binary),
+          },
+          {
+            op: "copy",
+            path: "logo-old.png",
+            expectedVersion: null,
+            from: { path: "logo.png", version: 1 },
+          },
+        ],
+      },
+    });
+    expect(response.status).toBe(201);
+    const commit = await response.json<{ id: string }>();
+    const stored = await api(stash, `/${commit.id}`);
+    await expect(stored.json()).resolves.toMatchObject({
+      entryCount: 4,
+      entries: [
+        { path: "index.html", op: "put", representation: "text" },
+        { path: "style.css", op: "put", representation: "text" },
+        { path: "hero.png", op: "put", representation: "binary", contentType: "image/png" },
+        {
+          path: "logo-old.png",
+          op: "copy",
+          copiedFrom: { path: "logo.png", version: 1 },
+        },
+      ],
+    });
+
+    const raw = await request(app, `http://stash.test/v1/stashes/${stash}/raw/hero.png`, {
+      headers: bearer("test-admin"),
+    });
+    expect(raw.status).toBe(200);
+    expect(raw.headers.get("Content-Type")).toBe("image/png");
+    expect(new Uint8Array(await raw.arrayBuffer())).toEqual(hero);
   });
 
   it("uses the write limiter for commit creation", async () => {

--- a/workers/stash/test/store/change-sets.test.ts
+++ b/workers/stash/test/store/change-sets.test.ts
@@ -134,7 +134,7 @@ describe("change-set store", () => {
     ).resolves.toMatchObject({ total: 1, changeSets: [{ entries: [{ path: "one.txt" }] }] });
   });
 
-  it("returns metadata outcomes for binary and copy entries", async () => {
+  it("returns exact metadata for binary review and a text diff for copy", async () => {
     await seedStash(STASH);
     const store = createStashStore(env as Env, dependencies());
     await store.writes.put(STASH, "source.txt", { body: "source", expectedVersion: null });
@@ -159,8 +159,21 @@ describe("change-set store", () => {
     const diff = await store.changeSets.getChangeSetDiff(STASH, created.value.id);
     expect(diff?.entries).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ path: "binary.bin", diff: { state: "binary" } }),
-        expect.objectContaining({ path: "copy.txt", diff: { state: "binary" } }),
+        expect.objectContaining({
+          path: "binary.bin",
+          diff: {
+            state: "binary",
+            base: null,
+            candidate: {
+              hash: "sha256-ae4b3280e56e2faf83f414a6e3dabe9d5fbe18976544c05fed121accb85b53fc",
+              size: 3,
+            },
+          },
+        }),
+        expect.objectContaining({
+          path: "copy.txt",
+          diff: expect.objectContaining({ state: "ready" }),
+        }),
       ]),
     );
   });

--- a/workers/stash/test/store/commits.test.ts
+++ b/workers/stash/test/store/commits.test.ts
@@ -1,10 +1,11 @@
 import { env } from "cloudflare:workers";
 import { beforeEach, describe, expect, it } from "vitest";
-import type { CreateCommitBody } from "@takazudo/zudo-history-stash-core";
+import { sha256Hex, type CreateCommitBody } from "@takazudo/zudo-history-stash-core";
 import type { Env } from "../../src/env.js";
 import { createCommits } from "../../src/d1/commits.js";
 import { createStashStore } from "../../src/d1/store.js";
 import { resetDatabase, seedStash } from "../helpers/app.js";
+import { generation } from "../helpers/blob-generations.js";
 
 const workerEnv = env as Env;
 let sequence = 0;
@@ -38,6 +39,12 @@ beforeEach(async () => {
 });
 
 describe("commit store", () => {
+  function base64(bytes: Uint8Array): string {
+    let binary = "";
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary);
+  }
+
   it("atomically seals create, put, and delete entries under one commit", async () => {
     const stash = "commit-three";
     await seedStash(stash);
@@ -191,6 +198,91 @@ describe("commit store", () => {
     await expect(
       env.DB.prepare("SELECT seq FROM sqlite_sequence WHERE name = 'versions'").first(),
     ).resolves.toEqual({ seq: 2 });
+  });
+
+  it("spills a 600KB binary and leaves a refused spill as an R2-only GC orphan", async () => {
+    const stash = "commit-binary-spill";
+    await seedStash(stash);
+    const bytes = Uint8Array.from({ length: 600 * 1024 }, (_, index) => index % 251);
+    const hash = await sha256Hex(bytes.slice().buffer as ArrayBuffer);
+    const first = createCommits(workerEnv, {
+      now: () => 10_000,
+      createId: () => "binary-spill-one",
+      createBlobGeneration: () => generation(1),
+    });
+    const committed = await first.createCommit(
+      stash,
+      {
+        entries: [
+          {
+            op: "put",
+            path: "large.bin",
+            expectedVersion: null,
+            representation: "binary",
+            contentType: "application/octet-stream",
+            bytesBase64: base64(bytes),
+          },
+        ],
+      },
+      { principal: "test" },
+    );
+    expect(committed).toMatchObject({
+      ok: true,
+      value: { entries: [{ hash, size: bytes.length }] },
+    });
+    await expect(
+      env.DB.prepare("SELECT body_bytes, r2_key FROM byte_blobs WHERE stash_name = ? AND hash = ?")
+        .bind(stash, hash)
+        .first(),
+    ).resolves.toEqual({
+      body_bytes: null,
+      r2_key: `v2/${stash}/${hash}/${generation(1)}`,
+    });
+
+    await seedFile(stash, "raced.txt", "before");
+    const refusedBytes = bytes.map((byte) => byte ^ 0xff);
+    const refusedHash = await sha256Hex(refusedBytes.slice().buffer as ArrayBuffer);
+    const writes = store(11_000).writes;
+    const raced = createCommits(workerEnv, {
+      now: () => 12_000,
+      createId: () => "binary-spill-raced",
+      createBlobGeneration: () => generation(2),
+      onBeforeCommit: async () => {
+        const winner = await writes.put(stash, "raced.txt", {
+          body: "winner",
+          expectedVersion: 1,
+        });
+        if (!winner.ok) throw new Error("Failed to commit race winner");
+      },
+    });
+    const refused = await raced.createCommit(
+      stash,
+      {
+        entries: [
+          {
+            op: "put",
+            path: "refused.bin",
+            expectedVersion: null,
+            representation: "binary",
+            contentType: "application/octet-stream",
+            bytesBase64: base64(refusedBytes),
+          },
+          { op: "put", path: "raced.txt", expectedVersion: 1, body: "loser" },
+        ],
+      },
+      { principal: "test" },
+    );
+    expect(refused).toMatchObject({ ok: false, error: { code: "commit-conflict" } });
+    await expect(
+      env.DB.prepare("SELECT 1 FROM byte_blobs WHERE stash_name = ? AND hash = ?")
+        .bind(stash, refusedHash)
+        .first(),
+    ).resolves.toBeNull();
+    const orphanKey = `v2/${stash}/${refusedHash}/${generation(2)}`;
+    await expect(env.BLOBS.head(orphanKey)).resolves.not.toBeNull();
+    await expect(
+      env.DB.prepare("SELECT 1 FROM byte_blobs WHERE r2_key = ?").bind(orphanKey).first(),
+    ).resolves.toBeNull();
   });
 
   it("builds copy and rollback entries from live stored versions", async () => {

--- a/workers/stash/test/store/commits.test.ts
+++ b/workers/stash/test/store/commits.test.ts
@@ -228,7 +228,7 @@ describe("commit store", () => {
     );
     expect(committed).toMatchObject({
       ok: true,
-      value: { entries: [{ hash, size: bytes.length }] },
+      value: { entries: [{ hash, size: bytes.length, storageTier: "r2" }] },
     });
     await expect(
       env.DB.prepare("SELECT body_bytes, r2_key FROM byte_blobs WHERE stash_name = ? AND hash = ?")

--- a/workers/viewer/e2e/new-file.mock.spec.ts
+++ b/workers/viewer/e2e/new-file.mock.spec.ts
@@ -13,7 +13,7 @@ const CAPABILITIES: CapabilitiesResponse = {
   contentAccess: ["inline", "raw", "deleted"],
   transferModes: ["json", "single", "multipart"],
   storageTiers: ["d1", "r2"],
-  commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
+  commitEntryKinds: ["put", "copy", "delete", "rollback"],
   limits: {
     jsonInlineMaxBytes: 5_000_000,
     d1InlineMaxBytes: 524_288,

--- a/workers/viewer/e2e/new-file.mock.spec.ts
+++ b/workers/viewer/e2e/new-file.mock.spec.ts
@@ -13,6 +13,7 @@ const CAPABILITIES: CapabilitiesResponse = {
   contentAccess: ["inline", "raw", "deleted"],
   transferModes: ["json", "single", "multipart"],
   storageTiers: ["d1", "r2"],
+  commitEntryKinds: ["put-text", "put-binary", "copy", "delete", "rollback"],
   limits: {
     jsonInlineMaxBytes: 5_000_000,
     d1InlineMaxBytes: 524_288,


### PR DESCRIPTION
Parent: #206

Relates to #215.

## Summary

- support inline and R2-backed `bytesBase64` commit entries
- support zero-byte copy-from-version entries for commits and change sets
- expose storage-tier evidence and preserve atomic source/blob validation

## Validation

- 40 focused Core tests and 121 focused Stash tests passed
- OpenAPI, typecheck, lint, and formatting passed
- blocking topic review completed before integration
