### PR TITLE
ci: gate documentation tooling tests

### DIFF
--- a/.github/workflows/doc-checks.yml
+++ b/.github/workflows/doc-checks.yml
@@ -13,6 +13,8 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".mdx-formatter.json"
+      - ".mdx-formatter-ignore"
+      - "lefthook.yml"
       - ".github/workflows/doc-checks.yml"
     types: [opened, synchronize, reopened]
   push:
@@ -26,6 +28,8 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".mdx-formatter.json"
+      - ".mdx-formatter-ignore"
+      - "lefthook.yml"
       - ".github/workflows/doc-checks.yml"
 
 permissions:
@@ -65,3 +69,6 @@ jobs:
 
       - name: Run documentation aggregate
         run: pnpm b4push:doc
+
+      - name: Run documentation tooling tests
+        run: pnpm --filter zudo-history-stash-doc test:tooling

--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -12,6 +12,8 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".mdx-formatter.json"
+      - ".mdx-formatter-ignore"
+      - "lefthook.yml"
       - ".github/workflows/doc-deploy.yml"
   workflow_dispatch:
 

--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -13,6 +13,8 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".mdx-formatter.json"
+      - ".mdx-formatter-ignore"
+      - "lefthook.yml"
       - ".github/workflows/doc-preview.yml"
     types: [opened, synchronize, reopened]
 

--- a/.mdx-formatter-ignore
+++ b/.mdx-formatter-ignore
@@ -1,0 +1,17 @@
+# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; integration.test.mjs keeps both files in lockstep.
+node_modules/**
+dist/**
+**/dist/**
+worktrees/**
+__inbox/**
+.playwright-cli/**
+_temp-resource/**
+doc/src/content/docs/claude*/**
+doc/src/content/docs-ja/claude*/**
+doc/dist/**
+doc/.zfb*/**
+doc/.zudo-doc/**
+doc/.wrangler/**
+doc/.claude/skills/zudo-history-stash-wisdom/**
+doc/.codex/skills/zudo-history-stash-wisdom/**
+packages/*/CHANGELOG.md

--- a/.mdx-formatter-ignore
+++ b/.mdx-formatter-ignore
@@ -1,4 +1,4 @@
-# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; integration.test.mjs keeps both files in lockstep.
+# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; doc/scripts/integration.test.mjs keeps both files in lockstep.
 node_modules/**
 dist/**
 **/dist/**

--- a/ZUDO_DEPS_PINS.md
+++ b/ZUDO_DEPS_PINS.md
@@ -12,4 +12,4 @@ Updated by /dev-bump-zudo-deps on every sync — keep `pinned:` accurate.
 - track: releases
 - pinned: 7ca73f197021961603c22042748c23d9ce9d6c50 (v5.13.1)
 - updated: 2026-08-29
-- notes: doc/.template-drift-allowlist records intentional scaffold differences; preserve every listed adaptation during sync
+- notes: doc/.template-drift-allowlist records intentional scaffold differences; preserve every listed adaptation during sync; the current create-zudo-doc generator still emits @takazudo/zdtp at 0.4.12, so it remains at 0.4.12 until a create-zudo-doc release re-pins it

--- a/doc/scripts/check-changelog-drift.test.mjs
+++ b/doc/scripts/check-changelog-drift.test.mjs
@@ -929,6 +929,10 @@ Released: 2026-08-25
       join(fixture, ".mdx-formatter.json"),
       `${JSON.stringify(formatterConfig, null, 2)}\n`,
     );
+    await writeFile(
+      join(fixture, ".mdx-formatter-ignore"),
+      await readFile(join(REPOSITORY_ROOT, ".mdx-formatter-ignore")),
+    );
     await writeFile(join(fixture, "package.json"), '{"name":"formatter-fixture","private":true}\n');
     await symlink(join(REPOSITORY_ROOT, "node_modules"), join(fixture, "node_modules"), "dir");
 
@@ -954,12 +958,39 @@ Released: 2026-08-25
     assert.notEqual(await readFile(enSource, "utf8"), unformattedHuman);
     assert.notEqual(await readFile(jaSource, "utf8"), unformattedHuman);
 
-    const lefthook = run("pnpm", ["exec", "mdx-formatter", "--write", ...generatedPaths], {
+    // lefthook.yml is the source of truth for this command shape.
+    const lefthook = run(
+      "pnpm",
+      [
+        "exec",
+        "mdx-formatter",
+        "--write",
+        "--ignore-path",
+        ".mdx-formatter-ignore",
+        ...generatedPaths,
+      ],
+      {
+        cwd: fixture,
+        env: { PATH: `${join(REPOSITORY_ROOT, "node_modules/.bin")}:${process.env.PATH}` },
+      },
+    );
+    assert.equal(lefthook.status, 0, `${lefthook.stdout}\n${lefthook.stderr}`);
+    await assertOutputsEqual(projectRoot, snapshots);
+
+    for (const entry of CHANGELOGS) {
+      await writeFile(outputPath(projectRoot, entry), snapshots.get(entry.slug));
+    }
+    const guardRemoved = run("pnpm", ["exec", "mdx-formatter", "--write", ...generatedPaths], {
       cwd: fixture,
       env: { PATH: `${join(REPOSITORY_ROOT, "node_modules/.bin")}:${process.env.PATH}` },
     });
-    assert.equal(lefthook.status, 0, `${lefthook.stdout}\n${lefthook.stderr}`);
-    await assertOutputsEqual(projectRoot, snapshots);
+    assert.equal(guardRemoved.status, 0, `${guardRemoved.stdout}\n${guardRemoved.stderr}`);
+    for (const entry of CHANGELOGS) {
+      assert.notDeepEqual(
+        await readFile(outputPath(projectRoot, entry)),
+        snapshots.get(entry.slug),
+      );
+    }
 
     formatterConfig.exclude = formatterConfig.exclude.filter(
       (pattern) => pattern !== "packages/*/CHANGELOG.md",
