### PR TITLE
Make the commit-batch D1 probe operator-ready: gitignore, template, validation test, TESTING.md result slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ _temp-resource/
 .env
 .env.*
 !.env.example
+wrangler.*.local.toml
 .DS_Store

--- a/TESTING.md
+++ b/TESTING.md
@@ -300,8 +300,11 @@ no credentials:
 pnpm --filter zudo-history-stash probe:commit-batch
 ```
 
-Remote mode must target a disposable D1 database. Point at a gitignored Wrangler config containing
-that database's real ID; never use the production database. Cloudflare's
+Remote mode must target a disposable D1 database. Copy
+`workers/stash/wrangler.probe.local.example.toml` to the gitignored
+`workers/stash/wrangler.probe.local.toml` and paste that database's real ID; the
+`wrangler.*.local.toml` pattern keeps the credential-bearing copy out of git. Never use the
+production database. Cloudflare's
 [D1 limits](https://developers.cloudflare.com/d1/platform/limits/) currently document 50 D1 queries
 per invocation on Workers Free and 1,000 on Workers Paid, and apply individual query limits to each
 statement in a batch. Supplying the applicable value lets the probe explain whether the observed
@@ -311,7 +314,7 @@ statement in a batch. Supplying the applicable value lets the probe explain whet
 CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" \
 CLOUDFLARE_API_TOKEN="$CLOUDFLARE_API_TOKEN" \
 COMMIT_BATCH_PROBE_REMOTE=1 \
-COMMIT_BATCH_PROBE_WRANGLER_CONFIG=wrangler.preview.local.toml \
+COMMIT_BATCH_PROBE_WRANGLER_CONFIG=wrangler.probe.local.toml \
 COMMIT_BATCH_PROBE_QUERY_LIMIT=1000 \
 pnpm --filter zudo-history-stash probe:commit-batch
 ```
@@ -321,6 +324,16 @@ run two probes concurrently against the same database. A failed or interrupted r
 the scratch tables behind; the next run drops them before starting and again during normal cleanup.
 The documented query limit is deliberately an input rather than a repository constant: limit
 constants and their contract rows belong to the separate limits task.
