### PR TITLE
Replace fictional npm install instructions everywhere, including the three package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,17 @@ capacity and at most 10,000 parts; 1 GiB is a correctness ceiling, not a perform
 
 ## Consumer guide
 
-Install the isomorphic client in a Node.js application, browser bundle, or Worker:
+The packages are not published to npm yet. Clone this repository and build them from the workspace
+root:
 
 ```bash
-pnpm add @takazudo/zudo-history-stash
+pnpm install
+pnpm build:libs
 ```
+
+Then depend on the workspace package at `packages/client`. For use outside the workspace, run
+`pnpm pack` in `packages/client` and install the generated tarball. The isomorphic client works in
+a Node.js application, browser bundle, or Worker.
 
 The client returns typed business outcomes and keeps compare-and-set versions explicit:
 

--- a/doc/src/content/docs-ja/getting-started/install.mdx
+++ b/doc/src/content/docs-ja/getting-started/install.mdx
@@ -5,9 +5,19 @@ sidebar_position: 2
 category: getting-started
 ---
 
-`pnpm add @takazudo/zudo-history-stash` で isomorphic なクライアントパッケージを追加します。
-パッケージルートからのみ import してください。公開クライアントと型は、Node.js、ブラウザバンドル、
-Cloudflare Workers で動作します。現在の Node.js、pnpm、パッケージの要件については、
+クライアントパッケージはまだ npm に公開されていません。このリポジトリをクローンし、
+ワークスペースのルートでパッケージをビルドしてください。
+
+```bash
+pnpm install
+pnpm build:libs
+```
+
+その後、ワークスペース内では `packages/client` のパッケージを依存関係として指定します。ワークスペース外で
+利用する場合は、`pnpm pack` を `packages/client` で実行し、生成された tarball ファイルをインストールしてください。
+
+インポートはパッケージルートからのみ行ってください。公開クライアントと型は、Node.js、
+ブラウザバンドル、Cloudflare Workers で動作します。現在の Node.js、pnpm、パッケージの要件については、
 [バージョン](../reference/versions.mdx)を参照してください。
 
 ランタイムが対応していても、すべての認証情報をあらゆるランタイムに置いて安全というわけでは

--- a/doc/src/content/docs-ja/reference/versions.mdx
+++ b/doc/src/content/docs-ja/reference/versions.mdx
@@ -7,6 +7,8 @@ category: reference
 
 次の値は、サイトのビルド時にリポジトリのマニフェストと OpenAPI ドキュメントから直接取得します。
 
+パッケージはまだ npm に公開されておらず、`0.0.0` は最初のリリース時に置き換わるプレリリース用の仮バージョンです。
+
 - Core パッケージ: <VersionValue name="core" />
 - Client パッケージ: <VersionValue name="client" />
 - UI パッケージ: <VersionValue name="ui" />

--- a/doc/src/content/docs/getting-started/install.mdx
+++ b/doc/src/content/docs/getting-started/install.mdx
@@ -5,10 +5,20 @@ sidebar_position: 2
 category: getting-started
 ---
 
-Add the isomorphic client package with `pnpm add @takazudo/zudo-history-stash`. Import only from the
-package root; its public client and types work in Node.js, browser bundles, and Cloudflare Workers.
-See [versions](../reference/versions.mdx) for the repository's current Node.js, pnpm, and package
-requirements.
+The client package is not published to npm yet. Clone this repository and build the workspace
+packages from the workspace root:
+
+```bash
+pnpm install
+pnpm build:libs
+```
+
+Then depend on the workspace package at `packages/client`. To use the client outside the workspace,
+run `pnpm pack` in `packages/client` and install the generated tarball.
+
+Import only from the package root; its public client and types work in Node.js, browser bundles,
+and Cloudflare Workers. See [versions](../reference/versions.mdx) for the repository's current
+Node.js, pnpm, and package requirements.
 
 Runtime support does not make every credential safe in every runtime. Keep the administrator token
 and stash-scoped write tokens in a trusted server or Worker secret. A browser-direct client should

--- a/doc/src/content/docs/reference/versions.mdx
+++ b/doc/src/content/docs/reference/versions.mdx
@@ -8,6 +8,9 @@ category: reference
 These values come directly from repository manifests and the OpenAPI document during the site
 build:
 
+The packages are not yet published to npm; `0.0.0` is a pre-release placeholder that the first
+release will replace.
+
 - Core package: <VersionValue name="core" />
 - Client package: <VersionValue name="client" />
 - UI package: <VersionValue name="ui" />

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -3,9 +3,10 @@
 Typed, isomorphic HTTP client for the zudo-history-stash API. It runs in Node.js, browsers, and
 Cloudflare Workers and returns typed business outcomes for API validation and conflict responses.
 
-```bash
-pnpm add @takazudo/zudo-history-stash
-```
+This package is not published to npm yet. Clone the repository and build the workspace packages
+from the workspace root with `pnpm install` followed by `pnpm build:libs`. Then depend on the
+workspace package at `packages/client`, or run `pnpm pack` in that directory and install the
+generated tarball.
 
 ```ts
 import { createStashClient, isCommitConflict } from "@takazudo/zudo-history-stash";

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,9 +3,10 @@
 Runtime-agnostic types, schemas, validators, hashes, limits, and diff helpers shared by the
 zudo-history-stash packages.
 
-```bash
-pnpm add @takazudo/zudo-history-stash-core
-```
+This package is not published to npm yet. Clone the repository and build the workspace packages
+from the workspace root with `pnpm install` followed by `pnpm build:libs`. Then depend on the
+workspace package at `packages/core`, or run `pnpm pack` in that directory and install the
+generated tarball.
 
 See the [repository documentation](https://github.com/Takazudo/zudo-history-stash/tree/main/docs)
 for the API reference and architecture guides.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -13,10 +13,11 @@ badge count. The default detail routes are `/s/:stash/commits/:id` and
 
 ## Install
 
-```bash
-pnpm add @takazudo/zudo-history-stash-ui @takazudo/zudo-history-stash \
-  @takazudo/zudo-history-stash-core react react-dom
-```
+This package is not published to npm yet. Clone the repository and build the workspace packages
+from the workspace root with `pnpm install` followed by `pnpm build:libs`. Then depend on the
+workspace package at `packages/ui`. For use outside the workspace, run `pnpm pack` in
+`packages/core`, `packages/client`, and `packages/ui`, then install the generated tarballs together
+with `react` and `react-dom`.
 
 Import the component stylesheet once in the host entry point, after the host's design tokens:
 


### PR DESCRIPTION
Part of #247.
Topic: #255.

## Summary

Implements the scoped topic described in #255 and records its reviewed integration into `base/pre-release-consolidation`.

## Verification

- Topic acceptance checks passed.
- Blocking foreground `codex-review` completed before integration.
- The topic worktree was clean at its verified completion gate.