@@ -971,11 +1002,12 @@ Released: 2026-08-25
     for (const entry of CHANGELOGS) {
       await writeFile(outputPath(projectRoot, entry), snapshots.get(entry.slug));
     }
-    const red = run("pnpm", ["exec", "mdx-formatter", "--write", ...generatedPaths], {
-      cwd: fixture,
-      env: { PATH: `${join(REPOSITORY_ROOT, "node_modules/.bin")}:${process.env.PATH}` },
-    });
-    assert.equal(red.status, 0, `${red.stdout}\n${red.stderr}`);
+    const excludeRemoved = run(
+      formatter,
+      ["--write", "--config", join(fixture, ".mdx-formatter.json"), "**/*.{md,mdx}"],
+      { cwd: fixture },
+    );
+    assert.equal(excludeRemoved.status, 0, excludeRemoved.stderr);
     for (const entry of CHANGELOGS) {
       assert.notDeepEqual(
         await readFile(outputPath(projectRoot, entry)),

--- a/doc/scripts/integration.test.mjs
+++ b/doc/scripts/integration.test.mjs
@@ -91,7 +91,16 @@ test("root recursion, aliases, formatter ownership, CI parity, and skill naming 
   ]) {
     assert.ok(formatter.exclude.includes(exclusion), `missing formatter exclusion ${exclusion}`);
   }
+  const formatterIgnore = (await readFile(join(repositoryRoot, ".mdx-formatter-ignore"), "utf8"))
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "" && !line.trimStart().startsWith("#"));
+  assert.deepEqual(formatterIgnore, formatter.exclude);
   const lefthook = await readFile(join(repositoryRoot, "lefthook.yml"), "utf8");
+  assert.ok(
+    lefthook.includes(
+      "pnpm exec mdx-formatter --write --ignore-path .mdx-formatter-ignore {staged_files}",
+    ),
+  );
   assert.match(lefthook, /stage_fixed:\s*true/);
   assert.doesNotMatch(lefthook, /git add/);
 

--- a/doc/scripts/integration.test.mjs
+++ b/doc/scripts/integration.test.mjs
@@ -63,6 +63,7 @@ test("root recursion, aliases, formatter ownership, CI parity, and skill naming 
     docManifest.scripts["check:template-drift"],
     "node scripts/check-template-drift.mjs",
   );
+  assert.equal(docManifest.scripts["test:tooling"], docManifest.scripts.test);
 
   const prettierIgnore = await readFile(join(repositoryRoot, ".prettierignore"), "utf8");
   assert.match(prettierIgnore, /^\*\*\/\*\.md$/m);

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,5 +8,5 @@ pre-commit:
   commands:
     format-mdx:
       glob: "*.{md,mdx}"
-      run: pnpm exec mdx-formatter --write {staged_files}
+      run: pnpm exec mdx-formatter --write --ignore-path .mdx-formatter-ignore {staged_files}
       stage_fixed: true

--- a/scripts/doc-workflows.test.mjs
+++ b/scripts/doc-workflows.test.mjs
@@ -19,6 +19,8 @@ const COMMON_PATHS = [
   "pnpm-lock.yaml",
   "pnpm-workspace.yaml",
   ".mdx-formatter.json",
+  ".mdx-formatter-ignore",
+  "lefthook.yml",
 ];
 const INTERNAL_AGGREGATE_COMMANDS = [
   "build:libs",
@@ -515,6 +517,7 @@ function assertChecks(source, pins) {
       "Setup Node.js",
       "Install dependencies",
       "Run documentation aggregate",
+      "Run documentation tooling tests",
     ],
   );
   assertSecretAllowlist(source, {});


### PR DESCRIPTION
Parent: #334

Sub-issue: #341

## Summary

- run the documentation tooling suite in the doc-checks workflow
- trigger doc workflows for `.mdx-formatter-ignore` and `lefthook.yml`
- pin workflow paths, step order, and `test:tooling` script parity

## Test plan

- `node --test scripts/doc-workflows.test.mjs`
- documentation integration contract
- manager verification: doc tooling suite 276/276 after `pnpm build:libs`

## NOT tested

- live Cloudflare deployment and browser preview lanes