+
+#### Recorded remote probe outcome
+
+Leave the row unfilled until a human runs the probe against a disposable account. `MAX_COMMIT_ENTRIES`
+remains 20 until this table is filled; copy the probe's `limitAssessment` string verbatim into the
+Limit assessment column.
+
+| Date | Plan (Free/Paid) | Query limit supplied | Statements | Result (ok/failed) | Elapsed ms | Limit assessment | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |  |
 
 ## Playwright conventions
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5547,6 +5547,9 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "expectedLastChangePrefix": {
+                    "type": "string"
+                  },
                   "expiresAt": {
                     "format": "date-time",
                     "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
@@ -6881,6 +6884,9 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "expectedLastChangePrefix": {
+                    "type": "string"
+                  },
                   "message": {
                     "description": "Must be a well-formed Unicode string. Maximum 2000 UTF-8 bytes.",
                     "type": "string"
@@ -7217,6 +7223,27 @@
             "explode": false,
             "in": "query",
             "name": "path",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "explode": false,
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "pattern": "^commit:.+$",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "explode": false,
+            "in": "query",
+            "name": "prefix",
             "required": false,
             "schema": {
               "type": "string"
@@ -10073,7 +10100,7 @@
             "name": "at",
             "required": true,
             "schema": {
-              "pattern": "^commit:.+$",
+              "pattern": "^(commit:.+|change:(0|[1-9][0-9]*))$",
               "type": "string"
             },
             "style": "form"

--- a/packages/core/src/paths.test.ts
+++ b/packages/core/src/paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isWellFormedString, utf8ByteLength } from "./hash.js";
-import { joinPath, validatePath, validateStashName } from "./paths.js";
+import { joinPath, pathPrefixRange, validatePath, validateStashName } from "./paths.js";
 
 describe("validatePath", () => {
   it.each(["..", ".", "a//b", "/a", "a/", "a/%2F", "a/日本語", "a".repeat(513)])(
@@ -17,6 +17,45 @@ describe("validateStashName", () => {
   });
   it.each(["", "A", "-a", "a_1", "a".repeat(64)])("rejects %j", (name) => {
     expect(validateStashName(name).ok).toBe(false);
+  });
+});
+
+describe("pathPrefixRange", () => {
+  it("returns no range for an undefined prefix", () => {
+    expect(pathPrefixRange(undefined)).toEqual({ ok: true, range: null });
+  });
+
+  it.each([
+    ["site", { ok: true, range: { lo: "site/", hi: "site0" } }],
+    ["site/", { ok: true, range: { lo: "site/", hi: "site0" } }],
+    ["a/b", { ok: true, range: { lo: "a/b/", hi: "a/b0" } }],
+  ])("normalizes %j", (prefix, expected) => {
+    expect(pathPrefixRange(prefix)).toEqual(expected);
+  });
+
+  it.each(["", "/", ".."])("rejects %j", (prefix) => {
+    expect(pathPrefixRange(prefix)).toEqual({
+      ok: false,
+      error: "invalid-path",
+      message: "Invalid file path",
+    });
+  });
+
+  it("uses an exclusive upper bound after the slash", () => {
+    const result = pathPrefixRange("site");
+    expect(result).toEqual({ ok: true, range: { lo: "site/", hi: "site0" } });
+    if (!result.ok || result.range === null) throw new Error("Expected a path range");
+
+    const paths = ["site/index.html", "site/x/y.md", "site2/a.md", "sit/a.md", "siteX"];
+    expect(paths.filter((path) => path >= result.range.lo && path < result.range.hi)).toEqual([
+      "site/index.html",
+      "site/x/y.md",
+    ]);
+    expect(paths.filter((path) => path < result.range.lo || path >= result.range.hi)).toEqual([
+      "site2/a.md",
+      "sit/a.md",
+      "siteX",
+    ]);
   });
 });
 

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -3,6 +3,15 @@ import { MAX_PATH_BYTES } from "./limits.js";
 export type ValidationResult =
   { ok: true } | { ok: false; error: "invalid-path" | "validation"; message: string };
 
+export interface PathPrefixRange {
+  lo: string;
+  hi: string;
+}
+
+export type PathPrefixRangeResult =
+  | { ok: true; range: PathPrefixRange | null }
+  | { ok: false; error: "invalid-path" | "validation"; message: string };
+
 const STASH_NAME = /^[a-z0-9][a-z0-9-]{0,62}$/;
 const PATH_SEGMENT = /^[A-Za-z0-9._-]+$/;
 
@@ -28,6 +37,15 @@ export function validatePath(path: string): ValidationResult {
     return { ok: false, error: "invalid-path", message: "Invalid file path" };
   }
   return { ok: true };
+}
+
+export function pathPrefixRange(prefix: string | undefined): PathPrefixRangeResult {
+  if (prefix === undefined) return { ok: true, range: null };
+  const path = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+  const result = validatePath(path);
+  if (!result.ok) return result;
+  // "0" (U+0030) follows "/" (U+002F), making it the exclusive descendant bound.
+  return { ok: true, range: { lo: `${path}/`, hi: `${path}0` } };
 }
 
 export function joinPath(...segments: string[]): string {

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -21,6 +21,7 @@ import {
   ListQuery,
   ListStashesQuery,
   PutFileBody,
+  parseSnapshotSelector,
   RejectChangeSetBody,
   SnapshotQuery,
   RunGcBody,
@@ -359,9 +360,28 @@ describe("commit and change-set request schemas", () => {
     expect(CreateCommitBody.safeParse({ entries: [put], expectedLastChangeId: 0 }).success).toBe(
       true,
     );
+    expect(
+      CreateCommitBody.safeParse({
+        entries: [put],
+        expectedLastChangeId: 0,
+        expectedLastChangePrefix: "docs/",
+      }).success,
+    ).toBe(true);
     expect(CreateCommitBody.safeParse({ entries: [put], expectedLastChangeId: -1 }).success).toBe(
       false,
     );
+    const commitPrefixWithoutId = CreateCommitBody.safeParse({
+      entries: [put],
+      expectedLastChangePrefix: "docs/",
+    });
+    expect(commitPrefixWithoutId.success).toBe(false);
+    if (!commitPrefixWithoutId.success) {
+      expect(commitPrefixWithoutId.error.issues).toContainEqual({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
     expect(
       CreateChangeSetBody.safeParse({
         entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
@@ -371,9 +391,28 @@ describe("commit and change-set request schemas", () => {
     expect(
       CreateChangeSetBody.safeParse({
         entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
+        expectedLastChangeId: 0,
+        expectedLastChangePrefix: "docs/",
+      }).success,
+    ).toBe(true);
+    expect(
+      CreateChangeSetBody.safeParse({
+        entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
         expectedLastChangeId: -1,
       }).success,
     ).toBe(false);
+    const changeSetPrefixWithoutId = CreateChangeSetBody.safeParse({
+      entries: [{ op: "put", path: "docs/a.md", baseVersion: null, body: "a" }],
+      expectedLastChangePrefix: "docs/",
+    });
+    expect(changeSetPrefixWithoutId.success).toBe(false);
+    if (!changeSetPrefixWithoutId.success) {
+      expect(changeSetPrefixWithoutId.error.issues).toContainEqual({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
   });
   it.each(["AB==", "AA=", "AA==\n", "_A=="])(
     "rejects non-canonical binary input %j",
@@ -439,12 +478,30 @@ describe("commit and change-set request schemas", () => {
     expect(ListCommitsQuery.parse({})).toEqual({ limit: 50 });
     expect(ListChangeSetsQuery.parse({})).toEqual({ status: "open", limit: 50 });
     expect(CommitDiffQuery.parse({ context: "0" })).toEqual({ context: 0 });
+    expect(
+      CommitDiffQuery.parse({ from: "commit:cmt_1", prefix: "docs/", path: "docs/a.md" }),
+    ).toEqual({ from: "commit:cmt_1", prefix: "docs/", path: "docs/a.md" });
+    expect(CommitDiffQuery.safeParse({ prefix: "docs/", unknown: true }).success).toBe(false);
     expect(ChangeSetDiffQuery.safeParse({ path: "../bad" }).success).toBe(false);
-    expect(SnapshotQuery.parse({ at: "commit:cmt_1" })).toMatchObject({
-      at: "commit:cmt_1",
-      includeDeleted: false,
-      limit: 50,
+    for (const at of ["commit:cmt_1", "change:0", "change:12"]) {
+      expect(SnapshotQuery.parse({ at })).toMatchObject({
+        at,
+        includeDeleted: false,
+        limit: 50,
+      });
+    }
+    expect(parseSnapshotSelector("commit:cmt_1")).toEqual({
+      kind: "commit",
+      commitId: "cmt_1",
     });
+    expect(parseSnapshotSelector("change:0")).toEqual({ kind: "change", changeId: 0 });
+    expect(parseSnapshotSelector("change:12")).toEqual({ kind: "change", changeId: 12 });
+    for (const at of ["change:-1", "change:01", "change:1.5", "change:", "nope:1"]) {
+      expect(SnapshotQuery.safeParse({ at }).success).toBe(false);
+      expect(parseSnapshotSelector(at)).toBeNull();
+    }
+    expect(parseSnapshotSelector("change:9007199254740992")).toBeNull();
+    expect(SnapshotQuery.safeParse({ at: "commit:cmt_1", unknown: true }).success).toBe(false);
     expect(ListFilesQuery.parse({ prefix: "docs/", delimiter: "/" })).toMatchObject({
       prefix: "docs/",
       delimiter: "/",

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -306,8 +306,18 @@ export const CreateCommitBody = z
     message,
     meta: commitMeta,
     expectedLastChangeId: nonNegativeInteger.optional(),
+    expectedLastChangePrefix: z.string().optional(),
   })
-  .superRefine(entryListRefinement);
+  .superRefine(entryListRefinement)
+  .superRefine((value, context) => {
+    if (value.expectedLastChangePrefix !== undefined && value.expectedLastChangeId === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
+  });
 export const RevertCommitBody = z.strictObject({ author, message, meta: commitMeta });
 export const ListCommitsQuery = z.strictObject({
   limit,
@@ -317,9 +327,14 @@ export const ListCommitsQuery = z.strictObject({
 export const CommitDiffQuery = z.strictObject({
   context: optionalQueryInteger(0),
   path: entryPath.optional(),
+  from: z
+    .string()
+    .regex(/^commit:.+$/)
+    .optional(),
+  prefix: z.string().optional(),
 });
 export const SnapshotQuery = z.strictObject({
-  at: z.string().regex(/^commit:.+$/),
+  at: z.string().regex(/^(commit:.+|change:(0|[1-9][0-9]*))$/),
   prefix: z.string().optional(),
   delimiter: z.string().optional(),
   includeDeleted: z.preprocess(
@@ -329,6 +344,21 @@ export const SnapshotQuery = z.strictObject({
   limit,
   after: z.string().optional(),
 });
+
+export type SnapshotSelector =
+  { kind: "commit"; commitId: string } | { kind: "change"; changeId: number };
+
+export function parseSnapshotSelector(at: string): SnapshotSelector | null {
+  const match = /^(commit:.+|change:(0|[1-9][0-9]*))$/.exec(at);
+  if (match === null) return null;
+
+  if (at.startsWith("change:")) {
+    const changeId = Number(at.slice("change:".length));
+    return Number.isSafeInteger(changeId) ? { kind: "change", changeId } : null;
+  }
+
+  return { kind: "commit", commitId: at.slice("commit:".length) };
+}
 
 const changeSetCommon = { path: entryPath, baseVersion: commitExpectedVersion };
 export const ChangeSetEntryInput = z.union([
@@ -366,8 +396,18 @@ export const CreateChangeSetBody = z
     meta: commitMeta,
     expiresAt: z.iso.datetime().optional(),
     expectedLastChangeId: nonNegativeInteger.optional(),
+    expectedLastChangePrefix: z.string().optional(),
   })
-  .superRefine(entryListRefinement);
+  .superRefine(entryListRefinement)
+  .superRefine((value, context) => {
+    if (value.expectedLastChangePrefix !== undefined && value.expectedLastChangeId === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["expectedLastChangePrefix"],
+        message: "expectedLastChangePrefix requires expectedLastChangeId",
+      });
+    }
+  });
 export const ApproveChangeSetBody = z.strictObject({ author, message });
 export const RejectChangeSetBody = z.strictObject({
   reason: boundedString(MAX_MESSAGE_BYTES).optional(),

--- a/scripts/probe-commit-batch.test.mjs
+++ b/scripts/probe-commit-batch.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { describe, it } from "node:test";
+import { resolve } from "node:path";
+
+const REPOSITORY_ROOT = resolve(import.meta.dirname, "..");
+const SCRIPT = resolve(REPOSITORY_ROOT, "workers/stash/scripts/probe-commit-batch.mjs");
+
+async function runProbe(environment) {
+  const childEnvironment = {
+    PATH: process.env.PATH,
+    ...environment,
+  };
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(process.execPath, [SCRIPT], {
+      cwd: REPOSITORY_ROOT,
+      env: childEnvironment,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", rejectPromise);
+    child.once("close", (code, signal) => resolvePromise({ code, signal, stderr, stdout }));
+  });
+}
+
+describe("commit-batch probe validation", () => {
+  for (const { name, environment, expectedError } of [
+    {
+      name: "an unsupported query limit of 100",
+      environment: { COMMIT_BATCH_PROBE_QUERY_LIMIT: "100" },
+      expectedError: /COMMIT_BATCH_PROBE_QUERY_LIMIT must be 50, 1000, or omitted/u,
+    },
+    {
+      name: "an unsupported query limit of 49",
+      environment: { COMMIT_BATCH_PROBE_QUERY_LIMIT: "49" },
+      expectedError: /COMMIT_BATCH_PROBE_QUERY_LIMIT must be 50, 1000, or omitted/u,
+    },
+    {
+      name: "a privileged port",
+      environment: { COMMIT_BATCH_PROBE_PORT: "80" },
+      expectedError: /COMMIT_BATCH_PROBE_PORT must be a safe, non-privileged TCP port/u,
+    },
+    {
+      name: "a non-numeric port",
+      environment: { COMMIT_BATCH_PROBE_PORT: "notanumber" },
+      expectedError: /COMMIT_BATCH_PROBE_PORT must be a safe, non-privileged TCP port/u,
+    },
+    {
+      name: "remote mode without Cloudflare credentials",
+      environment: { COMMIT_BATCH_PROBE_REMOTE: "1" },
+      expectedError: /Remote mode requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN/u,
+    },
+  ]) {
+    it(`rejects ${name} before starting a probe Worker`, async () => {
+      const result = await runProbe(environment);
+
+      assert.notEqual(result.code, 0);
+      assert.equal(result.signal, null);
+      assert.equal(result.stdout, "");
+      assert.match(result.stderr, expectedError);
+    });
+  }
+});

--- a/workers/stash/migrations/0012_gc_content_kind.sql
+++ b/workers/stash/migrations/0012_gc_content_kind.sql
@@ -1,0 +1,31 @@
+DROP TABLE gc_runs;
+DROP TABLE gc_jobs;
+
+CREATE TABLE gc_jobs (
+  kind TEXT PRIMARY KEY CHECK (kind IN ('r2-orphans', 'ledger', 'content')),
+  next_cursor TEXT,
+  lease_owner TEXT,
+  lease_generation INTEGER NOT NULL DEFAULT 0,
+  lease_until INTEGER,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO gc_jobs (kind, updated_at)
+VALUES ('r2-orphans', 0), ('ledger', 0), ('content', 0);
+
+CREATE TABLE gc_runs (
+  id TEXT PRIMARY KEY,
+  job_kind TEXT NOT NULL REFERENCES gc_jobs(kind),
+  lease_generation INTEGER NOT NULL,
+  dry_run INTEGER NOT NULL DEFAULT 0,
+  input_cursor TEXT,
+  next_cursor TEXT,
+  scanned INTEGER NOT NULL DEFAULT 0,
+  eligible INTEGER NOT NULL DEFAULT 0,
+  deleted INTEGER NOT NULL DEFAULT 0,
+  error TEXT,
+  started_at INTEGER NOT NULL,
+  finished_at INTEGER
+);
+CREATE INDEX gc_runs_job_started ON gc_runs (job_kind, started_at DESC, id DESC);
+CREATE INDEX versions_stash_blob ON versions (stash_name, blob_hash);
+CREATE INDEX change_set_entries_stash_blob ON change_set_entries (stash_name, blob_hash) WHERE blob_hash IS NOT NULL;

--- a/workers/stash/src/d1/reads.ts
+++ b/workers/stash/src/d1/reads.ts
@@ -10,7 +10,8 @@ import {
   type JsonValue,
   type Representation,
   type VersionKind,
-  validatePath,
+  pathPrefixRange,
+  type PathPrefixRange,
 } from "@takazudo/zudo-history-stash-core";
 import { parseBinarySettings } from "../binary-config.js";
 import type { Env } from "../env.js";
@@ -227,10 +228,7 @@ function validateString(value: string, name: string): string {
   return value;
 }
 
-interface PathRange {
-  lo: string | null;
-  hi: string | null;
-}
+type PathRange = PathPrefixRange | { lo: null; hi: null };
 
 interface NormalizedListOptions {
   includeDeleted: boolean;
@@ -241,12 +239,10 @@ interface NormalizedListOptions {
 }
 
 function normalizePrefix(value: string | undefined): PathRange {
-  if (value === undefined) return { lo: null, hi: null };
-  const prefix = validateString(value, "prefix");
-  const path = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
-  const result = validatePath(path);
+  const prefix = value === undefined ? undefined : validateString(value, "prefix");
+  const result = pathPrefixRange(prefix);
   if (!result.ok) throw new StashError(result.error, result.message);
-  return { lo: `${path}/`, hi: `${path}0` };
+  return result.range ?? { lo: null, hi: null };
 }
 
 function normalizeListOptions(options: ListFilesOptions): NormalizedListOptions {

--- a/workers/stash/test/migrations.test.ts
+++ b/workers/stash/test/migrations.test.ts
@@ -24,12 +24,21 @@ const appendOnlyMutationPatterns = [
   ["DELETE FROM versions", /\bDELETE\s+FROM\s+versions\b/i],
   ["DELETE FROM files", /\bDELETE\s+FROM\s+files\b/i],
   ["DELETE FROM blobs", /\bDELETE\s+FROM\s+blobs\b/i],
+  ["DELETE FROM byte_blobs", /\bDELETE\s+FROM\s+byte_blobs\b/i],
 ] as const;
 
-function assertAppendOnlyHygiene(sources: readonly string[]): void {
-  const source = sources.join("\n");
+const CONTENT_SWEEP_MODULE = "../src/d1/sql/gc.ts";
+const CONTENT_SWEEP_EXEMPT = new Set(["DELETE FROM blobs", "DELETE FROM byte_blobs"]);
+
+function assertAppendOnlyHygiene(sources: readonly (readonly [string, string])[]): void {
   const violations = appendOnlyMutationPatterns
-    .filter(([, pattern]) => pattern.test(source))
+    .filter(([name, pattern]) =>
+      sources.some(
+        ([path, source]) =>
+          pattern.test(source) &&
+          !(path.endsWith(CONTENT_SWEEP_MODULE) && CONTENT_SWEEP_EXEMPT.has(name)),
+      ),
+    )
     .map(([name]) => name);
   if (violations.length > 0) {
     throw new Error(`Append-only mutation guard failed: ${violations.join(", ")}`);
@@ -85,6 +94,7 @@ describe("D1 migrations", () => {
       name: string;
     }>();
     expect(versionIndexes.results.map(({ name }) => name)).toContain("versions_stash_commit");
+    expect(versionIndexes.results.map(({ name }) => name)).toContain("versions_stash_blob");
     const versionColumns = await env.DB.prepare("PRAGMA table_info(versions)").all<{
       name: string;
       notnull: number;
@@ -105,6 +115,7 @@ describe("D1 migrations", () => {
       name: string;
     }>();
     expect(entryIndexes.results.map(({ name }) => name)).toContain("change_set_entries_stash_path");
+    expect(entryIndexes.results.map(({ name }) => name)).toContain("change_set_entries_stash_blob");
 
     await expect(env.DB.prepare("SELECT 1 FROM proposals").first()).rejects.toThrow();
 
@@ -112,6 +123,14 @@ describe("D1 migrations", () => {
       "SELECT kind, next_cursor, lease_owner, lease_generation, lease_until, updated_at FROM gc_jobs ORDER BY kind",
     ).all();
     expect(jobs.results).toEqual([
+      {
+        kind: "content",
+        next_cursor: null,
+        lease_owner: null,
+        lease_generation: 0,
+        lease_until: null,
+        updated_at: 0,
+      },
       {
         kind: "ledger",
         next_cursor: null,
@@ -195,18 +214,50 @@ describe("D1 migrations", () => {
   });
 
   it("keeps append-only versions out of update and delete statements", () => {
-    assertAppendOnlyHygiene([...Object.values(migrationSources), ...Object.values(sourceModules)]);
+    assertAppendOnlyHygiene([
+      ...Object.entries(migrationSources),
+      ...Object.entries(sourceModules),
+    ]);
   });
 
   it("rejects forbidden append-only mutations while allowing cleanup tables", () => {
-    expect(() => assertAppendOnlyHygiene(["UPDATE versions SET message = 'rewritten'"])).toThrow(
-      "UPDATE versions",
-    );
-    expect(() => assertAppendOnlyHygiene(["DELETE FROM versions"])).toThrow("DELETE FROM versions");
-    expect(() => assertAppendOnlyHygiene(["DELETE FROM files"])).toThrow("DELETE FROM files");
-    expect(() => assertAppendOnlyHygiene(["DELETE FROM blobs"])).toThrow("DELETE FROM blobs");
     expect(() =>
-      assertAppendOnlyHygiene(["DELETE FROM idempotency", "DELETE FROM gc_runs"]),
+      assertAppendOnlyHygiene([["../src/x.ts", "UPDATE versions SET message = 'rewritten'"]]),
+    ).toThrow("UPDATE versions");
+    expect(() => assertAppendOnlyHygiene([["../src/x.ts", "DELETE FROM versions"]])).toThrow(
+      "DELETE FROM versions",
+    );
+    expect(() => assertAppendOnlyHygiene([["../src/x.ts", "DELETE FROM files"]])).toThrow(
+      "DELETE FROM files",
+    );
+    expect(() => assertAppendOnlyHygiene([["../src/x.ts", "DELETE FROM blobs"]])).toThrow(
+      "DELETE FROM blobs",
+    );
+    expect(() => assertAppendOnlyHygiene([["../src/x.ts", "DELETE FROM byte_blobs"]])).toThrow(
+      "DELETE FROM byte_blobs",
+    );
+    expect(() =>
+      assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM blobs"]]),
+    ).not.toThrow();
+    expect(() =>
+      assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM byte_blobs"]]),
+    ).not.toThrow();
+    expect(() => assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM versions"]])).toThrow(
+      "DELETE FROM versions",
+    );
+    expect(() => assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM files"]])).toThrow(
+      "DELETE FROM files",
+    );
+    expect(() =>
+      assertAppendOnlyHygiene([
+        [CONTENT_SWEEP_MODULE, "UPDATE versions SET message = 'rewritten'"],
+      ]),
+    ).toThrow("UPDATE versions");
+    expect(() =>
+      assertAppendOnlyHygiene([
+        ["../src/x.ts", "DELETE FROM idempotency"],
+        ["../src/x.ts", "DELETE FROM gc_runs"],
+      ]),
     ).not.toThrow();
   });
 
@@ -372,7 +423,7 @@ describe("D1 migrations", () => {
     });
   });
 
-  it("resets GC runs while retaining both seeded job rows", async () => {
+  it("resets GC runs while retaining all three seeded job rows", async () => {
     await env.DB.prepare(
       `UPDATE gc_jobs
          SET next_cursor = 'cursor', lease_owner = 'owner', lease_generation = 7,
@@ -391,6 +442,14 @@ describe("D1 migrations", () => {
       "SELECT kind, next_cursor, lease_owner, lease_generation, lease_until, updated_at FROM gc_jobs ORDER BY kind",
     ).all();
     expect(jobs.results).toEqual([
+      {
+        kind: "content",
+        next_cursor: null,
+        lease_owner: null,
+        lease_generation: 0,
+        lease_until: null,
+        updated_at: 0,
+      },
       {
         kind: "ledger",
         next_cursor: null,

--- a/workers/stash/wrangler.probe.local.example.toml
+++ b/workers/stash/wrangler.probe.local.example.toml
@@ -1,0 +1,10 @@
+# Copy this file to wrangler.probe.local.toml (gitignored) and paste a DISPOSABLE D1 id.
+# Never point it at production.
+name = "zudo-history-stash-commit-batch-probe"
+main = "src/index.ts"
+compatibility_date = "2026-08-25"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "zudo-history-stash-commit-batch-probe"
+database_id = "REPLACE_ME"


### PR DESCRIPTION
Part of #247.
Topic: #253.

## Summary

Implements the scoped topic described in #253 and records its reviewed integration into `base/pre-release-consolidation`.

## Verification

- Topic acceptance checks passed.
- Blocking foreground `codex-review` completed before integration.
- The topic worktree was clean at its verified completion gate.

