### PR TITLE
[Revert Onto Head] support reverting onto current heads

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -579,6 +579,9 @@ staged when a change set is created; binary review diffs report base/candidate h
 
 ### `POST /v1/stashes/:stash/commits/:id/revert`
 
+- **Request:** Optional `author`, `message`, and `meta` attribution; optional `onto` defaults to
+  `"commit"` and reverts each entry against the version written by the reverted commit, while
+  `"head"` deliberately overwrites later unrelated writes using each path's current head.
 - **Response:** `201 CommitResult`; replay includes `Idempotent-Replayed`.
 - **Errors:** `400 validation`, `401 unauthorized`, `403 scope`, `404 not-found`, `409 commit-conflict`, `413 payload-too-large`, `422 idempotency-key-reused`, `429 rate-limited`, `500 internal`.
 
@@ -784,8 +787,9 @@ staged when a change set is created; binary review diffs report base/candidate h
 
 - **Principal/capability:** `write`; administrator or a matching `write` token.
 - **Request:** JSON metadata with exact `size`, optional SHA-256 `hash`, `representation`,
-  `contentType`, expected-version CAS, and transfer preference; creation has its own
-  `Idempotency-Key` fingerprint.
+  `contentType`, expected-version CAS, transfer preference, and optional `author`, `message`, and
+  `meta` carried to the commit minted at finalize; creation has its own `Idempotency-Key`
+  fingerprint.
 - **Response:** `201` session with `Idempotent-Replayed`, chosen mode/tier, expiry, and generation.
 - **Errors:** `400 validation`, `400 invalid-path`, `401 unauthorized`, `403 scope`,
   `404 not-found`, `409 stale`, `413 payload-too-large`, `422 idempotency-key-reused`,
@@ -996,6 +1000,9 @@ Every file mutation is compare-and-set (CAS):
 2. Send that value as `expectedVersion`. Use `null` only when the path must not exist.
 3. On `409 stale`, inspect the root-level `current`, decide whether to recompute, and retry with a
    new operation. Do not blindly overwrite the winner.
