### PR TITLE
fix: guard staged Markdown formatter exclusions

### DIFF
--- a/.mdx-formatter-ignore
+++ b/.mdx-formatter-ignore
@@ -1,0 +1,17 @@
+# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; integration.test.mjs keeps both files in lockstep.
+node_modules/**
+dist/**
+**/dist/**
+worktrees/**
+__inbox/**
+.playwright-cli/**
+_temp-resource/**
+doc/src/content/docs/claude*/**
+doc/src/content/docs-ja/claude*/**
+doc/dist/**
+doc/.zfb*/**
+doc/.zudo-doc/**
+doc/.wrangler/**
+doc/.claude/skills/zudo-history-stash-wisdom/**
+doc/.codex/skills/zudo-history-stash-wisdom/**
+packages/*/CHANGELOG.md

--- a/.mdx-formatter-ignore
+++ b/.mdx-formatter-ignore
@@ -1,4 +1,4 @@
-# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; integration.test.mjs keeps both files in lockstep.
+# mdx-formatter 1.3.0-next.4 skips .mdx-formatter.json excludes for literal paths, so the pre-commit hook uses this file; doc/scripts/integration.test.mjs keeps both files in lockstep.
 node_modules/**
 dist/**
 **/dist/**

--- a/doc/scripts/integration.test.mjs
+++ b/doc/scripts/integration.test.mjs
@@ -91,7 +91,16 @@ test("root recursion, aliases, formatter ownership, CI parity, and skill naming 
   ]) {
     assert.ok(formatter.exclude.includes(exclusion), `missing formatter exclusion ${exclusion}`);
   }
+  const formatterIgnore = (await readFile(join(repositoryRoot, ".mdx-formatter-ignore"), "utf8"))
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "" && !line.trimStart().startsWith("#"));
+  assert.deepEqual(formatterIgnore, formatter.exclude);
   const lefthook = await readFile(join(repositoryRoot, "lefthook.yml"), "utf8");
+  assert.ok(
+    lefthook.includes(
+      "pnpm exec mdx-formatter --write --ignore-path .mdx-formatter-ignore {staged_files}",
+    ),
+  );
   assert.match(lefthook, /stage_fixed:\s*true/);
   assert.doesNotMatch(lefthook, /git add/);
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,5 +8,5 @@ pre-commit:
   commands:
     format-mdx:
       glob: "*.{md,mdx}"
-      run: pnpm exec mdx-formatter --write {staged_files}
+      run: pnpm exec mdx-formatter --write --ignore-path .mdx-formatter-ignore {staged_files}
       stage_fixed: true


### PR DESCRIPTION
Parent: #334

Sub-issue: #335

## Summary

- add a root `.mdx-formatter-ignore` mirror for literal staged paths
- pass it to the Lefthook formatter through `--ignore-path`
- pin ignore parity and the exact hook command in the integration contract

## Test plan

- `cd doc && node --test scripts/integration.test.mjs`
- guarded scratch control: generated changelog 33 bytes, human file 17 bytes
- unguarded control: generated changelog 34 bytes

## NOT tested

- browser, e2e, and deployment lanes (not applicable)
