### PR TITLE
[Single Path Collapse] extract shared write primitives

### DIFF
--- a/workers/stash/src/d1/import.ts
+++ b/workers/stash/src/d1/import.ts
@@ -12,7 +12,7 @@ import {
 import type { Env } from "../env.js";
 import { prepareBlob, type BlobGenerationFactory, type PreparedBlob } from "./blobs.js";
 import { importBatch, type PreparedImportVersion } from "./sql/import.js";
-import { selectHeadForWrite } from "./sql/writes.js";
+import { selectHeadForWrite } from "./sql/write-primitives.js";
 import type { StoreDependencies } from "./store.js";
 import { mintCommitId, SELECT_COMMIT_VERSIONS } from "./sql/commits.js";
 

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -1,7 +1,7 @@
 import type { ChangeSetEntryRow, CommitRow } from "../schema.js";
 import type { PreparedBlob } from "../blobs.js";
 import type { PreparedByteWrite } from "../byte-writes.js";
-import type { SqlFragment } from "./writes.js";
+import { insertLedger, type LedgerInsert, type SqlFragment } from "./write-primitives.js";
 
 type Preparer = Pick<D1DatabaseSession, "prepare">;
 
@@ -201,6 +201,7 @@ export type PreparedCommitEntry =
 export interface CommitBatchInput {
   row: CommitInsertRow;
   entries: PreparedCommitEntry[];
+  ledger?: LedgerInsert;
   expectedLastChangeId?: number;
   expectedLastChangePrefixLo?: string;
   expectedLastChangePrefixHi?: string;
@@ -452,6 +453,23 @@ export function commitBatch(db: Preparer, input: CommitBatchInput): D1PreparedSt
     if (entry.op === "put") statements.push(...putEntryStatements(db, input, entry));
     else statements.push(derivedEntryStatement(db, input, entry));
     statements.push(headStatement(db, input, entry));
+  }
+  // This ledger statement may sit here only because it is fenced on position-independent commitFence(stash, id), not the operation fence; an operation fence here would write zero rows and break idempotent replay.
+  if (input.ledger) {
+    const entry = input.entries[0];
+    if (input.entries.length !== 1 || !entry) {
+      throw new Error("Commit batch ledger requires exactly one entry");
+    }
+    statements.push(
+      insertLedger(db, {
+        stash: input.row.stash_name,
+        path: entry.path,
+        version: entry.version,
+        createdAt: entry.createdAt,
+        ledger: input.ledger,
+        operationFence: commitFence(input.row.stash_name, input.row.id),
+      }),
+    );
   }
   statements.push(commitSealStatement(db, input));
   return statements;

--- a/workers/stash/src/d1/sql/import.ts
+++ b/workers/stash/src/d1/sql/import.ts
@@ -1,5 +1,5 @@
 import type { PreparedBlob } from "../blobs.js";
-import { fence, type SqlFragment } from "./writes.js";
+import { fence, type SqlFragment } from "./write-primitives.js";
 import { commitInsertStatement, sealStatement } from "./commits.js";
 
 const DEFAULT_CONTENT_TYPE = "text/plain; charset=utf-8";

--- a/workers/stash/src/d1/sql/write-primitives.ts
+++ b/workers/stash/src/d1/sql/write-primitives.ts
@@ -1,0 +1,104 @@
+export interface SqlFragment {
+  sql: string;
+  params: unknown[];
+}
+
+export interface LedgerInsert {
+  key: string;
+  requestHash: string;
+  statusCode: number;
+}
+
+type Preparer = Pick<D1DatabaseSession, "prepare">;
+
+export const fence = {
+  create(stash: string, path: string): SqlFragment {
+    return {
+      sql: `EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
+        AND NOT EXISTS (SELECT 1 FROM files WHERE stash_name = ? AND path = ?)`,
+      params: [stash, stash, path],
+    };
+  },
+  put(stash: string, path: string, expectedVersion: number): SqlFragment {
+    return {
+      sql: `EXISTS (SELECT 1 FROM files
+        WHERE stash_name = ? AND path = ? AND head_version = ?)
+        AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)`,
+      params: [stash, path, expectedVersion, stash],
+    };
+  },
+  delete(stash: string, path: string, expectedVersion: number): SqlFragment {
+    return {
+      sql: `EXISTS (SELECT 1 FROM files
+        WHERE stash_name = ? AND path = ? AND head_version = ? AND deleted = 0)
+        AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)`,
+      params: [stash, path, expectedVersion, stash],
+    };
+  },
+  rollback(stash: string, path: string, expectedVersion: number, toVersion: number): SqlFragment {
+    return {
+      sql: `EXISTS (SELECT 1 FROM files
+        WHERE stash_name = ? AND path = ? AND head_version = ?)
+        AND EXISTS (SELECT 1 FROM versions
+          WHERE stash_name = ? AND path = ? AND version = ? AND blob_hash IS NOT NULL)
+        AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)`,
+      params: [stash, path, expectedVersion, stash, path, toVersion, stash],
+    };
+  },
+};
+
+export const selectHeadForWrite = `
+  SELECT f.head_version, f.head_hash, f.deleted, v.kind, v.author, v.created_at,
+    v.representation, v.content_type
+  FROM files f
+  JOIN versions v ON v.stash_name = f.stash_name AND v.path = f.path
+    AND v.version = f.head_version
+  WHERE f.stash_name = ? AND f.path = ?
+`;
+
+export const selectVersionMeta = `
+  SELECT v.id, v.version, v.kind, v.blob_hash, v.size_bytes, v.content_type,
+    v.rollback_of, v.author, v.message, v.meta_json, v.created_at,
+    v.representation, v.application_etag, v.content_storage, v.commit_id,
+    previous.blob_hash AS previous_blob_hash,
+    previous.representation AS previous_representation,
+    previous.content_type AS previous_content_type
+  FROM versions v
+  LEFT JOIN versions previous ON previous.stash_name = v.stash_name
+    AND previous.path = v.path AND previous.version = v.version - 1
+  WHERE v.stash_name = ? AND v.path = ? AND v.version = ?
+`;
+
+export const selectLedger = `
+  SELECT stash_name, key, request_hash, path, version, status_code, created_at
+  FROM idempotency WHERE stash_name = ? AND key = ?
+`;
+
+export function insertLedger(
+  db: Preparer,
+  input: {
+    stash: string;
+    path: string;
+    version: number;
+    createdAt: number;
+    ledger: LedgerInsert;
+    operationFence: SqlFragment;
+  },
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO idempotency
+        (stash_name, key, request_hash, path, version, status_code, created_at)
+       SELECT ?, ?, ?, ?, ?, ?, ? WHERE ${input.operationFence.sql}`,
+    )
+    .bind(
+      input.stash,
+      input.ledger.key,
+      input.ledger.requestHash,
+      input.path,
+      input.version,
+      input.ledger.statusCode,
+      input.createdAt,
+      ...input.operationFence.params,
+    );
+}

--- a/workers/stash/src/d1/sql/writes.ts
+++ b/workers/stash/src/d1/sql/writes.ts
@@ -1,5 +1,6 @@
 import type { PreparedBlob } from "../blobs.js";
 import { commitInsertStatement, sealStatement } from "./commits.js";
+import { fence, insertLedger, type LedgerInsert, type SqlFragment } from "./write-primitives.js";
 
 /**
  * Every mutation has one operation predicate F, and that exact predicate is applied to every
@@ -7,17 +8,6 @@ import { commitInsertStatement, sealStatement } from "./commits.js";
  * before the seal, and the seal is the final verdict. Only `results.at(-1)?.meta.changes === 1`
  * decides success. If F refuses a mutation, every statement changes zero rows.
  */
-export interface SqlFragment {
-  sql: string;
-  params: unknown[];
-}
-
-export interface LedgerInsert {
-  key: string;
-  requestHash: string;
-  statusCode: number;
-}
-
 export type PutBatchInput = {
   commitId: string;
   createdBy: string;
@@ -83,105 +73,6 @@ export interface HeadWriteInput {
   version: number;
   hash: string;
   createdAt: number;
-}
-
-export function combineFences(...fragments: SqlFragment[]): SqlFragment {
-  return {
-    sql: fragments.map((fragment) => `(${fragment.sql})`).join(" AND "),
-    params: fragments.flatMap((fragment) => fragment.params),
-  };
-}
-
-export const fence = {
-  create(stash: string, path: string): SqlFragment {
-    return {
-      sql: `EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
-        AND NOT EXISTS (SELECT 1 FROM files WHERE stash_name = ? AND path = ?)`,
-      params: [stash, stash, path],
-    };
-  },
-  put(stash: string, path: string, expectedVersion: number): SqlFragment {
-    return {
-      sql: `EXISTS (SELECT 1 FROM files
-        WHERE stash_name = ? AND path = ? AND head_version = ?)
-        AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)`,
-      params: [stash, path, expectedVersion, stash],
-    };
-  },
-  delete(stash: string, path: string, expectedVersion: number): SqlFragment {
-    return {
-      sql: `EXISTS (SELECT 1 FROM files
-        WHERE stash_name = ? AND path = ? AND head_version = ? AND deleted = 0)
-        AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)`,
-      params: [stash, path, expectedVersion, stash],
-    };
-  },
-  rollback(stash: string, path: string, expectedVersion: number, toVersion: number): SqlFragment {
-    return {
-      sql: `EXISTS (SELECT 1 FROM files
-        WHERE stash_name = ? AND path = ? AND head_version = ?)
-        AND EXISTS (SELECT 1 FROM versions
-          WHERE stash_name = ? AND path = ? AND version = ? AND blob_hash IS NOT NULL)
-        AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)`,
-      params: [stash, path, expectedVersion, stash, path, toVersion, stash],
-    };
-  },
-};
-
-export const selectHeadForWrite = `
-  SELECT f.head_version, f.head_hash, f.deleted, v.kind, v.author, v.created_at,
-    v.representation, v.content_type
-  FROM files f
-  JOIN versions v ON v.stash_name = f.stash_name AND v.path = f.path
-    AND v.version = f.head_version
-  WHERE f.stash_name = ? AND f.path = ?
-`;
-
-export const selectVersionMeta = `
-  SELECT v.id, v.version, v.kind, v.blob_hash, v.size_bytes, v.content_type,
-    v.rollback_of, v.author, v.message, v.meta_json, v.created_at,
-    v.representation, v.application_etag, v.content_storage, v.commit_id,
-    previous.blob_hash AS previous_blob_hash,
-    previous.representation AS previous_representation,
-    previous.content_type AS previous_content_type
-  FROM versions v
-  LEFT JOIN versions previous ON previous.stash_name = v.stash_name
-    AND previous.path = v.path AND previous.version = v.version - 1
-  WHERE v.stash_name = ? AND v.path = ? AND v.version = ?
-`;
-
-export const selectLedger = `
-  SELECT stash_name, key, request_hash, path, version, status_code, created_at
-  FROM idempotency WHERE stash_name = ? AND key = ?
-`;
-
-export function insertLedger(
-  db: Preparer,
-  input: {
-    stash: string;
-    path: string;
-    version: number;
-    createdAt: number;
-    ledger: LedgerInsert;
-    operationFence: SqlFragment;
-  },
-): D1PreparedStatement {
-  return db
-    .prepare(
-      `INSERT INTO idempotency
-        (stash_name, key, request_hash, path, version, status_code, created_at)
-       SELECT ?, ?, ?, ?, ?, ?, ? WHERE ${input.operationFence.sql}`,
-    )
-    .bind(
-      input.stash,
-      input.ledger.key,
-      input.ledger.requestHash,
-      input.path,
-      input.version,
-      input.ledger.statusCode,
-      input.createdAt,
-      ...input.operationFence.params,
-    );
 }
 
 export function versionInsert(

--- a/workers/stash/src/d1/writes.ts
+++ b/workers/stash/src/d1/writes.ts
@@ -21,16 +21,13 @@ import {
 import type { Env } from "../env.js";
 import { prepareBlob, type BlobGenerationFactory } from "./blobs.js";
 import type { IdempotencyRow, VersionRow } from "./schema.js";
+import { deleteBatch, putCreateBatch, putUpdateBatch, rollbackBatch } from "./sql/writes.js";
 import {
-  deleteBatch,
-  putCreateBatch,
-  putUpdateBatch,
-  rollbackBatch,
   selectHeadForWrite,
   selectLedger,
   selectVersionMeta,
   type LedgerInsert,
-} from "./sql/writes.js";
+} from "./sql/write-primitives.js";
 import type { StoreDependencies } from "./store.js";
 import { mintCommitId, SELECT_COMMIT_VERSIONS } from "./sql/commits.js";
 

--- a/workers/stash/test/store/commits.test.ts
+++ b/workers/stash/test/store/commits.test.ts
@@ -4,6 +4,11 @@ import { sha256Hex, type CreateCommitBody } from "@takazudo/zudo-history-stash-c
 import type { Env } from "../../src/env.js";
 import { createCommits } from "../../src/d1/commits.js";
 import { createStashStore } from "../../src/d1/store.js";
+import {
+  commitBatch,
+  type CommitBatchInput,
+  type PreparedCommitEntry,
+} from "../../src/d1/sql/commits.js";
 import { resetDatabase, seedStash } from "../helpers/app.js";
 import { generation } from "../helpers/blob-generations.js";
 
@@ -33,6 +38,55 @@ async function tableCount(table: "commits" | "versions" | "files", stash: string
   return row?.count ?? -1;
 }
 
+function preparedPut(
+  path: string,
+  expectedVersion: number | null,
+  version: number,
+): PreparedCommitEntry {
+  return {
+    op: "put",
+    path,
+    expectedVersion,
+    version,
+    author: "author",
+    message: "message",
+    metaJson: "{}",
+    createdAt: 1_000,
+    representation: "text",
+    hash: `sha256-${"a".repeat(64)}`,
+    size: 4,
+    contentType: "text/plain; charset=utf-8",
+    body: "body",
+    r2_key: null,
+  };
+}
+
+function commitBatchInput(
+  stash: string,
+  entries: PreparedCommitEntry[],
+  ledger?: CommitBatchInput["ledger"],
+): CommitBatchInput {
+  return {
+    row: {
+      id: `cmt-direct-${stash}`,
+      stash_name: stash,
+      source: "commit",
+      source_id: null,
+      author: "author",
+      message: "message",
+      meta_json: "{}",
+      entry_count: entries.length,
+      reverts_commit_id: null,
+      idempotency_key: null,
+      request_hash: "request-hash",
+      created_by: "test",
+      created_at: 1_000,
+    },
+    entries,
+    ...(ledger ? { ledger } : {}),
+  };
+}
+
 beforeEach(async () => {
   sequence = 0;
   await resetDatabase();
@@ -44,6 +98,68 @@ describe("commit store", () => {
     for (const byte of bytes) binary += String.fromCharCode(byte);
     return btoa(binary);
   }
+
+  it("writes one fenced ledger row for a successful direct commit batch", async () => {
+    const stash = "commit-batch-ledger";
+    await seedStash(stash);
+    const input = commitBatchInput(stash, [preparedPut("one.txt", null, 1)], {
+      key: "direct-key",
+      requestHash: "direct-request",
+      statusCode: 201,
+    });
+
+    const results = await env.DB.batch(commitBatch(env.DB, input));
+
+    expect(results.at(-1)?.meta.changes).toBe(1);
+    const ledger = await env.DB.prepare(
+      "SELECT key, request_hash, path, version, status_code FROM idempotency WHERE stash_name = ?",
+    )
+      .bind(stash)
+      .all();
+    expect(ledger.results).toEqual([
+      {
+        key: "direct-key",
+        request_hash: "direct-request",
+        path: "one.txt",
+        version: 1,
+        status_code: 201,
+      },
+    ]);
+  });
+
+  it("writes no ledger row when the direct commit batch gate refuses", async () => {
+    const stash = "commit-batch-ledger-refused";
+    await seedStash(stash);
+    await seedFile(stash, "one.txt", "before");
+    const input = commitBatchInput(stash, [preparedPut("one.txt", 99, 100)], {
+      key: "refused-key",
+      requestHash: "refused-request",
+      statusCode: 201,
+    });
+
+    const results = await env.DB.batch(commitBatch(env.DB, input));
+
+    expect(results.at(-1)?.meta.changes).toBe(0);
+    const ledger = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM idempotency WHERE stash_name = ?",
+    )
+      .bind(stash)
+      .first<{ count: number }>();
+    expect(ledger?.count).toBe(0);
+  });
+
+  it("rejects a ledger on a multi-entry direct commit batch", async () => {
+    const stash = "commit-batch-ledger-many";
+    const input = commitBatchInput(
+      stash,
+      [preparedPut("one.txt", null, 1), preparedPut("two.txt", null, 1)],
+      { key: "many-key", requestHash: "many-request", statusCode: 201 },
+    );
+
+    expect(() => commitBatch(env.DB, input)).toThrow(
+      "Commit batch ledger requires exactly one entry",
+    );
+  });
 
   it("atomically seals create, put, and delete entries under one commit", async () => {
     const stash = "commit-three";


### PR DESCRIPTION
Parent epic: #351

Issue: #352

## Summary

- extract the shared SQL write primitives into `write-primitives.ts`
- add the optional N=1 idempotency-ledger seam to `commitBatch`
- keep the commit seal last and fence the ledger on the commit gate
- cover successful, refused, and invalid multi-entry ledger batches

## Tests

- focused commit and write/import suites: 45 passed
- Worker typecheck
- targeted formatting and diff checks