+
+A revert with `onto: "head"` is the single deliberate, opt-in exception to “Do not blindly overwrite
+the winner.”
 
 `putLatest(stash, path, body)` performs the read and up to three bounded stale retries for simple
 last-head updates. Use explicit `files.put` when the consumer needs its own conflict policy.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7363,7 +7363,7 @@
     },
     "/v1/stashes/{stash}/commits/{id}/revert": {
       "post": {
-        "description": "Creates a new commit that reverses the named commit.\n\nwrite; administrator or a matching write stash token.",
+        "description": "Creates a new commit that reverses the named commit. The onto option defaults to \"commit\" (the strict behavior), deriving each entry's expectedVersion from the version the reverted commit itself wrote. Set onto to \"head\" as an opt-in mode to derive expectedVersion from the path's current head and deliberately overwrite later unrelated writes.\n\nwrite; administrator or a matching write stash token.",
         "operationId": "revertCommit",
         "parameters": [
           {
@@ -7429,6 +7429,11 @@
                       "type": "string"
                     },
                     "type": "object"
+                  },
+                  "onto": {
+                    "default": "commit",
+                    "enum": ["commit", "head"],
+                    "type": "string"
                   }
                 },
                 "type": "object"
@@ -10667,7 +10672,7 @@
     },
     "/v1/stashes/{stash}/uploads/{path}": {
       "post": {
-        "description": "Reserves declared exact content bytes and chooses single or multipart transfer plus D1 or R2 staging. Repeating the same idempotency fingerprint replays the session.\n\nwrite; administrator or a matching write stash token.\n\nThe path value contains unescaped `/`. OpenAPI 3.1 path templating does not permit this, so generated clients must not be assumed to work for this operation.",
+        "description": "Reserves declared exact content bytes and chooses single or multipart transfer plus D1 or R2 staging. Repeating the same idempotency fingerprint replays the session. Optional author, message, and meta are carried onto the commit minted when the upload is finalized.\n\nwrite; administrator or a matching write stash token.\n\nThe path value contains unescaped `/`. OpenAPI 3.1 path templating does not permit this, so generated clients must not be assumed to work for this operation.",
         "operationId": "createUploadSession",
         "parameters": [
           {
@@ -10718,6 +10723,9 @@
               "schema": {
                 "additionalProperties": false,
                 "properties": {
+                  "author": {
+                    "type": "string"
+                  },
                   "contentType": {
                     "type": "string"
                   },
@@ -10736,6 +10744,18 @@
                   "hash": {
                     "pattern": "^sha256-[0-9a-f]{64}$",
                     "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "meta": {
+                    "additionalProperties": {
+                      "description": "Any JSON value. The recursive z.json() validator is intentionally represented as an unconstrained schema."
+                    },
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "type": "object"
                   },
                   "mode": {
                     "default": "auto",

--- a/packages/core/src/openapi/contracts.ts
+++ b/packages/core/src/openapi/contracts.ts
@@ -422,7 +422,8 @@ export const ROUTE_CONTRACTS = {
   },
   revertCommit: {
     summary: "Revert a commit",
-    description: "Creates a new commit that reverses the named commit.",
+    description:
+      'Creates a new commit that reverses the named commit. The onto option defaults to "commit" (the strict behavior), deriving each entry\'s expectedVersion from the version the reverted commit itself wrote. Set onto to "head" as an opt-in mode to derive expectedVersion from the path\'s current head and deliberately overwrite later unrelated writes.',
     principalNote: "write; administrator or a matching write stash token.",
     body: RevertCommitBody,
     requestHeaders: ["Idempotency-Key", STASH_CLIENT_ID_HEADER],
@@ -875,7 +876,7 @@ export const ROUTE_CONTRACTS = {
   createUploadSession: {
     summary: "Create a raw upload session",
     description:
-      "Reserves declared exact content bytes and chooses single or multipart transfer plus D1 or R2 staging. Repeating the same idempotency fingerprint replays the session.",
+      "Reserves declared exact content bytes and chooses single or multipart transfer plus D1 or R2 staging. Repeating the same idempotency fingerprint replays the session. Optional author, message, and meta are carried onto the commit minted when the upload is finalized.",
     principalNote: "write; administrator or a matching write stash token.",
     body: CreateUploadSessionBody,
     requestHeaders: ["Idempotency-Key", STASH_CLIENT_ID_HEADER],

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { MAX_BODY_BYTES } from "./limits.js";
+import { MAX_BODY_BYTES, MAX_META_BYTES } from "./limits.js";
 import {
   ChangesQuery,
   ApproveChangeSetBody,
@@ -7,6 +7,7 @@ import {
   CommitDiffQuery,
   CreateChangeSetBody,
   CreateCommitBody,
+  CreateUploadSessionBody,
   CreateStashBody,
   CreateTokenBody,
   DiffCandidateBody,
@@ -23,6 +24,7 @@ import {
   PutFileBody,
   parseSnapshotSelector,
   RejectChangeSetBody,
+  RevertCommitBody,
   SnapshotQuery,
   RunGcBody,
   RotateTokenBody,
@@ -254,6 +256,36 @@ describe("ImportBody", () => {
 const put = { op: "put", path: "docs/a.md", expectedVersion: null, body: "a" } as const;
 
 describe("commit and change-set request schemas", () => {
+  it("defaults revert targeting, accepts head mode, and stays strict", () => {
+    expect(RevertCommitBody.parse({})).toEqual({ onto: "commit" });
+    expect(RevertCommitBody.parse({ onto: "head" })).toEqual({ onto: "head" });
+    expect(RevertCommitBody.safeParse({ onto: "latest" }).success).toBe(false);
+    expect(RevertCommitBody.safeParse({ unknown: true }).success).toBe(false);
+  });
+
+  it("accepts upload attribution and enforces the metadata byte limit", () => {
+    const request = {
+      expectedVersion: null,
+      size: 1,
+      representation: "text" as const,
+      contentType: "text/plain",
+    };
+    expect(
+      CreateUploadSessionBody.parse({
+        ...request,
+        author: "Ada",
+        message: "Upload fixture",
+        meta: { source: "test" },
+      }),
+    ).toMatchObject({ author: "Ada", message: "Upload fixture", meta: { source: "test" } });
+    expect(
+      CreateUploadSessionBody.safeParse({
+        ...request,
+        meta: { value: "x".repeat(MAX_META_BYTES) },
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts every commit entry shape with strict integer versions", () => {
     const entries = [
       put,

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -318,7 +318,12 @@ export const CreateCommitBody = z
       });
     }
   });
-export const RevertCommitBody = z.strictObject({ author, message, meta: commitMeta });
+export const RevertCommitBody = z.strictObject({
+  author,
+  message,
+  meta: commitMeta,
+  onto: z.enum(["commit", "head"]).default("commit"),
+});
 export const ListCommitsQuery = z.strictObject({
   limit,
   after: z.string().optional(),
@@ -426,6 +431,9 @@ export const ChangeSetDiffQuery = z.strictObject({
 /** Metadata-only creation request; content bytes always travel on a raw upload route. */
 export const CreateUploadSessionBody = z.strictObject({
   expectedVersion,
+  author,
+  message,
+  meta,
   size: z.number().int().nonnegative(),
   hash: sha256.optional(),
   representation: z.enum(["text", "binary"]),
@@ -512,7 +520,8 @@ export type ParsedListStashesQuery = z.output<typeof ListStashesQuery>;
 export type ListFilesQuery = z.infer<typeof ListFilesQuery>;
 export type CommitEntryInput = z.infer<typeof CommitEntryInput>;
 export type CreateCommitBody = z.infer<typeof CreateCommitBody>;
-export type RevertCommitBody = z.infer<typeof RevertCommitBody>;
+export type RevertCommitBody = z.input<typeof RevertCommitBody>;
+export type ParsedRevertCommitBody = z.output<typeof RevertCommitBody>;
 export type ListCommitsQuery = z.infer<typeof ListCommitsQuery>;
 export type CommitDiffQuery = z.infer<typeof CommitDiffQuery>;
 export type SnapshotQuery = z.infer<typeof SnapshotQuery>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -474,6 +474,9 @@ export interface AbortUploadResult {
 }
 export interface CreateUploadSessionInput {
   expectedVersion: number | null;
+  author?: string;
+  message?: string;
+  meta?: Record<string, JsonValue>;
   size: number;
   hash?: string;
   representation: Representation;

--- a/workers/stash/migrations/0014_upload_commit_attribution.sql
+++ b/workers/stash/migrations/0014_upload_commit_attribution.sql
@@ -1,0 +1,3 @@
+ALTER TABLE upload_sessions ADD COLUMN commit_author TEXT;
+ALTER TABLE upload_sessions ADD COLUMN commit_message TEXT;
+ALTER TABLE upload_sessions ADD COLUMN commit_meta_json TEXT;

--- a/workers/stash/src/d1/commits.ts
+++ b/workers/stash/src/d1/commits.ts
@@ -1040,6 +1040,7 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
         author: value.author ?? "",
         message: value.message ?? `Revert ${id}`,
         meta: value.meta ?? {},
+        onto: value.onto,
       }),
     );
     const db = env.DB.withSession("first-primary");
@@ -1103,15 +1104,22 @@ export function createCommits(env: Env, deps: CommitDependencies): StashCommits 
       if (first === undefined || last === undefined) continue;
       const head = headByPath.get(path);
       const shouldDelete = first.version === 1 || first.previous_hash === null;
-      if (shouldDelete && head?.head_version === last.version && head.deleted === 1) {
+      // A missing files row leaves the head-derived expectation underivable and must conflict rather than be guessed.
+      const expectedVersion =
+        value.onto === "head" && head !== undefined ? head.head_version : last.version;
+      const alreadyDeleted =
+        shouldDelete &&
+        head?.deleted === 1 &&
+        (value.onto === "head" || head.head_version === last.version);
+      if (alreadyDeleted) {
         skipped.push({ path, reason: "already-deleted" });
       } else if (shouldDelete) {
-        entries.push({ op: "delete", path, expectedVersion: last.version });
+        entries.push({ op: "delete", path, expectedVersion });
       } else {
         entries.push({
           op: "rollback",
           path,
-          expectedVersion: last.version,
+          expectedVersion,
           toVersion: first.version - 1,
         });
       }

--- a/workers/stash/src/d1/schema.ts
+++ b/workers/stash/src/d1/schema.ts
@@ -171,6 +171,9 @@ export interface UploadSessionRow {
   event_publish_owner: string | null;
   event_publish_until: number | null;
   event_origin: string | null;
+  commit_author: string | null;
+  commit_message: string | null;
+  commit_meta_json: string | null;
 }
 
 export interface UploadStagedBytesRow {
@@ -429,6 +432,9 @@ export const TABLE_COLUMNS = {
     "event_publish_owner",
     "event_publish_until",
     "event_origin",
+    "commit_author",
+    "commit_message",
+    "commit_meta_json",
   ],
   upload_staged_bytes: [
     "session_id",

--- a/workers/stash/test/routes/commits.test.ts
+++ b/workers/stash/test/routes/commits.test.ts
@@ -758,6 +758,140 @@ describe("commit routes", () => {
     });
   });
 
+  it("reverts onto current heads after a later write moves one path", async () => {
+    const stash = "commit-revert-onto-head";
+    await seedStash(stash);
+    await put(stash, "moved.txt", "moved before\n", null);
+    await put(stash, "steady.txt", "steady before\n", null);
+    const created = await api(stash, "", {
+      method: "POST",
+      body: {
+        entries: [
+          { op: "put", path: "moved.txt", expectedVersion: 1, body: "moved by commit\n" },
+          { op: "put", path: "steady.txt", expectedVersion: 1, body: "steady by commit\n" },
+        ],
+      },
+    });
+    expect(created.status).toBe(201);
+    const commit = await created.json<{ id: string }>();
+    await put(stash, "moved.txt", "later unrelated write\n", 2);
+
+    const reverted = await api(stash, `/${commit.id}/revert`, {
+      method: "POST",
+      body: { onto: "head" },
+    });
+    expect(reverted.status).toBe(201);
+    await expect(reverted.json()).resolves.toMatchObject({
+      source: "revert",
+      revertsCommitId: commit.id,
+      entries: [
+        { path: "moved.txt", op: "rollback", version: 4, rollbackOf: 1 },
+        { path: "steady.txt", op: "rollback", version: 3, rollbackOf: 1 },
+      ],
+    });
+    const store = createStashStore(createTestEnv().env);
+    await expect(store.reads.getFile(stash, "moved.txt")).resolves.toMatchObject({
+      version: 4,
+      body: "moved before\n",
+    });
+    await expect(
+      createTestEnv()
+        .env.DB.prepare(
+          "SELECT path, head_version, deleted FROM files WHERE stash_name = ? ORDER BY path",
+        )
+        .bind(stash)
+        .all(),
+    ).resolves.toMatchObject({
+      results: [
+        { path: "moved.txt", head_version: 4, deleted: 0 },
+        { path: "steady.txt", head_version: 3, deleted: 0 },
+      ],
+    });
+  });
+
+  it("skips a later tombstone when reverting created paths onto current heads", async () => {
+    const stash = "commit-revert-onto-tombstone";
+    await seedStash(stash);
+    await put(stash, "updated.txt", "before update\n", null);
+    const created = await api(stash, "", {
+      method: "POST",
+      body: {
+        entries: [
+          { op: "put", path: "created.txt", expectedVersion: null, body: "created\n" },
+          { op: "put", path: "updated.txt", expectedVersion: 1, body: "after update\n" },
+        ],
+      },
+    });
+    expect(created.status).toBe(201);
+    const commit = await created.json<{ id: string }>();
+    const tombstoned = await api(stash, "", {
+      method: "POST",
+      body: { entries: [{ op: "delete", path: "created.txt", expectedVersion: 1 }] },
+    });
+    expect(tombstoned.status).toBe(201);
+
+    const reverted = await api(stash, `/${commit.id}/revert`, {
+      method: "POST",
+      body: { onto: "head" },
+      key: "revert-onto-tombstone",
+    });
+    expect(reverted.status).toBe(201);
+    const value = await reverted.json();
+    expect(value).toMatchObject({
+      entries: [{ path: "updated.txt", op: "rollback", version: 3, rollbackOf: 1 }],
+      skipped: [{ path: "created.txt", reason: "already-deleted" }],
+    });
+    const replayed = await api(stash, `/${commit.id}/revert`, {
+      method: "POST",
+      body: { onto: "head" },
+      key: "revert-onto-tombstone",
+    });
+    expect(replayed.status).toBe(201);
+    expect(replayed.headers.get("Idempotent-Replayed")).toBe("true");
+    await expect(replayed.json()).resolves.toEqual(value);
+  });
+
+  it("rejects an idempotency key replayed with a different revert mode", async () => {
+    const stash = "commit-revert-onto-idempotency";
+    await seedStash(stash);
+    await put(stash, "updated.txt", "before update\n", null);
+    const created = await api(stash, "", {
+      method: "POST",
+      body: {
+        entries: [{ op: "put", path: "updated.txt", expectedVersion: 1, body: "after update\n" }],
+      },
+    });
+    expect(created.status).toBe(201);
+    const commit = await created.json<{ id: string }>();
+    const first = await api(stash, `/${commit.id}/revert`, {
+      method: "POST",
+      body: {},
+      key: "revert-onto-idempotency",
+    });
+    expect(first.status).toBe(201);
+
+    const diverged = await api(stash, `/${commit.id}/revert`, {
+      method: "POST",
+      body: { onto: "head" },
+      key: "revert-onto-idempotency",
+    });
+    expect(diverged.status).toBe(422);
+    await expect(diverged.json()).resolves.toMatchObject({
+      error: { code: "idempotency-key-reused" },
+    });
+  });
+
+  it("validates the revert onto mode", async () => {
+    const stash = "commit-revert-onto-validation";
+    await seedStash(stash);
+    const response = await api(stash, "/missing/revert", {
+      method: "POST",
+      body: { onto: "latest" },
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "validation" } });
+  });
+
   it("collapses an imported path to one inverse entry and restores its pre-import absence", async () => {
     const stash = "commit-revert-import";
     await seedStash(stash);


### PR DESCRIPTION
Parent epic: #343

Issue: #346

## Summary

- include `onto` in revert idempotency identity
- derive delete and rollback expectations from current heads in opt-in head mode
- preserve strict default behavior, tombstone skips, missing-head conflicts, and append-only gate semantics

## Tests

- commit route tests: 22 passed
- commit store/gate/race tests: 38 passed
- Worker typecheck, formatting, and diff checks
