### PR TITLE
Core schemas: prefix fence field, change: snapshot selector, range-diff query params

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5547,6 +5547,9 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "expectedLastChangePrefix": {
+                    "type": "string"
+                  },
                   "expiresAt": {
                     "format": "date-time",
                     "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
@@ -6881,6 +6884,9 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "expectedLastChangePrefix": {
+                    "type": "string"
+                  },
                   "message": {
                     "description": "Must be a well-formed Unicode string. Maximum 2000 UTF-8 bytes.",
                     "type": "string"
@@ -7217,6 +7223,27 @@
             "explode": false,
             "in": "query",
             "name": "path",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "explode": false,
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "pattern": "^commit:.+$",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "explode": false,
+            "in": "query",
+            "name": "prefix",
             "required": false,
             "schema": {
               "type": "string"
@@ -10073,7 +10100,7 @@
             "name": "at",
             "required": true,
             "schema": {
-              "pattern": "^commit:.+$",
+              "pattern": "^(commit:.+|change:(0|[1-9][0-9]*))$",
               "type": "string"
             },
             "style": "form"

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -21,6 +21,7 @@ import {
   ListQuery,
   ListStashesQuery,
   PutFileBody,
+  parseSnapshotSelector,
   RejectChangeSetBody,
   SnapshotQuery,
   RunGcBody,
@@ -359,9 +360,28 @@ describe("commit and change-set request schemas", () => {
     expect(CreateCommitBody.safeParse({ entries: [put], expectedLastChangeId: 0 }).success).toBe(
       true,
     );
+    expect(
+      CreateCommitBody.safeParse({
+        entries: [put],
+        expectedLastChangeId: 0,
+        expectedLastChangePrefix: "docs/",
+      }).success,
+    ).toBe(true);
     expect(CreateCommitBody.safeParse({ entries: [put], expectedLastChangeId: -1 }).success).toBe(
       false,
     );
+    const commitPrefixWithoutId = CreateCommitBody.safeParse({
+      entries: [put],
+      expectedLastChangePrefix: "docs/",
+    });
+    expect(commitPrefixWithoutId.success).toBe(false);
+    if (!commitPrefixWithoutId.success) {
+      expect(commitPrefixWithoutId.error.issues).toContainEqual({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
     expect(
       CreateChangeSetBody.safeParse({
         entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
@@ -371,9 +391,28 @@ describe("commit and change-set request schemas", () => {
     expect(
       CreateChangeSetBody.safeParse({
         entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
+        expectedLastChangeId: 0,
+        expectedLastChangePrefix: "docs/",
+      }).success,
+    ).toBe(true);
+    expect(
+      CreateChangeSetBody.safeParse({
+        entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
         expectedLastChangeId: -1,
       }).success,
     ).toBe(false);
+    const changeSetPrefixWithoutId = CreateChangeSetBody.safeParse({
+      entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
+      expectedLastChangePrefix: "docs/",
+    });
+    expect(changeSetPrefixWithoutId.success).toBe(false);
+    if (!changeSetPrefixWithoutId.success) {
+      expect(changeSetPrefixWithoutId.error.issues).toContainEqual({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
   });
   it.each(["AB==", "AA=", "AA==\n", "_A=="])(
     "rejects non-canonical binary input %j",
@@ -439,12 +478,30 @@ describe("commit and change-set request schemas", () => {
     expect(ListCommitsQuery.parse({})).toEqual({ limit: 50 });
     expect(ListChangeSetsQuery.parse({})).toEqual({ status: "open", limit: 50 });
     expect(CommitDiffQuery.parse({ context: "0" })).toEqual({ context: 0 });
+    expect(
+      CommitDiffQuery.parse({ from: "commit:cmt_1", prefix: "docs/", path: "docs/a.md" }),
+    ).toEqual({ from: "commit:cmt_1", prefix: "docs/", path: "docs/a.md" });
+    expect(CommitDiffQuery.safeParse({ prefix: "docs/", unknown: true }).success).toBe(false);
     expect(ChangeSetDiffQuery.safeParse({ path: "../bad" }).success).toBe(false);
-    expect(SnapshotQuery.parse({ at: "commit:cmt_1" })).toMatchObject({
-      at: "commit:cmt_1",
-      includeDeleted: false,
-      limit: 50,
+    for (const at of ["commit:cmt_1", "change:0", "change:12"]) {
+      expect(SnapshotQuery.parse({ at })).toMatchObject({
+        at,
+        includeDeleted: false,
+        limit: 50,
+      });
+    }
+    expect(parseSnapshotSelector("commit:cmt_1")).toEqual({
+      kind: "commit",
+      commitId: "cmt_1",
     });
+    expect(parseSnapshotSelector("change:0")).toEqual({ kind: "change", changeId: 0 });
+    expect(parseSnapshotSelector("change:12")).toEqual({ kind: "change", changeId: 12 });
+    for (const at of ["change:-1", "change:01", "change:1.5", "change:", "nope:1"]) {
+      expect(SnapshotQuery.safeParse({ at }).success).toBe(false);
+      expect(parseSnapshotSelector(at)).toBeNull();
+    }
+    expect(parseSnapshotSelector("change:9007199254740992")).toBeNull();
+    expect(SnapshotQuery.safeParse({ at: "commit:cmt_1", unknown: true }).success).toBe(false);
     expect(ListFilesQuery.parse({ prefix: "docs/", delimiter: "/" })).toMatchObject({
       prefix: "docs/",
       delimiter: "/",

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -306,8 +306,18 @@ export const CreateCommitBody = z
     message,
     meta: commitMeta,
     expectedLastChangeId: nonNegativeInteger.optional(),
+    expectedLastChangePrefix: z.string().optional(),
   })
-  .superRefine(entryListRefinement);
+  .superRefine(entryListRefinement)
+  .superRefine((value, context) => {
+    if (value.expectedLastChangePrefix !== undefined && value.expectedLastChangeId === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
+  });
 export const RevertCommitBody = z.strictObject({ author, message, meta: commitMeta });
 export const ListCommitsQuery = z.strictObject({
   limit,
@@ -317,9 +327,14 @@ export const ListCommitsQuery = z.strictObject({
 export const CommitDiffQuery = z.strictObject({
   context: optionalQueryInteger(0),
   path: entryPath.optional(),
+  from: z
+    .string()
+    .regex(/^commit:.+$/)
+    .optional(),
+  prefix: z.string().optional(),
 });
 export const SnapshotQuery = z.strictObject({
-  at: z.string().regex(/^commit:.+$/),
+  at: z.string().regex(/^(commit:.+|change:(0|[1-9][0-9]*))$/),
   prefix: z.string().optional(),
   delimiter: z.string().optional(),
   includeDeleted: z.preprocess(
@@ -329,6 +344,21 @@ export const SnapshotQuery = z.strictObject({
   limit,
   after: z.string().optional(),
 });
+
+export type SnapshotSelector =
+  { kind: "commit"; commitId: string } | { kind: "change"; changeId: number };
+
+export function parseSnapshotSelector(at: string): SnapshotSelector | null {
+  const match = /^(commit:.+|change:(0|[1-9][0-9]*))$/.exec(at);
+  if (match === null) return null;
+
+  if (at.startsWith("change:")) {
+    const changeId = Number(at.slice("change:".length));
+    return Number.isSafeInteger(changeId) ? { kind: "change", changeId } : null;
+  }
+
+  return { kind: "commit", commitId: at.slice("commit:".length) };
+}
 
 const changeSetCommon = { path: entryPath, baseVersion: commitExpectedVersion };
 export const ChangeSetEntryInput = z.union([
@@ -366,8 +396,18 @@ export const CreateChangeSetBody = z
     meta: commitMeta,
     expiresAt: z.iso.datetime().optional(),
     expectedLastChangeId: nonNegativeInteger.optional(),
+    expectedLastChangePrefix: z.string().optional(),
   })
-  .superRefine(entryListRefinement);
+  .superRefine(entryListRefinement)
+  .superRefine((value, context) => {
+    if (value.expectedLastChangePrefix !== undefined && value.expectedLastChangeId === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
+  });
 export const ApproveChangeSetBody = z.strictObject({ author, message });
 export const RejectChangeSetBody = z.strictObject({
   reason: boundedString(MAX_MESSAGE_BYTES).optional(),


### PR DESCRIPTION
Part of #247.
Topic: #249.

## Summary

Implements the scoped topic described in #249 and records its reviewed integration into `base/pre-release-consolidation`.

## Verification

- Topic acceptance checks passed.
- Blocking foreground `codex-review` completed before integration.
- The topic worktree was clean at its verified completion gate.

