### PR TITLE
test: re-arm changelog formatter ownership controls

### DIFF
--- a/.mdx-formatter-ignore
+++ b/.mdx-formatter-ignore
@@ -1,0 +1,17 @@
+# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; integration.test.mjs keeps both files in lockstep.
+node_modules/**
+dist/**
+**/dist/**
+worktrees/**
+__inbox/**
+.playwright-cli/**
+_temp-resource/**
+doc/src/content/docs/claude*/**
+doc/src/content/docs-ja/claude*/**
+doc/dist/**
+doc/.zfb*/**
+doc/.zudo-doc/**
+doc/.wrangler/**
+doc/.claude/skills/zudo-history-stash-wisdom/**
+doc/.codex/skills/zudo-history-stash-wisdom/**
+packages/*/CHANGELOG.md

--- a/.mdx-formatter-ignore
+++ b/.mdx-formatter-ignore
@@ -1,4 +1,4 @@
-# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; integration.test.mjs keeps both files in lockstep.
+# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; doc/scripts/integration.test.mjs keeps both files in lockstep.
 node_modules/**
 dist/**
 **/dist/**

--- a/doc/scripts/check-changelog-drift.test.mjs
+++ b/doc/scripts/check-changelog-drift.test.mjs
@@ -929,6 +929,10 @@ Released: 2026-08-25
       join(fixture, ".mdx-formatter.json"),
       `${JSON.stringify(formatterConfig, null, 2)}\n`,
     );
+    await writeFile(
+      join(fixture, ".mdx-formatter-ignore"),
+      await readFile(join(REPOSITORY_ROOT, ".mdx-formatter-ignore")),
+    );
     await writeFile(join(fixture, "package.json"), '{"name":"formatter-fixture","private":true}\n');
     await symlink(join(REPOSITORY_ROOT, "node_modules"), join(fixture, "node_modules"), "dir");
 
@@ -954,12 +958,39 @@ Released: 2026-08-25
     assert.notEqual(await readFile(enSource, "utf8"), unformattedHuman);
     assert.notEqual(await readFile(jaSource, "utf8"), unformattedHuman);
 
-    const lefthook = run("pnpm", ["exec", "mdx-formatter", "--write", ...generatedPaths], {
+    // lefthook.yml is the source of truth for this command shape.
+    const lefthook = run(
+      "pnpm",
+      [
+        "exec",
+        "mdx-formatter",
+        "--write",
+        "--ignore-path",
+        ".mdx-formatter-ignore",
+        ...generatedPaths,
+      ],
+      {
+        cwd: fixture,
+        env: { PATH: `${join(REPOSITORY_ROOT, "node_modules/.bin")}:${process.env.PATH}` },
+      },
+    );
+    assert.equal(lefthook.status, 0, `${lefthook.stdout}\n${lefthook.stderr}`);
+    await assertOutputsEqual(projectRoot, snapshots);
+
+    for (const entry of CHANGELOGS) {
+      await writeFile(outputPath(projectRoot, entry), snapshots.get(entry.slug));
+    }
+    const guardRemoved = run("pnpm", ["exec", "mdx-formatter", "--write", ...generatedPaths], {
       cwd: fixture,
       env: { PATH: `${join(REPOSITORY_ROOT, "node_modules/.bin")}:${process.env.PATH}` },
     });
-    assert.equal(lefthook.status, 0, `${lefthook.stdout}\n${lefthook.stderr}`);
-    await assertOutputsEqual(projectRoot, snapshots);
+    assert.equal(guardRemoved.status, 0, `${guardRemoved.stdout}\n${guardRemoved.stderr}`);
+    for (const entry of CHANGELOGS) {
+      assert.notDeepEqual(
+        await readFile(outputPath(projectRoot, entry)),
+        snapshots.get(entry.slug),
+      );
+    }
 
     formatterConfig.exclude = formatterConfig.exclude.filter(
       (pattern) => pattern !== "packages/*/CHANGELOG.md",
@@ -971,11 +1002,12 @@ Released: 2026-08-25
     for (const entry of CHANGELOGS) {
       await writeFile(outputPath(projectRoot, entry), snapshots.get(entry.slug));
     }
-    const red = run("pnpm", ["exec", "mdx-formatter", "--write", ...generatedPaths], {
-      cwd: fixture,
-      env: { PATH: `${join(REPOSITORY_ROOT, "node_modules/.bin")}:${process.env.PATH}` },
-    });
-    assert.equal(red.status, 0, `${red.stdout}\n${red.stderr}`);
+    const excludeRemoved = run(
+      formatter,
+      ["--write", "--config", join(fixture, ".mdx-formatter.json"), "**/*.{md,mdx}"],
+      { cwd: fixture },
+    );
+    assert.equal(excludeRemoved.status, 0, excludeRemoved.stderr);
     for (const entry of CHANGELOGS) {
       assert.notDeepEqual(
         await readFile(outputPath(projectRoot, entry)),

--- a/doc/scripts/integration.test.mjs
+++ b/doc/scripts/integration.test.mjs
@@ -91,7 +91,16 @@ test("root recursion, aliases, formatter ownership, CI parity, and skill naming 
   ]) {
     assert.ok(formatter.exclude.includes(exclusion), `missing formatter exclusion ${exclusion}`);
   }
+  const formatterIgnore = (await readFile(join(repositoryRoot, ".mdx-formatter-ignore"), "utf8"))
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "" && !line.trimStart().startsWith("#"));
+  assert.deepEqual(formatterIgnore, formatter.exclude);
   const lefthook = await readFile(join(repositoryRoot, "lefthook.yml"), "utf8");
+  assert.ok(
+    lefthook.includes(
+      "pnpm exec mdx-formatter --write --ignore-path .mdx-formatter-ignore {staged_files}",
+    ),
+  );
   assert.match(lefthook, /stage_fixed:\s*true/);
   assert.doesNotMatch(lefthook, /git add/);
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,5 +8,5 @@ pre-commit:
   commands:
     format-mdx:
       glob: "*.{md,mdx}"
-      run: pnpm exec mdx-formatter --write {staged_files}
+      run: pnpm exec mdx-formatter --write --ignore-path .mdx-formatter-ignore {staged_files}
       stage_fixed: true


### PR DESCRIPTION
Parent: #334

Sub-issue: #338

## Summary

- model the real guarded Lefthook command in the changelog ownership test
- replace the vacuous red control with independent guard-removed and exclude-removed controls

## Test plan

- focused issue #293 repro test
- full `check-changelog-drift.test.mjs` file: 47/47

## NOT tested

- browser, e2e, and deployment lanes (not applicable)
