### PR TITLE
[Commit Builder] Validate integrated migrations

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -290,6 +290,11 @@ pnpm --filter zudo-history-stash exec vitest run \
   --config vitest.config.ts test/store/commit-gate-proofs.test.ts --reporter=verbose
 ```
 
+`workers/stash/test/store/commit-builder-sequential.test.ts` is the permanent proof for sequential
+per-path chains, contiguous versions, and final per-path heads. `workers/stash/test/store/commit-builder-seams.test.ts`
+covers the upload gate/seal predicates, staged-content entries, and post-entry statement seams.
+Both files run in the ordinary `pnpm test` lane alongside the aggregate gate proof.
+
 `pnpm --filter zudo-history-stash probe:commit-batch` is an explicit, mutating L5 probe. It starts a
 short-lived probe Worker with the selected Wrangler config, runs the same 62-statement batch through
 the `DB` binding, prints the number of per-statement results and `meta.changes` values, drops its

--- a/workers/stash/src/d1/sql/commits.ts
+++ b/workers/stash/src/d1/sql/commits.ts
@@ -21,36 +21,6 @@ export function mintCommitId(now: number, createId: () => string): string {
   return `cmt_${timestamp}${randomHex}`;
 }
 
-export function commitInsertStatement(
-  db: Preparer,
-  row: CommitInsertRow,
-  fence: SqlFragment,
-): D1PreparedStatement {
-  return db
-    .prepare(
-      `INSERT INTO commits
-        (id, stash_name, source, source_id, author, message, meta_json, entry_count,
-         reverts_commit_id, idempotency_key, request_hash, created_by, created_at)
-       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? WHERE ${fence.sql}`,
-    )
-    .bind(
-      row.id,
-      row.stash_name,
-      row.source,
-      row.source_id,
-      row.author,
-      row.message,
-      row.meta_json,
-      row.entry_count,
-      row.reverts_commit_id,
-      row.idempotency_key,
-      row.request_hash,
-      row.created_by,
-      row.created_at,
-      ...fence.params,
-    );
-}
-
 export interface CommitGateEntry {
   op: "put" | "copy" | "delete" | "rollback";
   path: string;
@@ -646,25 +616,6 @@ function commitSealStatement(
       input.row.stash_name,
       input.row.id,
     );
-}
-
-export function sealStatement(
-  db: Preparer,
-  input: { stash: string; id: string; extraPredicate?: SqlFragment },
-): D1PreparedStatement {
-  const extra = input.extraPredicate;
-  return db
-    .prepare(
-      `UPDATE commits
-       SET change_count = (SELECT COUNT(*) FROM versions WHERE commit_id = commits.id),
-           first_change_id = (SELECT MIN(id) FROM versions WHERE commit_id = commits.id),
-           last_change_id = (SELECT MAX(id) FROM versions WHERE commit_id = commits.id),
-           sealed = 1
-       WHERE stash_name = ? AND id = ? AND sealed = 0
-         AND entry_count = (SELECT COUNT(*) FROM versions WHERE commit_id = commits.id)
-         ${extra ? `AND (${extra.sql})` : ""}`,
-    )
-    .bind(input.stash, input.id, ...(extra?.params ?? []));
 }
 
 export const SELECT_COMMIT_VERSIONS = `

--- a/workers/stash/test/routes/commits.test.ts
+++ b/workers/stash/test/routes/commits.test.ts
@@ -743,7 +743,10 @@ describe("commit routes", () => {
       body: JSON.stringify({
         path: "deleted.txt",
         expectedVersion: null,
-        versions: [{ kind: "delete", body: null, createdAt: 1 }],
+        versions: [
+          { kind: "put", body: "created then deleted", createdAt: 1 },
+          { kind: "delete", body: null, createdAt: 2 },
+        ],
       }),
     });
     expect(imported.status).toBe(201);


### PR DESCRIPTION
Parent: #397

Topic: #402

## Summary

- remove the unused legacy commit insert and seal helpers
- document the sequential and upload-seam D1 proof files
- align the tombstone-revert fixture with the approved first-delete validation
- validate all commit/import/upload changes together

## Test plan

- `pnpm b4push` (all ten steps passed)
- focused post-review Worker suite (6 files, 86 tests)
- legacy helper/import generator/stale-reference audit
- `git diff --check`
