### PR TITLE
[Commit Builder] Migrate upload finalization

### DIFF
--- a/workers/stash/src/context.ts
+++ b/workers/stash/src/context.ts
@@ -21,6 +21,7 @@ export type AppDependencies = Pick<StoreDependencies, "now" | "createId"> & {
     afterMultipartComplete?: () => void | Promise<void>;
     afterMultipartPart?: () => void | Promise<void>;
     duringFinalizing?: () => void | Promise<void>;
+    beforeFinalizeCommit?: () => void | Promise<void>;
     afterCommit?: () => void | Promise<void>;
     beforeEventPublish?: () => void | Promise<void>;
   };

--- a/workers/stash/src/d1/upload-finalize.ts
+++ b/workers/stash/src/d1/upload-finalize.ts
@@ -1,7 +1,7 @@
 import type { UploadCommitResult, UploadUnchangedResult } from "@takazudo/zudo-history-stash-core";
 import type { FinalizationLease } from "./upload-sessions.js";
 import type { UploadSessionRow } from "./schema.js";
-import { commitInsertStatement, sealStatement } from "./sql/commits.js";
+import { commitBatch, commitFence } from "./sql/commits.js";
 
 type Preparer = Pick<D1DatabaseSession, "prepare">;
 
@@ -12,6 +12,9 @@ export interface UploadFinalizeInput {
   lease: FinalizationLease;
   createdAt: number;
   eventOrigin: string | null;
+  alterUploadFinalizeStatementsForTest?: (
+    statements: D1PreparedStatement[],
+  ) => D1PreparedStatement[];
 }
 
 function leaseFence(input: UploadFinalizeInput): { sql: string; params: unknown[] } {
@@ -32,37 +35,6 @@ function leaseFence(input: UploadFinalizeInput): { sql: string; params: unknown[
   };
 }
 
-function casFence(input: UploadFinalizeInput): { sql: string; params: unknown[] } {
-  const lease = leaseFence(input);
-  if (input.session.expected_version === null) {
-    return {
-      sql: `${lease.sql}
-        AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
-        AND NOT EXISTS (SELECT 1 FROM files WHERE stash_name = ? AND path = ?)`,
-      params: [
-        ...lease.params,
-        input.session.stash_name,
-        input.session.stash_name,
-        input.session.path,
-      ],
-    };
-  }
-  return {
-    sql: `${lease.sql}
-      AND EXISTS (SELECT 1 FROM stashes WHERE name = ? AND deleted_at IS NULL)
-      AND EXISTS (SELECT 1 FROM files
-        WHERE stash_name = ? AND path = ? AND head_version = ?)`,
-    params: [
-      ...lease.params,
-      input.session.stash_name,
-      input.session.stash_name,
-      input.session.path,
-      input.session.expected_version,
-    ],
-  };
-}
-
-// See #384: commitBatch lacks the upload lease fence and staged-content promotion seams.
 export function uploadFinalizeBatch(
   db: Preparer,
   input: UploadFinalizeInput,
@@ -70,148 +42,36 @@ export function uploadFinalizeBatch(
   if (input.commitId === undefined || input.createdBy === undefined) {
     throw new Error("Committed upload finalization requires commit attribution");
   }
-  const fence = casFence(input);
+  if (input.session.uploaded_hash === null || input.session.uploaded_size === null) {
+    throw new Error("Committed upload finalization requires staged content metadata");
+  }
+  const uploadedHash = input.session.uploaded_hash;
+  const uploadedSize = input.session.uploaded_size;
   const version = (input.session.expected_version ?? 0) + 1;
-  const stagedSource =
-    input.session.storage_tier === "d1"
-      ? `SELECT ?, ?, staged.body_bytes, NULL, ?, staged.size_bytes, ?
-         FROM upload_staged_bytes staged
-         WHERE staged.session_id = ? AND staged.generation = ? AND staged.hash = ?
-           AND staged.size_bytes = ? AND ${fence.sql}`
-      : `SELECT ?, ?, NULL, sessions.staged_r2_key, ?, sessions.uploaded_size, ?
-         FROM upload_sessions sessions
-         WHERE sessions.id = ? AND sessions.attempt_generation = ?
-           AND sessions.uploaded_hash = ? AND sessions.uploaded_size = ?
-           AND sessions.staged_r2_key IS NOT NULL AND ${fence.sql}`;
-  const versionFence = `EXISTS (SELECT 1 FROM byte_blobs
-    WHERE stash_name = ? AND hash = ? AND size_bytes = ?) AND ${fence.sql}`;
-  const versionFenceParams = [
-    input.session.stash_name,
-    input.session.uploaded_hash,
-    input.session.uploaded_size,
-    ...fence.params,
-  ];
-  const statements: D1PreparedStatement[] = [
-    commitInsertStatement(
-      db,
-      {
-        id: input.commitId,
-        stash_name: input.session.stash_name,
-        source: "upload",
-        source_id: input.session.id,
-        author: input.session.commit_author ?? input.session.principal_id ?? "",
-        message: input.session.commit_message ?? "",
-        meta_json: input.session.commit_meta_json ?? "{}",
-        entry_count: 1,
-        reverts_commit_id: null,
-        idempotency_key: null,
-        request_hash: null,
-        created_by: input.createdBy,
-        created_at: input.createdAt,
-      },
-      fence,
-    ),
-    db
-      .prepare(
-        `INSERT INTO byte_blobs
-           (stash_name, hash, body_bytes, r2_key, storage_generation, size_bytes, created_at)
-         ${stagedSource}
-         ON CONFLICT(stash_name, hash) DO NOTHING`,
-      )
-      .bind(
-        input.session.stash_name,
-        input.session.uploaded_hash,
-        input.lease.generation,
-        input.createdAt,
-        input.session.id,
-        input.lease.generation,
-        input.session.uploaded_hash,
-        input.session.uploaded_size,
-        ...fence.params,
-      ),
-    db
-      .prepare(
-        `INSERT INTO versions
-           (stash_name, path, version, kind, blob_hash, size_bytes, content_type,
-            rollback_of, author, message, meta_json, created_at, representation,
-            application_etag, content_storage, commit_id)
-         SELECT ?, ?, ?, 'put', ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, 'bytes', ?
-         WHERE ${versionFence}`,
-      )
-      .bind(
-        input.session.stash_name,
-        input.session.path,
-        version,
-        input.session.uploaded_hash,
-        input.session.uploaded_size,
-        input.session.content_type,
-        input.session.commit_author ?? input.session.principal_id ?? "",
-        input.session.commit_message ?? "",
-        input.session.commit_meta_json ?? "{}",
-        input.createdAt,
-        input.session.representation,
-        input.session.uploaded_hash,
-        input.commitId,
-        ...versionFenceParams,
-      ),
-  ];
+  const author = input.session.commit_author ?? input.session.principal_id ?? "";
+  const message = input.session.commit_message ?? "";
+  const metaJson = input.session.commit_meta_json ?? "{}";
+  const commit = commitFence(input.session.stash_name, input.commitId);
   const insertedVersion = `EXISTS (SELECT 1 FROM versions
     WHERE stash_name = ? AND path = ? AND version = ? AND blob_hash = ?
-      AND content_storage = 'bytes')`;
+      AND content_storage = 'bytes' AND commit_id = ?)`;
   const insertedParams = [
     input.session.stash_name,
     input.session.path,
     version,
-    input.session.uploaded_hash,
+    uploadedHash,
+    input.commitId,
   ];
-  if (input.session.expected_version === null) {
-    statements.push(
-      db
-        .prepare(
-          `INSERT INTO files
-             (stash_name, path, head_version, head_hash, deleted, created_at, updated_at)
-           SELECT ?, ?, ?, ?, 0, ?, ? WHERE ${fence.sql} AND ${insertedVersion}`,
-        )
-        .bind(
-          input.session.stash_name,
-          input.session.path,
-          version,
-          input.session.uploaded_hash,
-          input.createdAt,
-          input.createdAt,
-          ...fence.params,
-          ...insertedParams,
-        ),
-    );
-  } else {
-    statements.push(
-      db
-        .prepare(
-          `UPDATE files SET head_version = ?, head_hash = ?, deleted = 0, updated_at = ?
-           WHERE stash_name = ? AND path = ? AND head_version = ?
-             AND ${fence.sql} AND ${insertedVersion}`,
-        )
-        .bind(
-          version,
-          input.session.uploaded_hash,
-          input.createdAt,
-          input.session.stash_name,
-          input.session.path,
-          input.session.expected_version,
-          ...fence.params,
-          ...insertedParams,
-        ),
-    );
-  }
+  const postEntryStatements: D1PreparedStatement[] = [];
   if (input.session.storage_tier === "r2") {
-    statements.push(
+    postEntryStatements.push(
       db
         .prepare(
           `UPDATE upload_objects SET purpose = 'committed', completed_at = ?
            WHERE object_key = ? AND session_id = ? AND generation = ?
              AND EXISTS (SELECT 1 FROM byte_blobs
                WHERE stash_name = ? AND hash = ? AND r2_key = ?)
-             AND ${insertedVersion}`,
+             AND ${commit.sql} AND ${insertedVersion}`,
         )
         .bind(
           input.createdAt,
@@ -219,22 +79,23 @@ export function uploadFinalizeBatch(
           input.session.id,
           input.lease.generation,
           input.session.stash_name,
-          input.session.uploaded_hash,
+          uploadedHash,
           input.session.staged_r2_key,
+          ...commit.params,
           ...insertedParams,
         ),
     );
   } else {
-    statements.push(
+    postEntryStatements.push(
       db
         .prepare(
           `DELETE FROM upload_staged_bytes WHERE session_id = ? AND generation = ?
-           AND ${insertedVersion}`,
+           AND ${commit.sql} AND ${insertedVersion}`,
         )
-        .bind(input.session.id, input.lease.generation, ...insertedParams),
+        .bind(input.session.id, input.lease.generation, ...commit.params, ...insertedParams),
     );
   }
-  statements.push(
+  postEntryStatements.push(
     db
       .prepare(
         `UPDATE upload_sessions SET state = 'committed', result_status = 201,
@@ -249,7 +110,7 @@ export function uploadFinalizeBatch(
            finalization_lease_until = NULL, updated_at = ?
          WHERE id = ? AND state = 'finalizing' AND attempt_generation = ?
            AND finalization_lease_owner = ? AND finalization_lease_until = ?
-           AND finalization_lease_until > ? AND ${insertedVersion}`,
+           AND finalization_lease_until > ? AND ${commit.sql} AND ${insertedVersion}`,
       )
       .bind(
         input.commitId,
@@ -266,22 +127,57 @@ export function uploadFinalizeBatch(
         input.lease.owner,
         input.lease.expiresAt,
         input.createdAt,
+        ...commit.params,
         ...insertedParams,
       ),
   );
-  statements.push(
-    sealStatement(db, {
-      stash: input.session.stash_name,
+  return commitBatch(db, {
+    row: {
       id: input.commitId,
-      extraPredicate: {
-        sql: `EXISTS (SELECT 1 FROM upload_sessions
-          WHERE id = ? AND state = 'committed' AND result_status = 201
-            AND json_extract(result_json, '$.commitId') = ?)`,
-        params: [input.session.id, input.commitId],
+      stash_name: input.session.stash_name,
+      source: "upload",
+      source_id: input.session.id,
+      author,
+      message,
+      meta_json: metaJson,
+      entry_count: 1,
+      reverts_commit_id: null,
+      idempotency_key: null,
+      request_hash: null,
+      created_by: input.createdBy,
+      created_at: input.createdAt,
+    },
+    entries: [
+      {
+        op: "put",
+        content: "staged",
+        path: input.session.path,
+        expectedVersion: input.session.expected_version,
+        version,
+        representation: input.session.representation,
+        hash: uploadedHash,
+        size: uploadedSize,
+        contentType: input.session.content_type,
+        staged: {
+          tier: input.session.storage_tier,
+          sessionId: input.session.id,
+          generation: input.lease.generation,
+        },
+        author,
+        message,
+        metaJson,
+        createdAt: input.createdAt,
       },
-    }),
-  );
-  return statements;
+    ],
+    extraGatePredicate: leaseFence(input),
+    postEntryStatements,
+    extraSealPredicate: {
+      sql: `EXISTS (SELECT 1 FROM upload_sessions
+        WHERE id = ? AND state = 'committed' AND result_status = 201
+          AND json_extract(result_json, '$.commitId') = ?)`,
+      params: [input.session.id, input.commitId],
+    },
+  });
 }
 
 export async function finalizeUnchanged(
@@ -352,7 +248,14 @@ export async function finalizeUpload(
   input: UploadFinalizeInput,
 ): Promise<UploadCommitResult | null> {
   const session = db.withSession("first-primary");
-  const results = await session.batch(uploadFinalizeBatch(session, input));
+  let results: D1Result<unknown>[];
+  try {
+    let statements = uploadFinalizeBatch(session, input);
+    statements = input.alterUploadFinalizeStatementsForTest?.(statements) ?? statements;
+    results = await session.batch(statements);
+  } catch {
+    return null;
+  }
   if (results.at(-1)?.meta.changes !== 1) return null;
   const row = await session
     .prepare("SELECT result_json FROM upload_sessions WHERE id = ?")

--- a/workers/stash/src/routes/uploads.ts
+++ b/workers/stash/src/routes/uploads.ts
@@ -971,6 +971,7 @@ async function complete(c: Context<AppEnv>): Promise<Response> {
     throw new StashError("internal", "Durable upload staging is unavailable.");
   }
   const origin = eventOrigin(c.req.raw);
+  await c.get("deps").uploadHooks.beforeFinalizeCommit?.();
   const unchanged = await finalizeUnchanged(c.env.DB, {
     session: row,
     lease: leaseState.current,

--- a/workers/stash/test/routes/uploads.test.ts
+++ b/workers/stash/test/routes/uploads.test.ts
@@ -7,6 +7,8 @@ import {
 } from "@takazudo/zudo-history-stash-core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../../src/app.js";
+import { finalizeUpload } from "../../src/d1/upload-finalize.js";
+import { D1UploadSessionStore } from "../../src/d1/upload-sessions.js";
 import { GC_ORPHAN_MIN_AGE_MS, createGcEngine } from "../../src/gc.js";
 import { bearer, mintToken, request, resetDatabase, seedStash } from "../helpers/app.js";
 import { createTestEnv } from "../helpers/env.js";
@@ -873,6 +875,149 @@ describe("single raw upload lifecycle", () => {
     expect((await complete(id, "complete-lease", custom, application)).status).toBe(409);
     now += 11;
     expect((await complete(id, "complete-lease", custom, application)).status).toBe(201);
+  });
+
+  it("fences a finalizer whose renewed lease is stolen immediately before commit", async () => {
+    let now = 1_800_000_100_000;
+    let id = "";
+    const winnerResult = {
+      commitId: "cmt_winner",
+      version: 1,
+      hash: "winner-hash",
+      size: 1,
+      representation: "binary",
+      contentType: "application/octet-stream",
+      changeId: 123,
+      createdAt: new Date(now).toISOString(),
+    };
+    const application = createApp({
+      now: () => now,
+      uploadLeaseMs: 10,
+      uploadHooks: {
+        async beforeFinalizeCommit() {
+          now += 11;
+          const store = new D1UploadSessionStore(env.DB);
+          const winner = await store.acquireFinalizationLease({
+            sessionId: id,
+            generation: 0,
+            owner: "winner",
+            now,
+            leaseUntil: now + 10,
+          });
+          if (winner === null) throw new Error("Expected winner to steal the expired lease");
+          const finished = await store.finish({
+            lease: winner,
+            state: "committed",
+            resultStatus: 201,
+            resultJson: JSON.stringify(winnerResult),
+            now,
+          });
+          if (!finished) throw new Error("Expected winner to preserve its committed result");
+        },
+      },
+    });
+    const custom = bindings();
+    const created = await create(
+      {
+        expectedVersion: null,
+        size: 1,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        mode: "single",
+        resumable: false,
+      },
+      "create-stolen-finalize-lease",
+      custom,
+      application,
+    );
+    id = (await created.json<{ id: string }>()).id;
+    await raw(id, new Uint8Array([1]), "upload-stolen-finalize-lease", {}, custom, application);
+
+    expect((await complete(id, "complete-stolen-finalize-lease", custom, application)).status).toBe(
+      500,
+    );
+    await expect(
+      env.DB.prepare("SELECT result_status, result_json FROM upload_sessions WHERE id = ?")
+        .bind(id)
+        .first(),
+    ).resolves.toEqual({ result_status: 201, result_json: JSON.stringify(winnerResult) });
+    for (const table of ["commits", "versions", "files", "byte_blobs"] as const) {
+      await expect(
+        env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table}`).first(),
+      ).resolves.toEqual({ count: 0 });
+    }
+  });
+
+  it("returns null and rolls back when the committed upload result fails the seal predicate", async () => {
+    const now = 1_800_000_200_000;
+    const application = createApp({ now: () => now });
+    const custom = bindings();
+    const created = await create(
+      {
+        expectedVersion: null,
+        size: 1,
+        representation: "binary",
+        contentType: "application/octet-stream",
+        mode: "single",
+        resumable: false,
+      },
+      "create-mismatched-finalize-result",
+      custom,
+      application,
+    );
+    const id = (await created.json<{ id: string }>()).id;
+    await raw(
+      id,
+      new Uint8Array([7]),
+      "upload-mismatched-finalize-result",
+      {},
+      custom,
+      application,
+    );
+    const store = new D1UploadSessionStore(env.DB);
+    const lease = await store.acquireFinalizationLease({
+      sessionId: id,
+      generation: 0,
+      owner: "seal-test",
+      now,
+      leaseUntil: now + 30_000,
+    });
+    if (lease === null) throw new Error("Expected finalization lease");
+    const session = await store.get(id);
+    if (session === null) throw new Error("Expected upload session");
+    const commitId = "cmt_seal_test";
+
+    await expect(
+      finalizeUpload(env.DB, {
+        commitId,
+        createdBy: "admin",
+        session,
+        lease,
+        createdAt: now,
+        eventOrigin: null,
+        alterUploadFinalizeStatementsForTest(statements) {
+          const altered = [...statements];
+          altered[altered.length - 2] = env.DB.prepare(
+            `UPDATE upload_sessions SET state = 'committed', result_status = 201,
+               result_json = json_object('commitId', 'mismatched'),
+               reservation_released_at = ?, finalization_lease_owner = NULL,
+               finalization_lease_until = NULL, updated_at = ?
+             WHERE id = ? AND state = 'finalizing'`,
+          ).bind(now, now, id);
+          return altered;
+        },
+      }),
+    ).resolves.toBeNull();
+    for (const table of ["commits", "versions", "files", "byte_blobs"] as const) {
+      await expect(
+        env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table}`).first(),
+      ).resolves.toEqual({ count: 0 });
+    }
+    await expect(
+      env.DB.prepare("SELECT state, result_status, result_json FROM upload_sessions WHERE id = ?")
+        .bind(id)
+        .first(),
+    ).resolves.toEqual({ state: "finalizing", result_status: null, result_json: null });
   });
 
   it("returns current state for open resume and finalizes durable uploaded staging", async () => {


### PR DESCRIPTION
Parent: #397

Topic: #401

## Summary

- reduce committed-upload finalization to a thin `commitBatch` adapter
- preserve upload attribution and caller-owned lifecycle statements
- fence post-renew lease loss and mismatched result finalization atomically
- return `null` on CHECK rollback so the route can recover current state

## Test plan

- `pnpm build:libs`
- focused upload/builder suite (4 files, 49 tests)
- `pnpm typecheck`
- `git diff --check`
