### PR TITLE
[Change Set Metadata GC][Sub] Migration 0015 and change-set delete guard

### DIFF
--- a/workers/stash/migrations/0015_gc_change_set_kind.sql
+++ b/workers/stash/migrations/0015_gc_change_set_kind.sql
@@ -1,0 +1,30 @@
+DROP TABLE gc_runs;
+DROP TABLE gc_jobs;
+
+CREATE TABLE gc_jobs (
+  kind TEXT PRIMARY KEY CHECK (kind IN ('r2-orphans', 'ledger', 'content', 'change-sets')),
+  next_cursor TEXT,
+  lease_owner TEXT,
+  lease_generation INTEGER NOT NULL DEFAULT 0,
+  lease_until INTEGER,
+  updated_at INTEGER NOT NULL
+);
+INSERT INTO gc_jobs (kind, updated_at)
+VALUES ('r2-orphans', 0), ('ledger', 0), ('content', 0), ('change-sets', 0);
+
+CREATE TABLE gc_runs (
+  id TEXT PRIMARY KEY,
+  job_kind TEXT NOT NULL REFERENCES gc_jobs(kind),
+  lease_generation INTEGER NOT NULL,
+  dry_run INTEGER NOT NULL DEFAULT 0,
+  input_cursor TEXT,
+  next_cursor TEXT,
+  scanned INTEGER NOT NULL DEFAULT 0,
+  eligible INTEGER NOT NULL DEFAULT 0,
+  deleted INTEGER NOT NULL DEFAULT 0,
+  error TEXT,
+  started_at INTEGER NOT NULL,
+  finished_at INTEGER
+);
+CREATE INDEX gc_runs_job_started ON gc_runs (job_kind, started_at DESC, id DESC);
+CREATE INDEX change_sets_status_id ON change_sets (status, id);

--- a/workers/stash/test/migrations.test.ts
+++ b/workers/stash/test/migrations.test.ts
@@ -25,10 +25,16 @@ const appendOnlyMutationPatterns = [
   ["DELETE FROM files", /\bDELETE\s+FROM\s+files\b/i],
   ["DELETE FROM blobs", /\bDELETE\s+FROM\s+blobs\b/i],
   ["DELETE FROM byte_blobs", /\bDELETE\s+FROM\s+byte_blobs\b/i],
+  ["DELETE FROM change_sets", /\bDELETE\s+FROM\s+change_sets\b/i],
+  ["DELETE FROM change_set_entries", /\bDELETE\s+FROM\s+change_set_entries\b/i],
 ] as const;
 
 const CONTENT_SWEEP_MODULE = "../src/d1/sql/gc.ts";
 const CONTENT_SWEEP_EXEMPT = new Set(["DELETE FROM blobs", "DELETE FROM byte_blobs"]);
+const CHANGE_SET_SWEEP_EXEMPT = new Set([
+  "DELETE FROM change_sets",
+  "DELETE FROM change_set_entries",
+]);
 
 function assertAppendOnlyHygiene(sources: readonly (readonly [string, string])[]): void {
   const violations = appendOnlyMutationPatterns
@@ -36,7 +42,10 @@ function assertAppendOnlyHygiene(sources: readonly (readonly [string, string])[]
       sources.some(
         ([path, source]) =>
           pattern.test(source) &&
-          !(path.endsWith(CONTENT_SWEEP_MODULE) && CONTENT_SWEEP_EXEMPT.has(name)),
+          !(
+            path.endsWith(CONTENT_SWEEP_MODULE) &&
+            (CONTENT_SWEEP_EXEMPT.has(name) || CHANGE_SET_SWEEP_EXEMPT.has(name))
+          ),
       ),
     )
     .map(([name]) => name);
@@ -111,6 +120,7 @@ describe("D1 migrations", () => {
         expect.objectContaining({ name: "change_sets_stash_idempotency", partial: 1 }),
       ]),
     );
