### PR TITLE
Single-source the path-prefix SQL range bound in core paths.ts

### DIFF
--- a/packages/core/src/paths.test.ts
+++ b/packages/core/src/paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isWellFormedString, utf8ByteLength } from "./hash.js";
-import { joinPath, validatePath, validateStashName } from "./paths.js";
+import { joinPath, pathPrefixRange, validatePath, validateStashName } from "./paths.js";
 
 describe("validatePath", () => {
   it.each(["..", ".", "a//b", "/a", "a/", "a/%2F", "a/日本語", "a".repeat(513)])(
@@ -17,6 +17,45 @@ describe("validateStashName", () => {
   });
   it.each(["", "A", "-a", "a_1", "a".repeat(64)])("rejects %j", (name) => {
     expect(validateStashName(name).ok).toBe(false);
+  });
+});
+
+describe("pathPrefixRange", () => {
+  it("returns no range for an undefined prefix", () => {
+    expect(pathPrefixRange(undefined)).toEqual({ ok: true, range: null });
+  });
+
+  it.each([
+    ["site", { ok: true, range: { lo: "site/", hi: "site0" } }],
+    ["site/", { ok: true, range: { lo: "site/", hi: "site0" } }],
+    ["a/b", { ok: true, range: { lo: "a/b/", hi: "a/b0" } }],
+  ])("normalizes %j", (prefix, expected) => {
+    expect(pathPrefixRange(prefix)).toEqual(expected);
+  });
+
+  it.each(["", "/", ".."])("rejects %j", (prefix) => {
+    expect(pathPrefixRange(prefix)).toEqual({
+      ok: false,
+      error: "invalid-path",
+      message: "Invalid file path",
+    });
+  });
+
+  it("uses an exclusive upper bound after the slash", () => {
+    const result = pathPrefixRange("site");
+    expect(result).toEqual({ ok: true, range: { lo: "site/", hi: "site0" } });
+    if (!result.ok || result.range === null) throw new Error("Expected a path range");
+
+    const paths = ["site/index.html", "site/x/y.md", "site2/a.md", "sit/a.md", "siteX"];
+    expect(paths.filter((path) => path >= result.range.lo && path < result.range.hi)).toEqual([
+      "site/index.html",
+      "site/x/y.md",
+    ]);
+    expect(paths.filter((path) => path < result.range.lo || path >= result.range.hi)).toEqual([
+      "site2/a.md",
+      "sit/a.md",
+      "siteX",
+    ]);
   });
 });
 

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -3,6 +3,15 @@ import { MAX_PATH_BYTES } from "./limits.js";
 export type ValidationResult =
   { ok: true } | { ok: false; error: "invalid-path" | "validation"; message: string };
 
+export interface PathPrefixRange {
+  lo: string;
+  hi: string;
+}
+
+export type PathPrefixRangeResult =
+  | { ok: true; range: PathPrefixRange | null }
+  | { ok: false; error: "invalid-path" | "validation"; message: string };
+
 const STASH_NAME = /^[a-z0-9][a-z0-9-]{0,62}$/;
 const PATH_SEGMENT = /^[A-Za-z0-9._-]+$/;
 
@@ -28,6 +37,15 @@ export function validatePath(path: string): ValidationResult {
     return { ok: false, error: "invalid-path", message: "Invalid file path" };
   }
   return { ok: true };
+}
+
+export function pathPrefixRange(prefix: string | undefined): PathPrefixRangeResult {
+  if (prefix === undefined) return { ok: true, range: null };
+  const path = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+  const result = validatePath(path);
+  if (!result.ok) return result;
+  // "0" (U+0030) follows "/" (U+002F), making it the exclusive descendant bound.
+  return { ok: true, range: { lo: `${path}/`, hi: `${path}0` } };
 }
 
 export function joinPath(...segments: string[]): string {

--- a/workers/stash/src/d1/reads.ts
+++ b/workers/stash/src/d1/reads.ts
@@ -10,7 +10,8 @@ import {
   type JsonValue,
   type Representation,
   type VersionKind,
-  validatePath,
+  pathPrefixRange,
+  type PathPrefixRange,
 } from "@takazudo/zudo-history-stash-core";
 import { parseBinarySettings } from "../binary-config.js";
 import type { Env } from "../env.js";
@@ -227,10 +228,7 @@ function validateString(value: string, name: string): string {
   return value;
 }
 
-interface PathRange {
-  lo: string | null;
-  hi: string | null;
-}
+type PathRange = PathPrefixRange | { lo: null; hi: null };
 
 interface NormalizedListOptions {
   includeDeleted: boolean;
@@ -241,12 +239,10 @@ interface NormalizedListOptions {
 }
 
 function normalizePrefix(value: string | undefined): PathRange {
-  if (value === undefined) return { lo: null, hi: null };
-  const prefix = validateString(value, "prefix");
-  const path = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
-  const result = validatePath(path);
+  const prefix = value === undefined ? undefined : validateString(value, "prefix");
+  const result = pathPrefixRange(prefix);
   if (!result.ok) throw new StashError(result.error, result.message);
-  return { lo: `${path}/`, hi: `${path}0` };
+  return result.range ?? { lo: null, hi: null };
 }
 
 function normalizeListOptions(options: ListFilesOptions): NormalizedListOptions {


### PR DESCRIPTION
Part of #247.
Topic: #248.

## Summary

Implements the scoped topic described in #248 and records its reviewed integration into `base/pre-release-consolidation`.

## Verification

- Topic acceptance checks passed.
- Blocking foreground `codex-review` completed before integration.
- The topic worktree was clean at its verified completion gate.

