### PR TITLE
[Revert Onto Head] add upload attribution migration

### DIFF
--- a/workers/stash/migrations/0014_upload_commit_attribution.sql
+++ b/workers/stash/migrations/0014_upload_commit_attribution.sql
@@ -1,0 +1,3 @@
+ALTER TABLE upload_sessions ADD COLUMN commit_author TEXT;
+ALTER TABLE upload_sessions ADD COLUMN commit_message TEXT;
+ALTER TABLE upload_sessions ADD COLUMN commit_meta_json TEXT;

--- a/workers/stash/src/d1/schema.ts
+++ b/workers/stash/src/d1/schema.ts
@@ -171,6 +171,9 @@ export interface UploadSessionRow {
   event_publish_owner: string | null;
   event_publish_until: number | null;
   event_origin: string | null;
+  commit_author: string | null;
+  commit_message: string | null;
+  commit_meta_json: string | null;
 }
 
 export interface UploadStagedBytesRow {
@@ -429,6 +432,9 @@ export const TABLE_COLUMNS = {
     "event_publish_owner",
     "event_publish_until",
     "event_origin",
+    "commit_author",
+    "commit_message",
+    "commit_meta_json",
   ],
   upload_staged_bytes: [
     "session_id",


### PR DESCRIPTION
Parent epic: #343

Issue: #345

## Summary

- add migration 0014 with nullable upload commit attribution columns
- keep `UploadSessionRow` and `TABLE_COLUMNS.upload_sessions` in exact migration order

## Tests

- migration tests: 11 passed
- upload-session store tests: 4 passed
- Worker typecheck and diff checks