+    expect(changeSetIndexes.results.map(({ name }) => name)).toContain("change_sets_status_id");
     const entryIndexes = await env.DB.prepare("PRAGMA index_list(change_set_entries)").all<{
       name: string;
     }>();
@@ -123,6 +133,14 @@ describe("D1 migrations", () => {
       "SELECT kind, next_cursor, lease_owner, lease_generation, lease_until, updated_at FROM gc_jobs ORDER BY kind",
     ).all();
     expect(jobs.results).toEqual([
+      {
+        kind: "change-sets",
+        next_cursor: null,
+        lease_owner: null,
+        lease_generation: 0,
+        lease_until: null,
+        updated_at: 0,
+      },
       {
         kind: "content",
         next_cursor: null,
@@ -236,11 +254,23 @@ describe("D1 migrations", () => {
     expect(() => assertAppendOnlyHygiene([["../src/x.ts", "DELETE FROM byte_blobs"]])).toThrow(
       "DELETE FROM byte_blobs",
     );
+    expect(() => assertAppendOnlyHygiene([["../src/x.ts", "DELETE FROM change_sets"]])).toThrow(
+      "DELETE FROM change_sets",
+    );
+    expect(() =>
+      assertAppendOnlyHygiene([["../src/x.ts", "DELETE FROM change_set_entries"]]),
+    ).toThrow("DELETE FROM change_set_entries");
     expect(() =>
       assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM blobs"]]),
     ).not.toThrow();
     expect(() =>
       assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM byte_blobs"]]),
+    ).not.toThrow();
+    expect(() =>
+      assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM change_sets"]]),
+    ).not.toThrow();
+    expect(() =>
+      assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM change_set_entries"]]),
     ).not.toThrow();
     expect(() => assertAppendOnlyHygiene([[CONTENT_SWEEP_MODULE, "DELETE FROM versions"]])).toThrow(
       "DELETE FROM versions",
@@ -423,7 +453,7 @@ describe("D1 migrations", () => {
     });
   });
 
-  it("resets GC runs while retaining all three seeded job rows", async () => {
+  it("resets GC runs while retaining all four seeded job rows", async () => {
     await env.DB.prepare(
       `UPDATE gc_jobs
          SET next_cursor = 'cursor', lease_owner = 'owner', lease_generation = 7,
@@ -442,6 +472,14 @@ describe("D1 migrations", () => {
       "SELECT kind, next_cursor, lease_owner, lease_generation, lease_until, updated_at FROM gc_jobs ORDER BY kind",
     ).all();
     expect(jobs.results).toEqual([
+      {
+        kind: "change-sets",
+        next_cursor: null,
+        lease_owner: null,
+        lease_generation: 0,
+        lease_until: null,
+        updated_at: 0,
+      },
       {
         kind: "content",
         next_cursor: null,

--- a/workers/stash/test/scheduled.test.ts
+++ b/workers/stash/test/scheduled.test.ts
@@ -153,11 +153,14 @@ describe("scheduled GC orchestration", () => {
       next_cursor: string | null;
     }>();
     expect(jobs.results).toEqual([
+      { kind: "change-sets", next_cursor: null },
       { kind: "content", next_cursor: expect.any(String) },
       { kind: "ledger", next_cursor: expect.any(String) },
       { kind: "r2-orphans", next_cursor: expect.any(String) },
     ]);
-    expect(decodeGcCursor("content", jobs.results[0]!.next_cursor!)).toEqual({
+    expect(
+      decodeGcCursor("content", jobs.results.find((row) => row.kind === "content")!.next_cursor!),
+    ).toEqual({
       v: 1,
       kind: "content",
       table: "byte_blobs",


### PR DESCRIPTION
Closes #360

Part of #359.

## Summary

- add migration `0015_gc_change_set_kind.sql`
- widen and seed the GC job tables for `change-sets`
- add the change-set deletion guard and schema/index fixtures

## Validation

- migration/scheduler focused suite: 14 tests passed
- Worker typecheck and formatting passed
